### PR TITLE
fix: Set cohort property to empty string in LookupValidation

### DIFF
--- a/application/CohortManager/src/Functions/ScreeningValidationService/LookupValidation/LookupValidation.cs
+++ b/application/CohortManager/src/Functions/ScreeningValidationService/LookupValidation/LookupValidation.cs
@@ -73,7 +73,7 @@ public class LookupValidation
                 DateResolved = DateTime.MaxValue,
                 Category = 1,
                 ScreeningService = 1,
-                Cohort = null,
+                Cohort = "",
                 Fatal = 0
             };
 


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Set Cohort property on ValidationException to empty string.

## Context

Cohort property on ValidationException must not be null in order to be inserted into the database table.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
