### PR TITLE
feat: demographic data lookup validation rule

### DIFF
--- a/application/CohortManager/src/Functions/ScreeningValidationService/LookupValidation/LookupValidation.cs
+++ b/application/CohortManager/src/Functions/ScreeningValidationService/LookupValidation/LookupValidation.cs
@@ -33,7 +33,14 @@ public class LookupValidation
                 var requestBodyJson = reader.ReadToEnd();
                 requestBody = JsonSerializer.Deserialize<LookupValidationRequestBody>(requestBodyJson);
             }
+        }
+        catch
+        {
+            return _createResponse.CreateHttpResponse(HttpStatusCode.BadRequest, req);
+        }
 
+        try
+        {
             var existingParticipant = requestBody.ExistingParticipant;
             var newParticipant = requestBody.NewParticipant;
 

--- a/application/CohortManager/src/Functions/ScreeningValidationService/LookupValidation/LookupValidation.cs
+++ b/application/CohortManager/src/Functions/ScreeningValidationService/LookupValidation/LookupValidation.cs
@@ -6,6 +6,7 @@ using System.Text.Json;
 using Common;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Extensions.Logging;
 using Model;
 using RulesEngine.Models;
 
@@ -15,10 +16,13 @@ public class LookupValidation
 
     private readonly ICreateResponse _createResponse;
 
-    public LookupValidation(ICreateResponse createResponse, IExceptionHandler handleException)
+    private readonly ILogger<LookupValidation> _logger;
+
+    public LookupValidation(ICreateResponse createResponse, IExceptionHandler handleException, ILogger<LookupValidation> logger)
     {
         _createResponse = createResponse;
         _handleException = handleException;
+        _logger = logger;
     }
 
     [Function("LookupValidation")]
@@ -38,11 +42,12 @@ public class LookupValidation
         {
             return _createResponse.CreateHttpResponse(HttpStatusCode.BadRequest, req);
         }
+        Participant newParticipant = null;
 
         try
         {
             var existingParticipant = requestBody.ExistingParticipant;
-            var newParticipant = requestBody.NewParticipant;
+            newParticipant = requestBody.NewParticipant;
 
             string json = File.ReadAllText("lookupRules.json");
             var rules = JsonSerializer.Deserialize<Workflow[]>(json);
@@ -78,9 +83,12 @@ public class LookupValidation
             }
             return _createResponse.CreateHttpResponse(HttpStatusCode.OK, req);
         }
-        catch
+        catch(Exception ex)
         {
+            _handleException.CreateSystemExceptionLog(ex,newParticipant);
+            _logger.LogWarning(ex,$"Error while processing lookup Validation message: {ex.Message}");
             return _createResponse.CreateHttpResponse(HttpStatusCode.InternalServerError, req);
+
         }
     }
 }

--- a/application/CohortManager/src/Functions/ScreeningValidationService/LookupValidation/lookupRules.json
+++ b/application/CohortManager/src/Functions/ScreeningValidationService/LookupValidation/lookupRules.json
@@ -12,11 +12,7 @@
       },
       {
         "RuleName": "11.Demographics",
-        "Expression": "(newParticipant.Surname == existingParticipant.Surname AND newParticipant.Gender == existingParticipant.Gender) OR (newParticipant.Surname == existingParticipant.Surname AND newParticipant.DateOfBirth == existingParticipant.DateOfBirth) OR (newParticipant.Gender == existingParticipant.Gender AND newParticipant.DateOfBirth == existingParticipant.DateOfBirth)"
-      },
-      {
-        "RuleName": "71.MustNotOverwriteAddressWithEmpty",
-        "Expression": "newParticipant.recordType == Actions.New OR (!string.IsNullOrEmpty(newParticipant.AddressLine1) OR !string.IsNullOrEmpty(newParticipant.AddressLine2) OR !string.IsNullOrEmpty(newParticipant.AddressLine3) OR !string.IsNullOrEmpty(newParticipant.AddressLine4) OR !string.IsNullOrEmpty(newParticipant.AddressLine5)) OR (string.IsNullOrEmpty(existingParticipant.AddressLine1) AND string.IsNullOrEmpty(existingParticipant.AddressLine2) AND string.IsNullOrEmpty(existingParticipant.AddressLine3) AND string.IsNullOrEmpty(existingParticipant.AddressLine4) AND string.IsNullOrEmpty(existingParticipant.AddressLine5))"
+        "Expression": "newParticipant.RecordType != Actions.Amended OR (newParticipant.Surname == existingParticipant.Surname AND newParticipant.Gender == existingParticipant.Gender) OR (newParticipant.Surname == existingParticipant.Surname AND newParticipant.DateOfBirth == existingParticipant.DateOfBirth) OR (newParticipant.Gender == existingParticipant.Gender AND newParticipant.DateOfBirth == existingParticipant.DateOfBirth)"
       }
     ]
   }

--- a/application/CohortManager/src/Functions/ScreeningValidationService/LookupValidation/lookupRules.json
+++ b/application/CohortManager/src/Functions/ScreeningValidationService/LookupValidation/lookupRules.json
@@ -3,7 +3,7 @@
     "WorkflowName": "Common",
     "Rules": [
       {
-        "RuleName": "ParticipantMustNotExist",
+        "RuleName": "47.ParticipantMustNotExist",
         "Expression": "newParticipant.RecordType != Actions.New OR string.IsNullOrWhiteSpace(existingParticipant.NhsNumber)"
       },
       {
@@ -11,7 +11,7 @@
         "Expression": "newParticipant.RecordType == Actions.New OR !string.IsNullOrWhiteSpace(existingParticipant.NhsNumber)"
       },
       {
-        "RuleName": "11.Demographics",
+        "RuleName": "35.Demographics",
         "Expression": "newParticipant.RecordType != Actions.Amended OR (newParticipant.Surname == existingParticipant.Surname AND newParticipant.Gender == existingParticipant.Gender) OR (newParticipant.Surname == existingParticipant.Surname AND newParticipant.DateOfBirth == existingParticipant.DateOfBirth) OR (newParticipant.Gender == existingParticipant.Gender AND newParticipant.DateOfBirth == existingParticipant.DateOfBirth)"
       }
     ]

--- a/application/CohortManager/src/Functions/ScreeningValidationService/LookupValidation/lookupRules.json
+++ b/application/CohortManager/src/Functions/ScreeningValidationService/LookupValidation/lookupRules.json
@@ -3,16 +3,20 @@
     "WorkflowName": "Common",
     "Rules": [
       {
-        "RuleName": "1.NewParticipantMustNotAlreadyExist",
+        "RuleName": "ParticipantMustNotExist",
         "Expression": "newParticipant.RecordType != Actions.New OR string.IsNullOrWhiteSpace(existingParticipant.NhsNumber)"
       },
       {
-        "RuleName": "2.AmendedParticipantMustExist",
-        "Expression": "newParticipant.RecordType != Actions.Amended OR !string.IsNullOrWhiteSpace(existingParticipant.NhsNumber)"
+        "RuleName": "22.ParticipantMustExist",
+        "Expression": "newParticipant.RecordType == Actions.New OR !string.IsNullOrWhiteSpace(existingParticipant.NhsNumber)"
       },
       {
-        "RuleName": "3.RemovedParticipantMustExist",
-        "Expression": "newParticipant.RecordType != Actions.Removed OR !string.IsNullOrWhiteSpace(existingParticipant.NhsNumber)"
+        "RuleName": "11.Demographics",
+        "Expression": "(newParticipant.Surname == existingParticipant.Surname AND newParticipant.Gender == existingParticipant.Gender) OR (newParticipant.Surname == existingParticipant.Surname AND newParticipant.DateOfBirth == existingParticipant.DateOfBirth) OR (newParticipant.Gender == existingParticipant.Gender AND newParticipant.DateOfBirth == existingParticipant.DateOfBirth)"
+      },
+      {
+        "RuleName": "71.MustNotOverwriteAddressWithEmpty",
+        "Expression": "newParticipant.recordType == Actions.New OR (!string.IsNullOrEmpty(newParticipant.AddressLine1) OR !string.IsNullOrEmpty(newParticipant.AddressLine2) OR !string.IsNullOrEmpty(newParticipant.AddressLine3) OR !string.IsNullOrEmpty(newParticipant.AddressLine4) OR !string.IsNullOrEmpty(newParticipant.AddressLine5)) OR (string.IsNullOrEmpty(existingParticipant.AddressLine1) AND string.IsNullOrEmpty(existingParticipant.AddressLine2) AND string.IsNullOrEmpty(existingParticipant.AddressLine3) AND string.IsNullOrEmpty(existingParticipant.AddressLine4) AND string.IsNullOrEmpty(existingParticipant.AddressLine5))"
       }
     ]
   }

--- a/tests/ScreeningValidationServiceTests/LookupValidation/LookupValidationTests.cs
+++ b/tests/ScreeningValidationServiceTests/LookupValidation/LookupValidationTests.cs
@@ -125,6 +125,10 @@ public class LookupValidationTests
     [DataRow(Actions.New, "")]
     [DataRow(Actions.New, null)]
     [DataRow(Actions.New, " ")]
+    [DataRow(Actions.Amended, "0000000000")]
+    [DataRow(Actions.Amended, "9999999999")]
+    [DataRow(Actions.Removed, "0000000000")]
+    [DataRow(Actions.Removed, "9999999999")]
     public async Task Run_Should_Not_Create_Exception_When_ParticipantMustExist_Rule_Passes(string recordType, string nhsNumber)
     {
         // Arrange
@@ -166,13 +170,17 @@ public class LookupValidationTests
     }
 
     [TestMethod]
-    [DataRow("")]
-    [DataRow(null)]
-    [DataRow(" ")]
-    public async Task Run_Should_Not_Create_Exception_When_ParticipantMustNotExist_Rule_Passes(string nhsNumber)
+    [DataRow(Actions.New, "")]
+    [DataRow(Actions.New, null)]
+    [DataRow(Actions.New, " ")]
+    [DataRow(Actions.Amended, "0000000000")]
+    [DataRow(Actions.Amended, "9999999999")]
+    [DataRow(Actions.Removed, "0000000000")]
+    [DataRow(Actions.Removed, "9999999999")]
+    public async Task Run_Should_Not_Create_Exception_When_ParticipantMustNotExist_Rule_Passes(string recordType, string nhsNumber)
     {
         // Arrange
-        _requestBody.NewParticipant.RecordType = Actions.New;
+        _requestBody.NewParticipant.RecordType = recordType;
         _requestBody.ExistingParticipant.NhsNumber = nhsNumber;
         var json = JsonSerializer.Serialize(_requestBody);
         SetUpRequestBody(json);

--- a/tests/ScreeningValidationServiceTests/LookupValidation/LookupValidationTests.cs
+++ b/tests/ScreeningValidationServiceTests/LookupValidation/LookupValidationTests.cs
@@ -8,18 +8,17 @@ using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Model;
+using Model.Enums;
 using Moq;
 using NHS.CohortManager.ScreeningValidationService;
-using NHS.CohortManager.Tests.TestUtils;
 using RulesEngine.Models;
 
 [TestClass]
 public class LookupValidationTests
 {
-    private readonly Mock<ICallFunction> _callFunction = new();
     private readonly Mock<FunctionContext> _context = new();
     private readonly Mock<HttpRequestData> _request;
-    private readonly Mock<IExceptionHandler> _handleException = new();
+    private readonly Mock<IExceptionHandler> _exceptionHandler = new();
     private readonly CreateResponse _createResponse = new();
     private readonly ServiceCollection _serviceCollection = new();
     private readonly LookupValidationRequestBody _requestBody;
@@ -50,10 +49,10 @@ public class LookupValidationTests
         };
         _requestBody = new LookupValidationRequestBody(existingParticipant, newParticipant, "caas.csv");
 
-        _handleException.Setup(x => x.CreateValidationExceptionLog(It.IsAny<IEnumerable<RuleResultTree>>(), It.IsAny<ParticipantCsvRecord>()))
-            .Returns(Task.FromResult(true)).Verifiable();
+        _exceptionHandler.Setup(x => x.CreateValidationExceptionLog(It.IsAny<IEnumerable<RuleResultTree>>(), It.IsAny<ParticipantCsvRecord>()))
+            .Returns(Task.FromResult(true));
 
-        _function = new LookupValidation(_createResponse, _handleException.Object);
+        _function = new LookupValidation(_createResponse, _exceptionHandler.Object);
 
         _request.Setup(r => r.CreateResponse()).Returns(() =>
         {
@@ -72,8 +71,11 @@ public class LookupValidationTests
         var result = await _function.RunAsync(_request.Object);
 
         // Assert
-        Assert.AreEqual(HttpStatusCode.InternalServerError, result.StatusCode);
-        _callFunction.Verify(call => call.SendPost(It.IsAny<string>(), It.IsAny<string>()), Times.Never());
+        Assert.AreEqual(HttpStatusCode.BadRequest, result.StatusCode);
+        _exceptionHandler.Verify(handler => handler.CreateValidationExceptionLog(
+            It.IsAny<IEnumerable<RuleResultTree>>(),
+            It.IsAny<ParticipantCsvRecord>()),
+            Times.Never());
     }
 
     [TestMethod]
@@ -86,18 +88,24 @@ public class LookupValidationTests
         var result = await _function.RunAsync(_request.Object);
 
         // Assert
-        Assert.AreEqual(HttpStatusCode.InternalServerError, result.StatusCode);
-        _callFunction.Verify(call => call.SendPost(It.IsAny<string>(), It.IsAny<string>()), Times.Never());
+        Assert.AreEqual(HttpStatusCode.BadRequest, result.StatusCode);
+        _exceptionHandler.Verify(handler => handler.CreateValidationExceptionLog(
+            It.IsAny<IEnumerable<RuleResultTree>>(),
+            It.IsAny<ParticipantCsvRecord>()),
+            Times.Never());
     }
 
     [TestMethod]
-    [DataRow("")]
-    [DataRow(null)]
-    [DataRow(" ")]
-    public async Task Run_Should_Return_OK_And_Create_Exception_When_AmendedParticipantMustExist_Rule_Fails(string nhsNumber)
+    [DataRow(Actions.Amended, "")]
+    [DataRow(Actions.Amended, null)]
+    [DataRow(Actions.Amended, " ")]
+    [DataRow(Actions.Removed, "")]
+    [DataRow(Actions.Removed, null)]
+    [DataRow(Actions.Removed, " ")]
+    public async Task Run_Should_Return_Created_And_Create_Exception_When_ParticipantMustExist_Rule_Fails(string recordType, string nhsNumber)
     {
         // Arrange
-        _requestBody.NewParticipant.RecordType = Actions.Amended;
+        _requestBody.NewParticipant.RecordType = recordType;
         _requestBody.ExistingParticipant.NhsNumber = nhsNumber;
         var json = JsonSerializer.Serialize(_requestBody);
         SetUpRequestBody(json);
@@ -107,19 +115,20 @@ public class LookupValidationTests
 
         // Assert
         Assert.AreEqual(HttpStatusCode.Created, result.StatusCode);
-        _handleException.Verify(handleException => handleException.CreateValidationExceptionLog(
-            It.IsAny<IEnumerable<RuleResultTree>>(),
+        _exceptionHandler.Verify(handleException => handleException.CreateValidationExceptionLog(
+            It.Is<IEnumerable<RuleResultTree>>(r => r.Any(x => x.Rule.RuleName == "22.ParticipantMustExist")),
             It.IsAny<ParticipantCsvRecord>()),
             Times.Once());
     }
 
     [TestMethod]
-    [DataRow("0000000000")]
-    [DataRow("9999999999")]
-    public async Task Run_Should_Not_Create_Exception_When_AmendedParticipantMustExist_Rule_Passes(string nhsNumber)
+    [DataRow(Actions.New, "")]
+    [DataRow(Actions.New, null)]
+    [DataRow(Actions.New, " ")]
+    public async Task Run_Should_Not_Create_Exception_When_ParticipantMustExist_Rule_Passes(string recordType, string nhsNumber)
     {
         // Arrange
-        _requestBody.NewParticipant.RecordType = Actions.Amended;
+        _requestBody.NewParticipant.RecordType = recordType;
         _requestBody.ExistingParticipant.NhsNumber = nhsNumber;
         var json = JsonSerializer.Serialize(_requestBody);
         SetUpRequestBody(json);
@@ -128,8 +137,8 @@ public class LookupValidationTests
         await _function.RunAsync(_request.Object);
 
         // Assert
-        _handleException.Verify(handleException => handleException.CreateValidationExceptionLog(
-            It.IsAny<IEnumerable<RuleResultTree>>(),
+        _exceptionHandler.Verify(handleException => handleException.CreateValidationExceptionLog(
+            It.Is<IEnumerable<RuleResultTree>>(r => r.Any(x => x.Rule.RuleName == "22.ParticipantMustExist")),
             It.IsAny<ParticipantCsvRecord>()),
             Times.Never());
     }
@@ -137,7 +146,7 @@ public class LookupValidationTests
     [TestMethod]
     [DataRow("0000000000")]
     [DataRow("9999999999")]
-    public async Task Run_Should_Return_OK_And_Create_Exception_When_NewParticipantMustNotAlreadyExist_Rule_Fails(string nhsNumber)
+    public async Task Run_Should_Return_Created_And_Create_Exception_When_ParticipantMustNotExist_Rule_Fails(string nhsNumber)
     {
         // Arrange
         _requestBody.NewParticipant.RecordType = Actions.New;
@@ -150,8 +159,8 @@ public class LookupValidationTests
 
         // Assert
         Assert.AreEqual(HttpStatusCode.Created, result.StatusCode);
-        _handleException.Verify(handleException => handleException.CreateValidationExceptionLog(
-            It.IsAny<IEnumerable<RuleResultTree>>(),
+        _exceptionHandler.Verify(handleException => handleException.CreateValidationExceptionLog(
+            It.Is<IEnumerable<RuleResultTree>>(r => r.Any(x => x.Rule.RuleName == "ParticipantMustNotExist")),
             It.IsAny<ParticipantCsvRecord>()),
             Times.Once());
     }
@@ -160,7 +169,7 @@ public class LookupValidationTests
     [DataRow("")]
     [DataRow(null)]
     [DataRow(" ")]
-    public async Task Run_Should_Not_Create_Exception_When_NewParticipantMustNotAlreadyExist_Rule_Passes(string nhsNumber)
+    public async Task Run_Should_Not_Create_Exception_When_ParticipantMustNotExist_Rule_Passes(string nhsNumber)
     {
         // Arrange
         _requestBody.NewParticipant.RecordType = Actions.New;
@@ -172,21 +181,27 @@ public class LookupValidationTests
         await _function.RunAsync(_request.Object);
 
         // Assert
-        _handleException.Verify(handleException => handleException.CreateValidationExceptionLog(
-            It.IsAny<IEnumerable<RuleResultTree>>(),
+        _exceptionHandler.Verify(handleException => handleException.CreateValidationExceptionLog(
+            It.Is<IEnumerable<RuleResultTree>>(r => r.Any(x => x.Rule.RuleName == "ParticipantMustNotExist")),
             It.IsAny<ParticipantCsvRecord>()),
             Times.Never());
     }
 
     [TestMethod]
-    [DataRow("")]
-    [DataRow(null)]
-    [DataRow(" ")]
-    public async Task Run_Should_Return_OK_And_Create_Exception_When_RemovedParticipantMustExist_Rule_Fails(string nhsNumber)
+    [DataRow("Smith", Gender.Female, "19700101", "Jones", Gender.Male, "19700101")]     // New Family Name & Gender
+    [DataRow("Smith", Gender.Female, "19700101", "Jones", Gender.Female, "19700102")]   // New Family Name & Date of Birth
+    [DataRow("Smith", Gender.Female, "19700101", "Smith", Gender.Male, "19700102")]     // New Gender & Date of Birth
+    [DataRow("Smith", Gender.Female, "19700101", "Jones", Gender.Male, "19700102")]     // New Family Name, Gender & Date of Birth
+    public async Task Run_Should_Return_Created_And_Create_Exception_When_Demographics_Rule_Fails(
+        string existingFamilyName, Gender existingGender, string existingDateOfBirth, string newFamilyName, Gender newGender, string newDateOfBirth)
     {
         // Arrange
-        _requestBody.NewParticipant.RecordType = Actions.Removed;
-        _requestBody.ExistingParticipant.NhsNumber = nhsNumber;
+        _requestBody.ExistingParticipant.Surname = existingFamilyName;
+        _requestBody.ExistingParticipant.Gender = existingGender;
+        _requestBody.ExistingParticipant.DateOfBirth = existingDateOfBirth;
+        _requestBody.NewParticipant.Surname = newFamilyName;
+        _requestBody.NewParticipant.Gender = newGender;
+        _requestBody.NewParticipant.DateOfBirth = newDateOfBirth;
         var json = JsonSerializer.Serialize(_requestBody);
         SetUpRequestBody(json);
 
@@ -195,20 +210,28 @@ public class LookupValidationTests
 
         // Assert
         Assert.AreEqual(HttpStatusCode.Created, result.StatusCode);
-        _handleException.Verify(handleException => handleException.CreateValidationExceptionLog(
-            It.IsAny<IEnumerable<RuleResultTree>>(),
+        _exceptionHandler.Verify(handleException => handleException.CreateValidationExceptionLog(
+            It.Is<IEnumerable<RuleResultTree>>(r => r.Any(x => x.Rule.RuleName == "11.Demographics")),
             It.IsAny<ParticipantCsvRecord>()),
             Times.Once());
     }
 
+
     [TestMethod]
-    [DataRow("0000000000")]
-    [DataRow("9999999999")]
-    public async Task Run_Should_Not_Create_Exception_When_RemovedParticipantMustExist_Rule_Passes(string nhsNumber)
+    [DataRow("Smith", Gender.Female, "19700101", "Jones", Gender.Female, "19700101")]   // New Family Name Only
+    [DataRow("Smith", Gender.Female, "19700101", "Smith", Gender.Male, "19700101")]     // New Gender Only
+    [DataRow("Smith", Gender.Female, "19700101", "Smith", Gender.Female, "19700102")]   // New Date of Birth Only
+    [DataRow("Smith", Gender.Female, "19700101", "Smith", Gender.Female, "19700101")]   // No Change
+    public async Task Run_Should_Not_Create_Exception_When_Demographics_Rule_Passes(
+        string existingFamilyName, Gender existingGender, string existingDateOfBirth, string newFamilyName, Gender newGender, string newDateOfBirth)
     {
         // Arrange
-        _requestBody.NewParticipant.RecordType = Actions.Removed;
-        _requestBody.ExistingParticipant.NhsNumber = nhsNumber;
+        _requestBody.ExistingParticipant.Surname = existingFamilyName;
+        _requestBody.ExistingParticipant.Gender = existingGender;
+        _requestBody.ExistingParticipant.DateOfBirth = existingDateOfBirth;
+        _requestBody.NewParticipant.Surname = newFamilyName;
+        _requestBody.NewParticipant.Gender = newGender;
+        _requestBody.NewParticipant.DateOfBirth = newDateOfBirth;
         var json = JsonSerializer.Serialize(_requestBody);
         SetUpRequestBody(json);
 
@@ -216,8 +239,84 @@ public class LookupValidationTests
         await _function.RunAsync(_request.Object);
 
         // Assert
-        _handleException.Verify(handleException => handleException.CreateValidationExceptionLog(
-            It.IsAny<IEnumerable<RuleResultTree>>(),
+        _exceptionHandler.Verify(handleException => handleException.CreateValidationExceptionLog(
+            It.Is<IEnumerable<RuleResultTree>>(r => r.Any(x => x.Rule.RuleName == "11.Demographics")),
+            It.IsAny<ParticipantCsvRecord>()),
+            Times.Never());
+    }
+
+    [TestMethod]
+    [DataRow("221B Baker Street", "Flat 1", "Marylebone", "Westminster", "London", null, null, null, null, null)]
+    [DataRow("221B Baker Street", "Flat 1", "Marylebone", "Westminster", "London", "", "", "", "", "")]
+    [DataRow("221B Baker Street", null, null, null, null, "", "", "", "", "")]
+    [DataRow(null, "Flat 1", null, null, null, "", "", "", "", "")]
+    [DataRow(null, null, "Marylebone", null, null, "", "", "", "", "")]
+    [DataRow(null, null, null, "Westminster", null, "", "", "", "", "")]
+    [DataRow(null, null, null, null, "London", "", "", "", "", "")]
+    public async Task Run_Should_Return_Created_And_Create_Exception_When_Address_Rule_Fails(
+        string existingAddressLine1, string existingAddressLine2, string existingAddressLine3, string existingAddressLine4, string existingAddressLine5,
+        string newAddressLine1, string newAddressLine2, string newAddressLine3, string newAddressLine4, string newAddressLine5)
+    {
+        // Arrange
+        _requestBody.NewParticipant.RecordType = Actions.Amended;
+        _requestBody.ExistingParticipant.AddressLine1 = existingAddressLine1;
+        _requestBody.ExistingParticipant.AddressLine2 = existingAddressLine2;
+        _requestBody.ExistingParticipant.AddressLine3 = existingAddressLine3;
+        _requestBody.ExistingParticipant.AddressLine4 = existingAddressLine4;
+        _requestBody.ExistingParticipant.AddressLine5 = existingAddressLine5;
+        _requestBody.NewParticipant.AddressLine1 = newAddressLine1;
+        _requestBody.NewParticipant.AddressLine2 = newAddressLine2;
+        _requestBody.NewParticipant.AddressLine3 = newAddressLine3;
+        _requestBody.NewParticipant.AddressLine4 = newAddressLine4;
+        _requestBody.NewParticipant.AddressLine5 = newAddressLine5;
+        var json = JsonSerializer.Serialize(_requestBody);
+        SetUpRequestBody(json);
+
+        // Act
+        var result = await _function.RunAsync(_request.Object);
+
+        // Assert
+        Assert.AreEqual(HttpStatusCode.Created, result.StatusCode);
+        _exceptionHandler.Verify(handleException => handleException.CreateValidationExceptionLog(
+            It.Is<IEnumerable<RuleResultTree>>(r => r.Any(x => x.Rule.RuleName == "71.MustNotOverwriteAddressWithEmpty")),
+            It.IsAny<ParticipantCsvRecord>()),
+            Times.Once());
+    }
+
+    [TestMethod]
+    [DataRow(Actions.Amended, null, null, null, null, null, "221B Baker Street", "Flat 2", "Marylebone", "Westminster", "London")]
+    [DataRow(Actions.Amended, "221B Baker Street", "Flat 1", "Marylebone", "Westminster", "London", "221B Baker Street", "Flat 2", "Marylebone", "Westminster", "London")]
+    [DataRow(Actions.Amended, "221B Baker Street", "Flat 1", "Marylebone", "Westminster", "London", "221B Baker Street", null, null, null, null)]
+    [DataRow(Actions.Amended, "221B Baker Street", "Flat 1", "Marylebone", "Westminster", "London", null, "Flat 2", null, null, null)]
+    [DataRow(Actions.Amended, "221B Baker Street", "Flat 1", "Marylebone", "Westminster", "London", null, null, "Marylebone", null, null)]
+    [DataRow(Actions.Amended, "221B Baker Street", "Flat 1", "Marylebone", "Westminster", "London", null, null, null, "Westminster", null)]
+    [DataRow(Actions.Amended, "221B Baker Street", "Flat 1", "Marylebone", "Westminster", "London", null, null, null, null, "London")]
+    [DataRow(Actions.New, "221B Baker Street", "Flat 1", "Marylebone", "Westminster", "London", null, null, null, null, null)]
+    public async Task Run_Should_Not_Create_Exception_When_Address_Rule_Passes(string recordType,
+        string existingAddressLine1, string existingAddressLine2, string existingAddressLine3, string existingAddressLine4, string existingAddressLine5,
+        string newAddressLine1, string newAddressLine2, string newAddressLine3, string newAddressLine4, string newAddressLine5)
+    {
+        // Arrange
+        _requestBody.NewParticipant.RecordType = recordType;
+        _requestBody.ExistingParticipant.AddressLine1 = existingAddressLine1;
+        _requestBody.ExistingParticipant.AddressLine2 = existingAddressLine2;
+        _requestBody.ExistingParticipant.AddressLine3 = existingAddressLine3;
+        _requestBody.ExistingParticipant.AddressLine4 = existingAddressLine4;
+        _requestBody.ExistingParticipant.AddressLine5 = existingAddressLine5;
+        _requestBody.NewParticipant.AddressLine1 = newAddressLine1;
+        _requestBody.NewParticipant.AddressLine2 = newAddressLine2;
+        _requestBody.NewParticipant.AddressLine3 = newAddressLine3;
+        _requestBody.NewParticipant.AddressLine4 = newAddressLine4;
+        _requestBody.NewParticipant.AddressLine5 = newAddressLine5;
+        var json = JsonSerializer.Serialize(_requestBody);
+        SetUpRequestBody(json);
+
+        // Act
+        await _function.RunAsync(_request.Object);
+
+        // Assert
+        _exceptionHandler.Verify(handleException => handleException.CreateValidationExceptionLog(
+            It.Is<IEnumerable<RuleResultTree>>(r => r.Any(x => x.Rule.RuleName == "71.MustNotOverwriteAddressWithEmpty")),
             It.IsAny<ParticipantCsvRecord>()),
             Times.Never());
     }

--- a/tests/ScreeningValidationServiceTests/LookupValidation/LookupValidationTests.cs
+++ b/tests/ScreeningValidationServiceTests/LookupValidation/LookupValidationTests.cs
@@ -160,7 +160,7 @@ public class LookupValidationTests
         // Assert
         Assert.AreEqual(HttpStatusCode.Created, result.StatusCode);
         _exceptionHandler.Verify(handleException => handleException.CreateValidationExceptionLog(
-            It.Is<IEnumerable<RuleResultTree>>(r => r.Any(x => x.Rule.RuleName == "ParticipantMustNotExist")),
+            It.Is<IEnumerable<RuleResultTree>>(r => r.Any(x => x.Rule.RuleName == "47.ParticipantMustNotExist")),
             It.IsAny<ParticipantCsvRecord>()),
             Times.Once());
     }
@@ -182,7 +182,7 @@ public class LookupValidationTests
 
         // Assert
         _exceptionHandler.Verify(handleException => handleException.CreateValidationExceptionLog(
-            It.Is<IEnumerable<RuleResultTree>>(r => r.Any(x => x.Rule.RuleName == "ParticipantMustNotExist")),
+            It.Is<IEnumerable<RuleResultTree>>(r => r.Any(x => x.Rule.RuleName == "47.ParticipantMustNotExist")),
             It.IsAny<ParticipantCsvRecord>()),
             Times.Never());
     }
@@ -212,7 +212,7 @@ public class LookupValidationTests
         // Assert
         Assert.AreEqual(HttpStatusCode.Created, result.StatusCode);
         _exceptionHandler.Verify(handleException => handleException.CreateValidationExceptionLog(
-            It.Is<IEnumerable<RuleResultTree>>(r => r.Any(x => x.Rule.RuleName == "11.Demographics")),
+            It.Is<IEnumerable<RuleResultTree>>(r => r.Any(x => x.Rule.RuleName == "35.Demographics")),
             It.IsAny<ParticipantCsvRecord>()),
             Times.Once());
     }
@@ -243,7 +243,7 @@ public class LookupValidationTests
 
         // Assert
         _exceptionHandler.Verify(handleException => handleException.CreateValidationExceptionLog(
-            It.Is<IEnumerable<RuleResultTree>>(r => r.Any(x => x.Rule.RuleName == "11.Demographics")),
+            It.Is<IEnumerable<RuleResultTree>>(r => r.Any(x => x.Rule.RuleName == "35.Demographics")),
             It.IsAny<ParticipantCsvRecord>()),
             Times.Never());
     }

--- a/tests/ScreeningValidationServiceTests/LookupValidation/LookupValidationTests.cs
+++ b/tests/ScreeningValidationServiceTests/LookupValidation/LookupValidationTests.cs
@@ -7,6 +7,7 @@ using Common;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Model;
 using Model.Enums;
 using Moq;
@@ -23,6 +24,7 @@ public class LookupValidationTests
     private readonly ServiceCollection _serviceCollection = new();
     private readonly LookupValidationRequestBody _requestBody;
     private readonly LookupValidation _function;
+    private readonly Mock<ILogger<LookupValidation>> _mockLogger = new();
 
 
     public LookupValidationTests()
@@ -52,7 +54,7 @@ public class LookupValidationTests
         _exceptionHandler.Setup(x => x.CreateValidationExceptionLog(It.IsAny<IEnumerable<RuleResultTree>>(), It.IsAny<ParticipantCsvRecord>()))
             .Returns(Task.FromResult(true));
 
-        _function = new LookupValidation(_createResponse, _exceptionHandler.Object);
+        _function = new LookupValidation(_createResponse, _exceptionHandler.Object, _mockLogger.Object);
 
         _request.Setup(r => r.CreateResponse()).Returns(() =>
         {


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

- Implemented demographics lookup validation rule
- Combined AmendedParticipantMustExist and RemovedParticipantMustExist rules into ParticipantMustExist
- Changed LookupValidation response to BadRequest for when a valid LookupValidationRequestBody is not received 

## Context

[DTOSS-3477](https://nhsd-jira.digital.nhs.uk/browse/DTOSS-3477)

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
