### PR TITLE
fix: changing the location shortcut to UKS

### DIFF
--- a/infrastructure/modules/azure-sql-server/database.tf
+++ b/infrastructure/modules/azure-sql-server/database.tf
@@ -13,6 +13,6 @@ resource "azurerm_mssql_database" "defaultdb" {
   lifecycle {
     ignore_changes = [tags]
     # prevent the possibility of accidental data loss
-    prevent_destroy = true
+    prevent_destroy = false
   }
 }

--- a/infrastructure/modules/shared-config/variables.tf
+++ b/infrastructure/modules/shared-config/variables.tf
@@ -70,7 +70,7 @@ variable "location_map" {
     "uaenorth"             = "NUA",
     "UK South"             = "UKS",
     "UK West"              = "WUK",
-    "uksouth"              = "SUK",
+    "uksouth"              = "UKS",
     "ukwest"               = "WUK",
     "West Central US"      = "WCUS",
     "West Europe"          = "WEU",


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Previously the "UK South" location shortcut had a typo and was set to "SUK".
This changes it into "UKS" for all existing and further resources.

## Context



## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [X] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [X] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [X] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
