### PR TITLE
fix: acr naming scheme change with environment at the end

### DIFF
--- a/infrastructure/modules/shared-config/output.tf
+++ b/infrastructure/modules/shared-config/output.tf
@@ -1,6 +1,6 @@
 locals {
   names = {
-    azure-container-registry    = lower("ACR${var.env}${var.location_map[var.location]}${var.application}")
+    azure-container-registry    = lower("ACR${var.location_map[var.location]}${var.application}${var.env}")
     availability-set            = lower("AVS-${var.env}-${var.location_map[var.location]}-${var.application}")
     app-insights                = upper("${var.env}-${var.location_map[var.location]}")
     app-service-plan            = lower("ASP-${var.application}-${var.env}-${var.location_map[var.location]}")


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Change the naming scheme of ACR from:
- lower("ACR${var.env}${var.location_map[var.location]}${var.application}") (acrdevukscohman)
to
- lower("ACR${var.location_map[var.location]}${var.application}${var.env}") (acrukscohmandev)

## Context


## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
