### PR TITLE
fix: change to the API Managemet name scheme

### DIFF
--- a/infrastructure/modules/shared-config/output.tf
+++ b/infrastructure/modules/shared-config/output.tf
@@ -1,6 +1,6 @@
 locals {
   names = {
-    api-management              = lower("APIM-${var.application}-${var.env}-${var.location_map[var.location]}")
+    api-management              = lower("APIM-${var.env}-${var.application}-${var.location_map[var.location]}")
     app-insights                = upper("${var.env}-${var.location_map[var.location]}")
     app-service-plan            = lower("ASP-${var.application}-${var.env}-${var.location_map[var.location]}")
     app-service                 = lower("AS-${var.env}-${var.location_map[var.location]}-${var.application}")


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

A change to the naming scheme of API Management resources due to name conflict issue.

## Context

Change from: 
- lower("APIM-${var.application}-${var.env}-${var.location_map[var.location]}") (apim-cohman-dev-uks)
to
- lower("APIM-${var.env}-${var.application}-${var.location_map[var.location]}") (apim-dev-cohman-uks)

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
