### PR TITLE
feat: DTOSS-3665 - new storage account with container + change to ReceiveCaasFile fnapp config

### DIFF
--- a/infrastructure/environments/development.tfvars.config
+++ b/infrastructure/environments/development.tfvars.config
@@ -28,6 +28,17 @@ storage_accounts = {
     public_network_access_enabled = true
   }
 
+  file_exceptions = {
+    name_suffix                   = "filexptns"
+    resource_group_key            = "cohman"
+    account_tier                  = "Standard"
+    replication_type              = "LRS"
+    public_network_access_enabled = true
+
+    cont_name        = "file-exceptions"
+    cont_access_type = "private"
+  }
+
 }
 
 key_vault = {

--- a/infrastructure/fnapp.tf
+++ b/infrastructure/fnapp.tf
@@ -25,6 +25,9 @@ module "functionapp" {
 
   image_tag = var.function_app.gl_docker_env_tag
 
+  #Specific FNApp settings:
+  caasfolder_STORAGE = module.storage.sa_fe_primary_connection_string
+
   tags = var.tags
 
 }

--- a/infrastructure/modules/function-app/locals.tf
+++ b/infrastructure/modules/function-app/locals.tf
@@ -59,7 +59,6 @@ locals {
       #FUNCTIONS_WORKER_RUNTIME = "dotnet-isolated"
       DOCKER_ENABLE_CI = "false"
 
-      UNCTIONS_WORKER_RUNTIME = "dotnet-isolated"
       #DtOsDatabaseConnectionString = Server=localhost,1433;Database=${DB_NAME};User Id=SA;Password=${PASSWORD};TrustServerCertificate=True
       LookupValidationURL = "https://${var.names.function-app}-${lower(var.function_app.LookupValidation.name_suffix)}/api/LookupValidation"
 

--- a/infrastructure/modules/function-app/locals.tf
+++ b/infrastructure/modules/function-app/locals.tf
@@ -12,10 +12,9 @@ locals {
       #FUNCTIONS_WORKER_RUNTIME = "dotnet-isolated"
       DOCKER_ENABLE_CI = "false"
 
-      AzureWebJobsStorage = "UseDevelopmentStorage=true"
-      caasfolder_STORAGE  = "UseDevelopmentStorage=true"
-      targetFunction      = "https://${var.names.function-app}-${lower(var.function_app.ProcessCaasFile.name_suffix)}/api/processCaasFile"
-      FileValidationURL   = "https://${var.names.function-app}-${lower(var.function_app.FileValidation.name_suffix)}/api/FileValidation"
+      caasfolder_STORAGE = var.caasfolder_STORAGE
+      targetFunction     = "https://${var.names.function-app}-${lower(var.function_app.ProcessCaasFile.name_suffix)}/api/processCaasFile"
+      FileValidationURL  = "https://${var.names.function-app}-${lower(var.function_app.FileValidation.name_suffix)}/api/FileValidation"
     }
 
     ProcessCaasFile = {

--- a/infrastructure/modules/function-app/variables.tf
+++ b/infrastructure/modules/function-app/variables.tf
@@ -72,3 +72,7 @@ variable "acr_mi_id" {
 variable "acr_mi_client_id" {
   description = "The Client ID of the Managed Service Identity to use for connections to the Azure Container Registry."
 }
+
+variable "caasfolder_STORAGE" {
+  description = "Primary connection string to file exeptions storage account"
+}

--- a/infrastructure/modules/storage/main.tf
+++ b/infrastructure/modules/storage/main.tf
@@ -13,3 +13,25 @@ resource "azurerm_storage_account" "sa" {
     ignore_changes = [tags]
   }
 }
+
+resource "azurerm_storage_account" "fileexception" {
+
+  name                          = var.fe_name
+  resource_group_name           = var.fe_resource_group_name
+  location                      = var.fe_location
+  account_tier                  = var.fe_account_tier
+  account_replication_type      = var.fe_sa_replication_type
+  public_network_access_enabled = var.fe_public_access
+
+  tags = var.tags
+
+  lifecycle {
+    ignore_changes = [tags]
+  }
+}
+
+resource "azurerm_storage_container" "example" {
+  name                  = var.fe_cont_name # "vhds"
+  storage_account_name  = azurerm_storage_account.fileexception.name
+  container_access_type = var.fe_cont_access_type # "private"
+}

--- a/infrastructure/modules/storage/output.tf
+++ b/infrastructure/modules/storage/output.tf
@@ -7,3 +7,8 @@ output "storage_account_primary_access_key" {
   sensitive = true
   value     = azurerm_storage_account.sa.primary_access_key
 }
+
+output "sa_fe_primary_connection_string" {
+  sensitive = true
+  value     = azurerm_storage_account.fileexception.primary_connection_string
+}

--- a/infrastructure/modules/storage/variables.tf
+++ b/infrastructure/modules/storage/variables.tf
@@ -35,3 +35,45 @@ variable "tags" {
   description = "Resource tags to be applied throughout the deployment."
   default     = {}
 }
+
+### File Exceptions
+variable "fe_name" {
+  type        = string
+  description = "The name of the Storage Account."
+}
+
+variable "fe_resource_group_name" {
+  type        = string
+  description = "The name of the resource group in which to create the Storage Account. Changing this forces a new resource to be created."
+}
+
+variable "fe_location" {
+  type        = string
+  description = "The location/region where the Storage Account is created."
+}
+
+variable "fe_account_tier" {
+  description = "."
+  default     = {}
+}
+
+variable "fe_sa_replication_type" {
+  description = "."
+  default     = {}
+}
+
+variable "fe_public_access" {
+  description = "."
+  default     = {}
+}
+
+variable "fe_cont_name" {
+  type        = string
+  description = "The name of the Container which should be created within the Storage Account. Changing this forces a new resource to be created."
+}
+
+variable "fe_cont_access_type" {
+  type        = string
+  description = "The Access Level configured for this Container. Possible values are blob, container or private. Defaults to private."
+}
+

--- a/infrastructure/modules/storage/variables.tf
+++ b/infrastructure/modules/storage/variables.tf
@@ -15,17 +15,17 @@ variable "name" {
 }
 
 variable "account_tier" {
-  description = "."
+  description = "Defines the Tier to use for this storage account."
   default     = {}
 }
 
 variable "sa_replication_type" {
-  description = "."
+  description = "Defines the type of replication to use for this storage account."
   default     = {}
 }
 
 variable "public_access" {
-  description = "."
+  description = "Whether the public network access is enabled."
   default     = {}
 }
 
@@ -53,17 +53,17 @@ variable "fe_location" {
 }
 
 variable "fe_account_tier" {
-  description = "."
+  description = "Defines the Tier to use for this storage account."
   default     = {}
 }
 
 variable "fe_sa_replication_type" {
-  description = "."
+  description = "Defines the type of replication to use for this storage account."
   default     = {}
 }
 
 variable "fe_public_access" {
-  description = "."
+  description = "Whether the public network access is enabled."
   default     = {}
 }
 

--- a/infrastructure/storage.tf
+++ b/infrastructure/storage.tf
@@ -11,4 +11,17 @@ module "storage" {
 
   tags = var.tags
 
+  ## File exception
+
+  fe_name                = substr("${module.config.names.storage-account}${lower(var.storage_accounts.file_exceptions.name_suffix)}", 0, 24)
+  fe_resource_group_name = module.baseline.resource_group_names[var.storage_accounts.file_exceptions.resource_group_key]
+  fe_location            = module.baseline.resource_group_locations[var.storage_accounts.file_exceptions.resource_group_key]
+
+  fe_account_tier        = var.storage_accounts.file_exceptions.account_tier
+  fe_sa_replication_type = var.storage_accounts.file_exceptions.replication_type
+  fe_public_access       = var.storage_accounts.file_exceptions.public_network_access_enabled
+
+  fe_cont_name        = var.storage_accounts.file_exceptions.cont_name
+  fe_cont_access_type = var.storage_accounts.file_exceptions.cont_access_type
+
 }

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -42,6 +42,15 @@ variable "storage_accounts" {
       replication_type              = optional(string, "LRS")
       public_network_access_enabled = optional(bool, true)
     })
+    file_exceptions = object({
+      name_suffix                   = optional(string, "filexptns")
+      resource_group_key            = optional(string, "cohman")
+      account_tier                  = optional(string, "Standard")
+      replication_type              = optional(string, "LRS")
+      public_network_access_enabled = optional(bool, true)
+      cont_name                     = optional(string, "file-exceptions")
+      cont_access_type              = optional(string, "private")
+    })
   })
 }
 


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

According to [DTOSS-3665](https://nhsd-jira.digital.nhs.uk/browse/DTOSS-3665):
- new storage account
- new container named 'file-exceptions'
- change in configuiration for the receiveCaasFile function app (caasfolder_STORAGE)

## Context

Required for a proper communication between the function and a storage account. 

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [X] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [X] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
