### PR TITLE
fix: renamed function apps and added missing env variables

### DIFF
--- a/infrastructure/environments/development.tfvars.config
+++ b/infrastructure/environments/development.tfvars.config
@@ -112,7 +112,7 @@ function_app = {
 
   fa_config = {
 
-    receiveCaasFile = {
+    ReceiveCaasFile = {
       name_suffix = "receive-caas-file"
       site_config = {
         application_stack = {
@@ -128,7 +128,7 @@ function_app = {
       }
     }
 
-    AddNewParticipant = {
+    AddParticipant = {
       name_suffix = "add-participant"
       site_config = {
         application_stack = {
@@ -160,8 +160,8 @@ function_app = {
       }
     }
 
-    MarkParticipantEligible = {
-      name_suffix = "mark-participant-eligible"
+    MarkParticipantAsEligible = {
+      name_suffix = "mark-participant-as-eligible"
       site_config = {
         application_stack = {
         }
@@ -169,7 +169,7 @@ function_app = {
     }
 
     MarkParticipantAsIneligible = {
-      name_suffix = "mark-participant-ineligible"
+      name_suffix = "mark-participant-as-ineligible"
       site_config = {
         application_stack = {
         }
@@ -184,8 +184,8 @@ function_app = {
       }
     }
 
-    CreateValidationExceptions = {
-      name_suffix = "create-validation-exception"
+    CreateException = {
+      name_suffix = "create-exception"
       site_config = {
         application_stack = {
         }
@@ -256,16 +256,16 @@ function_app = {
       }
     }
 
-    RemoveCohortDistributionData = {
-      name_suffix = "remove-cohort-distribution-data"
+    RemoveFromCohortDistributionData = {
+      name_suffix = "remove-from-cohort-distribution-data"
       site_config = {
         application_stack = {
         }
       }
     }
 
-    TransformData = {
-      name_suffix = "transform-data"
+    TransformDataService = {
+      name_suffix = "transform-data-service"
       site_config = {
         application_stack = {
         }

--- a/infrastructure/modules/function-app/locals.tf
+++ b/infrastructure/modules/function-app/locals.tf
@@ -1,20 +1,26 @@
 locals {
   fnapp_urls = {
 
-    processCaasFile             = "https://${var.names.function-app}-${lower(var.function_app.ProcessCaasFile.name_suffix)}.azurewebsites.net/api/processCaasFile"
-    fileValidation              = "https://${var.names.function-app}-${lower(var.function_app.FileValidation.name_suffix)}.azurewebsites.net/api/FileValidation"
-    addParticipant              = "https://${var.names.function-app}-${lower(var.function_app.AddNewParticipant.name_suffix)}.azurewebsites.net/api/addParticipant"
-    removeParticipant           = "https://${var.names.function-app}-${lower(var.function_app.RemoveParticipant.name_suffix)}.azurewebsites.net/api/RemoveParticipant"
-    updateParticipant           = "https://${var.names.function-app}-${lower(var.function_app.UpdateParticipant.name_suffix)}.azurewebsites.net/api/updateParticipant"
-    demographicDataFunction     = "https://${var.names.function-app}-${lower(var.function_app.DemographicDataManagement.name_suffix)}.azurewebsites.net/api/DemographicDataFunction"
-    createParticipant           = "https://${var.names.function-app}-${lower(var.function_app.CreateParticipant.name_suffix)}.azurewebsites.net/api/CreateParticipant"
-    markParticipantAsEligible   = "https://${var.names.function-app}-${lower(var.function_app.MarkParticipantEligible.name_suffix)}.azurewebsites.net/api/markParticipantAsEligible"
-    staticValidation            = "https://${var.names.function-app}-${lower(var.function_app.StaticValidation.name_suffix)}.azurewebsites.net/api/StaticValidation"
-    markParticipantAsIneligible = "https://${var.names.function-app}-${lower(var.function_app.MarkParticipantAsIneligible.name_suffix)}.azurewebsites.net/api/markParticipantAsIneligible"
-    updateParticipant           = "https://${var.names.function-app}-${lower(var.function_app.UpdateParticipantDetails.name_suffix)}.azurewebsites.net/api/updateParticipantDetails"
-    lookupValidation            = "https://${var.names.function-app}-${lower(var.function_app.LookupValidation.name_suffix)}.azurewebsites.net/api/LookupValidation"
-    createValidationException   = "https://${var.names.function-app}-${lower(var.function_app.CreateValidationExceptions.name_suffix)}.azurewebsites.net/api/CreateValidationException"
-    demographicDataService      = "https://${var.names.function-app}-${lower(var.function_app.DemographicDataService.name_suffix)}.azurewebsites.net/api/DemographicDataService"
+    processCaasFile                  = "https://${var.names.function-app}-${lower(var.function_app.ProcessCaasFile.name_suffix)}.azurewebsites.net/api/processCaasFile"
+    fileValidation                   = "https://${var.names.function-app}-${lower(var.function_app.FileValidation.name_suffix)}.azurewebsites.net/api/FileValidation"
+    addParticipant                   = "https://${var.names.function-app}-${lower(var.function_app.AddParticipant.name_suffix)}.azurewebsites.net/api/addParticipant"
+    removeParticipant                = "https://${var.names.function-app}-${lower(var.function_app.RemoveParticipant.name_suffix)}.azurewebsites.net/api/RemoveParticipant"
+    updateParticipant                = "https://${var.names.function-app}-${lower(var.function_app.UpdateParticipant.name_suffix)}.azurewebsites.net/api/updateParticipant"
+    updateParticipantDetails         = "https://${var.names.function-app}-${lower(var.function_app.UpdateParticipantDetails.name_suffix)}.azurewebsites.net/api/updateParticipantDetails"
+    demographicDataFunction          = "https://${var.names.function-app}-${lower(var.function_app.DemographicDataManagement.name_suffix)}.azurewebsites.net/api/DemographicDataFunction"
+    createParticipant                = "https://${var.names.function-app}-${lower(var.function_app.CreateParticipant.name_suffix)}.azurewebsites.net/api/CreateParticipant"
+    markParticipantAsEligible        = "https://${var.names.function-app}-${lower(var.function_app.MarkParticipantAsEligible.name_suffix)}.azurewebsites.net/api/markParticipantAsEligible"
+    staticValidation                 = "https://${var.names.function-app}-${lower(var.function_app.StaticValidation.name_suffix)}.azurewebsites.net/api/StaticValidation"
+    markParticipantAsIneligible      = "https://${var.names.function-app}-${lower(var.function_app.MarkParticipantAsIneligible.name_suffix)}.azurewebsites.net/api/markParticipantAsIneligible"
+    lookupValidation                 = "https://${var.names.function-app}-${lower(var.function_app.LookupValidation.name_suffix)}.azurewebsites.net/api/LookupValidation"
+    createException                  = "https://${var.names.function-app}-${lower(var.function_app.CreateException.name_suffix)}.azurewebsites.net/api/CreateException"
+    demographicDataService           = "https://${var.names.function-app}-${lower(var.function_app.DemographicDataService.name_suffix)}.azurewebsites.net/api/DemographicDataService"
+    retrieveParticipantData          = "https://${var.names.function-app}-${lower(var.function_app.RetrieveParticipantData.name_suffix)}.azurewebsites.net/api/RetrieveParticipantData"
+    allocateServiceProvider          = "https://${var.names.function-app}-${lower(var.function_app.AllocateServiceProvider.name_suffix)}.azurewebsites.net/api/AllocateServiceProvider"
+    transformDataService             = "https://${var.names.function-app}-${lower(var.function_app.TransformDataService.name_suffix)}.azurewebsites.net/api/TransformDataService"
+    addCohortDistributionData        = "https://${var.names.function-app}-${lower(var.function_app.AddCohortDistributionData.name_suffix)}.azurewebsites.net/api/AddCohortDistributionData"
+    removeFromCohortDistributionData = "https://${var.names.function-app}-${lower(var.function_app.RemoveFromCohortDistributionData.name_suffix)}.azurewebsites.net/api/RemoveFromCohortDistributionData"
+    createCohortDistribution         = "https://${var.names.function-app}-${lower(var.function_app.CreateCohortDistribution.name_suffix)}.azurewebsites.net/api/CreateCohortDistribution"
 
   }
 
@@ -33,7 +39,7 @@ locals {
 locals {
   app_settings = {
 
-    receiveCaasFile = {
+    ReceiveCaasFile = {
 
       caasfolder_STORAGE = var.caasfolder_STORAGE
       targetFunction     = local.fnapp_urls.processCaasFile
@@ -48,50 +54,60 @@ locals {
       DemographicURI       = local.fnapp_urls.demographicDataFunction
     }
 
-    AddNewParticipant = {
+    AddParticipant = {
 
       DSaddParticipant            = local.fnapp_urls.createParticipant
       DSmarkParticipantAsEligible = local.fnapp_urls.markParticipantAsEligible
       DemographicURIGet           = local.fnapp_urls.demographicDataFunction
       StaticValidationURL         = local.fnapp_urls.staticValidation
+      exceptionFunctionURL        = local.fnapp_urls.createException
     }
 
     RemoveParticipant = {
 
-      markParticipantAsIneligible = local.fnapp_urls.markParticipantAsIneligible
+      markParticipantAsIneligible     = local.fnapp_urls.markParticipantAsIneligible
+      DemographicURI                  = local.fnapp_urls.demographicDataFunction
+      removeFromCohortDistributionURL = local.fnapp_urls.removeFromCohortDistributionData
+      exceptionFunctionURL            = local.fnapp_urls.createException
     }
 
     UpdateParticipant = {
 
-      UpdateParticipant   = local.fnapp_urls.updateParticipant
-      StaticValidationURL = local.fnapp_urls.staticValidation
-      DemographicURIGet   = local.fnapp_urls.demographicDataFunction
+      UpdateParticipant            = local.fnapp_urls.updateParticipantDetails
+      StaticValidationURL          = local.fnapp_urls.staticValidation
+      DemographicURIGet            = local.fnapp_urls.demographicDataFunction
+      cohortDistributionServiceURL = local.fnapp_urls.createCohortDistribution
+      exceptionFunctionURL         = local.fnapp_urls.createException
     }
 
     CreateParticipant = {
 
       DtOsDatabaseConnectionString = local.db_connection_string
       LookupValidationURL          = local.fnapp_urls.lookupValidation
+      exceptionFunctionURL         = local.fnapp_urls.createException
     }
 
-    MarkParticipantEligible = {
+    MarkParticipantAsEligible = {
 
       DtOsDatabaseConnectionString = local.db_connection_string
+      exceptionFunctionURL         = local.fnapp_urls.createException
     }
 
     MarkParticipantAsIneligible = {
 
       DtOsDatabaseConnectionString = local.db_connection_string
       LookupValidationURL          = local.fnapp_urls.lookupValidation
+      exceptionFunctionURL         = local.fnapp_urls.createException
     }
 
     UpdateParticipantDetails = {
 
       DtOsDatabaseConnectionString = local.db_connection_string
       LookupValidationURL          = local.fnapp_urls.lookupValidation
+      exceptionFunctionURL         = local.fnapp_urls.createException
     }
 
-    CreateValidationExceptions = {
+    CreateException = {
 
       DtOsDatabaseConnectionString = local.db_connection_string
     }
@@ -108,18 +124,18 @@ locals {
 
     FileValidation = {
 
-      CreateValidationExceptionURL = local.fnapp_urls.createValidationException
-      inboundBlobName              = "file-exceptions"
+      exceptionFunctionURL = local.fnapp_urls.createException
+      inboundBlobName      = "file-exceptions"
     }
 
     StaticValidation = {
 
-      CreateValidationExceptionURL = local.fnapp_urls.createValidationException
+      exceptionFunctionURL = local.fnapp_urls.createException
     }
 
     LookupValidation = {
 
-      CreateValidationExceptionURL = local.fnapp_urls.createValidationException
+      exceptionFunctionURL = local.fnapp_urls.createException
     }
 
     DemographicDataManagement = {
@@ -137,22 +153,26 @@ locals {
       DtOsDatabaseConnectionString = local.db_connection_string
     }
 
-    RemoveCohortDistributionData = {
+    RemoveFromCohortDistributionData = {
 
       DtOsDatabaseConnectionString = local.db_connection_string
     }
 
-    TransformData = {
+    TransformDataService = {
 
     }
 
     AllocateServiceProvider = {
 
-      CreateValidationExceptionURL = local.fnapp_urls.createValidationException
+      exceptionFunctionURL = local.fnapp_urls.createException
     }
 
     CreateCohortDistribution = {
 
+      retrieveParticipantDataURL = local.fnapp_urls.retrieveParticipantData
+      allocateServiceProviderURL = local.fnapp_urls.allocateServiceProvider
+      transformDataServiceURL    = local.fnapp_urls.transformDataService
+      addCohortDistributionURL   = local.fnapp_urls.addCohortDistributionData
     }
 
     RetrieveParticipantData = {

--- a/infrastructure/modules/function-app/locals.tf
+++ b/infrastructure/modules/function-app/locals.tf
@@ -23,8 +23,8 @@ locals {
     createCohortDistribution         = "https://${var.names.function-app}-${lower(var.function_app.CreateCohortDistribution.name_suffix)}.azurewebsites.net/api/CreateCohortDistribution"
 
   }
-
   db_connection_string = "Server=${var.names.sql-server}.database.windows.net; Authentication=Active Directory Managed Identity; Database=${var.db_name}"
+
 }
 
 locals {


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

This PR includes:
- renaming a few of the function apps to be consistent across the whole solution
- adding missing environmental variables for a few functions, based on the input from Martin

## Context

Current list of the function apps after implementing this change:
`<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:////Users/macmur/Library/Group%20Containers/UBF8T346G9.Office/TemporaryItems/msohtmlclip/clip.htm">
<link rel=File-List
href="file:////Users/macmur/Library/Group%20Containers/UBF8T346G9.Office/TemporaryItems/msohtmlclip/clip_filelist.xml">
<style>
<!--table
	{mso-displayed-decimal-separator:"\.";
	mso-displayed-thousand-separator:"\,";}
@page
	{margin:.75in .7in .75in .7in;
	mso-header-margin:.3in;
	mso-footer-margin:.3in;}
tr
	{mso-height-source:auto;}
col
	{mso-width-source:auto;}
br
	{mso-data-placement:same-cell;}
td
	{padding-top:1px;
	padding-right:1px;
	padding-left:1px;
	mso-ignore:padding;
	color:black;
	font-size:12.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:"Aptos Narrow", sans-serif;
	mso-font-charset:0;
	mso-number-format:General;
	text-align:general;
	vertical-align:bottom;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
.xl65
	{font-weight:700;
	font-family:"Aptos Narrow";
	mso-generic-font-family:auto;
	mso-font-charset:0;}
-->
</style>
</head>

<body link="#467886" vlink="#96607D">


ObjectName | NameSuffix
-- | --
ReceiveCaasFile | "receive-caas-file"
ProcessCaasFile | "process-caas-file"
AddParticipant | "add-participant"
RemoveParticipant | "remove-participant"
UpdateParticipant | "update-participant"
CreateParticipant | "create-participant"
MarkParticipantAsEligible | "mark-participant-as-eligible"
MarkParticipantAsIneligible | "mark-participant-as-ineligible"
UpdateParticipantDetails | "update-participant-details"
CreateException | "create-exception"
GetValidationExceptions | "get-validation-exceptions"
DemographicDataService | "demographic-data-service"
FileValidation | "file-validation"
StaticValidation | "static-validation"
LookupValidation | "lookup-validation"
DemographicDataManagement | "demographic-data-management"
AddCohortDistributionData | "add-cohort-distribution-data"
RetrieveCohortDistributionData | "retrieve-cohort-distribution-data"
RemoveFromCohortDistributionData | "remove-from-cohort-distribution-data"
TransformDataService | "transform-data-service"
AllocateServiceProvider | "allocate-service-provider"
CreateCohortDistribution | "create-cohort-distribution"
RetrieveParticipantData | "retrieve-participant-data"



</body>

</html>
`

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [X] Refactoring (non-breaking change)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [X] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [X] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
