### PR TITLE
fix: add the ExceptionFunctionURL variable to ReceiveCaasFile function

### DIFF
--- a/infrastructure/modules/function-app/locals.tf
+++ b/infrastructure/modules/function-app/locals.tf
@@ -41,9 +41,10 @@ locals {
 
     ReceiveCaasFile = {
 
-      caasfolder_STORAGE = var.caasfolder_STORAGE
-      targetFunction     = local.fnapp_urls.processCaasFile
-      FileValidationURL  = local.fnapp_urls.fileValidation
+      caasfolder_STORAGE   = var.caasfolder_STORAGE
+      targetFunction       = local.fnapp_urls.processCaasFile
+      FileValidationURL    = local.fnapp_urls.fileValidation
+      ExceptionFunctionURL = local.fnapp_urls.createException
     }
 
     ProcessCaasFile = {


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

This PR adds the missing `ExceptionFunctionURL` variable to ReceiveCaasFile function.

## Context

The missing variable has been already added via portal, this terraform update reflect those changes.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [X] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [X] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
