### PR TITLE
fix: making sure all tests pass for static and lookup rules validation

### DIFF
--- a/tests/ScreeningValidationServiceTests/LookupValidation/LookupValidationTests.cs
+++ b/tests/ScreeningValidationServiceTests/LookupValidation/LookupValidationTests.cs
@@ -1,4 +1,4 @@
-/*I am going to fix these tests but for now we need to get these changes in
+
 namespace NHS.CohortManager.Tests.ScreeningValidationServiceTests;
 using System.Net;
 using System.Text;
@@ -26,6 +26,8 @@ public class LookupValidationTests
     private readonly LookupValidation _function;
     private readonly Mock<ILogger<LookupValidation>> _mockLogger = new();
 
+    private readonly Mock<IReadRulesFromBlobStorage> _readRulesFromBlobStorage = new();
+
 
     public LookupValidationTests()
     {
@@ -51,10 +53,13 @@ public class LookupValidationTests
         };
         _requestBody = new LookupValidationRequestBody(existingParticipant, newParticipant, "caas.csv");
 
+        var json = File.ReadAllText("lookupRules.json");
+        _readRulesFromBlobStorage.Setup(x => x.GetRulesFromBlob(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult<string>(json));
+
         _exceptionHandler.Setup(x => x.CreateValidationExceptionLog(It.IsAny<IEnumerable<RuleResultTree>>(), It.IsAny<ParticipantCsvRecord>()))
             .Returns(Task.FromResult(true));
 
-        _function = new LookupValidation(_createResponse, _exceptionHandler.Object, _mockLogger.Object);
+        _function = new LookupValidation(_createResponse, _exceptionHandler.Object, _mockLogger.Object, _readRulesFromBlobStorage.Object);
 
         _request.Setup(r => r.CreateResponse()).Returns(() =>
         {
@@ -266,4 +271,3 @@ public class LookupValidationTests
         _request.Setup(r => r.Body).Returns(bodyStream);
     }
 }
-*/

--- a/tests/ScreeningValidationServiceTests/StaticValidation/StaticValidationTests.cs
+++ b/tests/ScreeningValidationServiceTests/StaticValidation/StaticValidationTests.cs
@@ -1,5 +1,3 @@
-/* we will be fixing these tests I just don't have time to fix them right now
-
 namespace NHS.CohortManager.Tests.ScreeningValidationServiceTests;
 
 using System.IO.Compression;
@@ -46,6 +44,9 @@ public class StaticValidationTests
 
         _handleException.Setup(x => x.CreateValidationExceptionLog(It.IsAny<IEnumerable<RuleResultTree>>(), It.IsAny<ParticipantCsvRecord>()))
             .Returns(Task.FromResult(true)).Verifiable();
+
+        var json = File.ReadAllText("staticRules.json");
+        _readRulesFromBlobStorage.Setup(x => x.GetRulesFromBlob(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult<string>(json));
 
         _function = new StaticValidation(_logger.Object, _callFunction.Object, _handleException.Object, _createResponse, _readRulesFromBlobStorage.Object);
 
@@ -989,4 +990,3 @@ public class StaticValidationTests
     }
 
 }
-*/


### PR DESCRIPTION
…reading from local rules in directory via mocked IReadRulesFromBlobStorage

<!-- markdownlint-disable-next-line first-line-heading -->
## Description

tests are now getting rules from local json file for static and lookup tests

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
