### PR TITLE
feat: DTOSS-3834 - Date Validation for Participant Data Fields

### DIFF
--- a/tests/CaasIntegrationTests/processCaasFileTest/processCaasFileTests.cs
+++ b/tests/CaasIntegrationTests/processCaasFileTest/processCaasFileTests.cs
@@ -251,4 +251,66 @@ public class ProcessCaasFileTests
             (Func<object, Exception, string>)It.IsAny<object>()
             ), Times.Once);
     }
+
+        [TestMethod]
+    public void IsValidDate_ShouldReturnFalse_WhenDateIsInTheFuture()
+    {
+        // Arrange: Setup dependencies using Mock.Of and create future date
+        var logger = Mock.Of<ILogger<ProcessCaasFileFunction>>();
+        var callFunction = Mock.Of<ICallFunction>();
+        var createResponse = Mock.Of<ICreateResponse>();
+        var checkDemographic = Mock.Of<ICheckDemographic>();
+        var createBasicParticipantData = Mock.Of<ICreateBasicParticipantData>();
+        var handleException = Mock.Of<IExceptionHandler>();
+
+        var validator = new ProcessCaasFileFunction(logger, callFunction, createResponse, checkDemographic, createBasicParticipantData, handleException);
+        var futureDate = DateTime.UtcNow.AddDays(1);
+
+        // Act: Call IsValidDate with a future date
+        bool result = validator.IsValidDate(futureDate);
+
+        // Assert: The method should return false for dates in the future
+        Assert.IsFalse(result, "The 'IsValidDate' method should return false for dates in the future.");
+    }
+
+    [TestMethod]
+    public void IsValidDate_ShouldReturnTrue_WhenDateIsNotInTheFuture()
+    {
+        // Arrange: Setup dependencies using Mock.Of and create future date
+        var logger = Mock.Of<ILogger<ProcessCaasFileFunction>>();
+        var callFunction = Mock.Of<ICallFunction>();
+        var createResponse = Mock.Of<ICreateResponse>();
+        var checkDemographic = Mock.Of<ICheckDemographic>();
+        var createBasicParticipantData = Mock.Of<ICreateBasicParticipantData>();
+        var handleException = Mock.Of<IExceptionHandler>();
+
+        var validator = new ProcessCaasFileFunction(logger, callFunction, createResponse, checkDemographic, createBasicParticipantData, handleException);
+        var pastDate = DateTime.UtcNow.AddDays(-1);
+        var currentDate = DateTime.UtcNow;
+
+        // Act & Assert: The method should return true for past and current dates
+        Assert.IsTrue(validator.IsValidDate(pastDate), "The 'IsValidDate' method should return true for dates in the past.");
+        Assert.IsTrue(validator.IsValidDate(currentDate), "The 'IsValidDate' method should return true for the current date.");
+    }
+
+    [TestMethod]
+    public void IsValidDate_ShouldReturnTrue_WhenDateIsNull()
+    {
+        // Arrange: Set up dependencies and create a null date
+        var logger = Mock.Of<ILogger<ProcessCaasFileFunction>>();
+        var callFunction = Mock.Of<ICallFunction>();
+        var createResponse = Mock.Of<ICreateResponse>();
+        var checkDemographic = Mock.Of<ICheckDemographic>();
+        var createBasicParticipantData = Mock.Of<ICreateBasicParticipantData>();
+        var handleException = Mock.Of<IExceptionHandler>();
+
+        var validator = new ProcessCaasFileFunction(logger, callFunction, createResponse, checkDemographic, createBasicParticipantData, handleException);
+        DateTime? nullDate = null;
+
+        // Act: Call IsValidDate with a null date
+        bool result = validator.IsValidDate(nullDate);
+
+        // Assert: The method should return true for null dates
+        Assert.IsTrue(result, "The 'IsValidDate' method should return true for null dates.");
+    }
 }


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description
This PR is adding validation logic in order to make sure date fields within participant records with dates are not set to future dates. Also handles cases where the date fields are null.

<!-- Describe your changes in detail. -->

## Context

<!-- Why is this change required? What problem does it solve? -->
The aim is to prevent processing participant records with dates that are mistakenly set in the future, leading to data inconsistencies or errors in the system.

Logic added is the following:
- `TryParseDate` method is converting the string version of a date into DateTime object.
- `IsValidDate` method checks if the date is either null or not in the future.
- If any date fails validation, participant record is skipped.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [x] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
