### PR TITLE
fix: returning correctly

### DIFF
--- a/application/CohortManager/src/Functions/CaasIntegration/processCaasFile/processCaasFile.cs
+++ b/application/CohortManager/src/Functions/CaasIntegration/processCaasFile/processCaasFile.cs
@@ -146,9 +146,6 @@ public class ProcessCaasFileFunction
                             ScreeningService = 0
 
                         });
-
-                        return _createResponse.CreateHttpResponse(HttpStatusCode.Created, req);
-
                     }
                     catch (Exception ex)
                     {
@@ -163,7 +160,7 @@ public class ProcessCaasFileFunction
 
         if (err > 0)
         {
-            return _createResponse.CreateHttpResponse(HttpStatusCode.InternalServerError, req);
+            return _createResponse.CreateHttpResponse(HttpStatusCode.Created, req);
         }
 
         return _createResponse.CreateHttpResponse(HttpStatusCode.OK, req);


### PR DESCRIPTION
…hen there is a sinngle error stoppig records form being processed

<!-- markdownlint-disable-next-line first-line-heading -->
## Description

now returns created when there is an erorr and does not return when there is a single error stopping records form being processed 


## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
