### PR TITLE
fix: DTOSS-3653 create Resource Group in audit subscription

### DIFF
--- a/infrastructure/appinsights.tf
+++ b/infrastructure/appinsights.tf
@@ -16,8 +16,7 @@ module "app_insights" {
   law_id       = module.log_analytics_workspace.id
   audit_law_id = module.log_analytics_workspace.audit_id
 
-  audit_resource_group_name = module.baseline.resource_group_names[var.app_insights.audit_resource_group_key]
-
-  tags = var.tags
+  audit_resource_group_name = module.baseline.resource_group_names_audit[var.app_insights.audit_resource_group_key]
+  tags                      = var.tags
 
 }

--- a/infrastructure/baseline.tf
+++ b/infrastructure/baseline.tf
@@ -1,9 +1,16 @@
 module "baseline" {
   source = ".//modules/baseline"
 
+  providers = {
+    azurerm       = azurerm
+    azurerm.audit = azurerm.audit
+  }
+
   location        = var.location
   names           = module.config.names
   tags            = var.tags
   resource_groups = var.resource_groups
+
+  resource_groups_audit = var.resource_groups_audit
 
 }

--- a/infrastructure/environments/development.tfvars.config
+++ b/infrastructure/environments/development.tfvars.config
@@ -11,18 +11,20 @@ resource_groups = {
   # cohman RG
   cohman = {
 
-    name = "rg-cohort-manager-dev-uks"
-    # Is is worth leaving location as a parameter for RG?
-    # location = "uksouth"
-  }
-
-  audit = {
-
-    name = "rg-audit-cohort-manager-dev-uks"
+    name     = "rg-cohort-manager-dev-uks"
+    location = "uksouth"
   }
 
 }
 
+resource_groups_audit = {
+
+  audit = {
+
+    name     = "rg-audit-cohort-manager-dev-uks"
+    location = "uksouth"
+  }
+}
 storage_accounts = {
 
   fnapp = {

--- a/infrastructure/law.tf
+++ b/infrastructure/law.tf
@@ -15,7 +15,7 @@ module "log_analytics_workspace" {
   law_sku        = var.law.law_sku
   retention_days = var.law.retention_days
 
-  audit_resource_group_name = module.baseline.resource_group_names[var.law.audit_resource_group_key]
+  audit_resource_group_name = module.baseline.resource_group_names_audit[var.law.audit_resource_group_key]
 
   tags = var.tags
 

--- a/infrastructure/modules/app-insights/output.tf
+++ b/infrastructure/modules/app-insights/output.tf
@@ -5,3 +5,14 @@ output "ai_instrumentation_key" {
 output "ai_connection_string" {
   value = azurerm_application_insights.appins.connection_string
 }
+
+
+### audit sub
+
+output "ai_instrumentation_key_audit" {
+  value = azurerm_application_insights.appins_audit.instrumentation_key
+}
+
+output "ai_connection_string_audit" {
+  value = azurerm_application_insights.appins_audit.connection_string
+}

--- a/infrastructure/modules/app-insights/output.tf
+++ b/infrastructure/modules/app-insights/output.tf
@@ -1,17 +1,9 @@
-output "ai_instrumentation_key" {
-  value = azurerm_application_insights.appins.instrumentation_key
-}
 
 output "ai_connection_string" {
   value = azurerm_application_insights.appins.connection_string
 }
 
-
 ### audit sub
-
-output "ai_instrumentation_key_audit" {
-  value = azurerm_application_insights.appins_audit.instrumentation_key
-}
 
 output "ai_connection_string_audit" {
   value = azurerm_application_insights.appins_audit.connection_string

--- a/infrastructure/modules/baseline/base-rg.tf
+++ b/infrastructure/modules/baseline/base-rg.tf
@@ -2,8 +2,23 @@
 resource "azurerm_resource_group" "rg" {
   for_each = var.resource_groups
 
+  provider = azurerm
+
   name     = each.value.name
   location = var.location
+
+  lifecycle {
+    ignore_changes = [tags]
+  }
+}
+
+resource "azurerm_resource_group" "rg-audit" {
+  for_each = var.resource_groups_audit
+
+  provider = azurerm.audit
+
+  name     = each.value.name
+  location = each.value.location
 
   lifecycle {
     ignore_changes = [tags]

--- a/infrastructure/modules/baseline/outputs.tf
+++ b/infrastructure/modules/baseline/outputs.tf
@@ -17,3 +17,23 @@ output "resource_group_locations" {
   value       = { for k, rg in azurerm_resource_group.rg : k => rg.location }
 }
 
+### audit subscription
+
+output "resource_groupsrg_audit" {
+  value = length(var.resource_groups) > 0 ? azurerm_resource_group.rg : {}
+}
+
+output "resource_group_names_audit" {
+  description = "The names of the created resource groups"
+  value       = { for k, rg in azurerm_resource_group.rg-audit : k => rg.name }
+}
+
+output "resource_group_ids_audit" {
+  description = "The IDs of the created resource groups"
+  value       = { for k, rg in azurerm_resource_group.rg-audit : k => rg.id }
+}
+
+output "resource_group_locations_audit" {
+  description = "The locations of the created resource groups"
+  value       = { for k, rg in azurerm_resource_group.rg-audit : k => rg.location }
+}

--- a/infrastructure/modules/baseline/variables.tf
+++ b/infrastructure/modules/baseline/variables.tf
@@ -8,3 +8,6 @@ variable "tags" {
 
 variable "resource_groups" {
 }
+
+variable "resource_groups_audit" {
+}

--- a/infrastructure/modules/log-analytics-workspace/output.tf
+++ b/infrastructure/modules/log-analytics-workspace/output.tf
@@ -6,6 +6,7 @@ output "name" {
   value = azurerm_log_analytics_workspace.law.name
 }
 
+### audit sub
 output "audit_id" {
   value = azurerm_log_analytics_workspace.law_audit.id
 }

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -33,7 +33,16 @@ variable "tags" {
 variable "resource_groups" {
   description = "Map of resource groups"
   type = map(object({
-    name = optional(string, "rg-cohort-manager-dev-suk")
+    name     = optional(string, "rg-cohort-manager-dev-suk")
+    location = optional(string, "uksouth")
+  }))
+}
+
+variable "resource_groups_audit" {
+  description = "Map of resource groups in Audit subscription"
+  type = map(object({
+    name     = optional(string, "rg-audit-cohort-manager-dev-uks")
+    location = optional(string, "uksouth")
   }))
 }
 


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

This PR is a part of DTOSS-3653 and includes a fix to create a new Resource Group in the Dev Audit subscription.

## Context

Along with implementing it, I will recreate AppInsights and LAW in the new subscription.
Switching Function Apps to new AI/LAW will have it's own PR. 

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [X] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [X] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
