### PR TITLE
feat: DTOSS-4049 participant lookup by NHS Number and Screening Id

### DIFF
--- a/application/CohortManager/src/Functions/CohortDistributionServices/CreateCohortDistribution/CreateCohortDistribution.cs
+++ b/application/CohortManager/src/Functions/CohortDistributionServices/CreateCohortDistribution/CreateCohortDistribution.cs
@@ -74,7 +74,7 @@ public class CreateCohortDistribution
             response = await HandleErrorResponseIfNull(serviceProvider, req);
             if (response != null) return response;
 
-            if (ParticipantHasException(requestBody.NhsNumber))
+            if (ParticipantHasException(requestBody.NhsNumber,participantData.ScreeningId))
             {
                 _logger.LogInformation($"Unable to add to cohort distribution. As participant with ParticipantId: {participantData.ParticipantId}. Has an Exception against it");
                 // we return OK here as there has not been an error
@@ -127,9 +127,9 @@ public class CreateCohortDistribution
         return response;
     }
 
-    private bool ParticipantHasException(string nhsNumber)
+    private bool ParticipantHasException(string nhsNumber, string screeningId)
     {
-        var participant = _participantManagerData.GetParticipant(nhsNumber);
+        var participant = _participantManagerData.GetParticipant(nhsNumber,screeningId);
         var exceptionFlag = Enum.TryParse(participant.ExceptionFlag, out Exists value) ? value : Exists.No;
         return exceptionFlag == Exists.Yes;
     }

--- a/application/CohortManager/src/Functions/ParticipantManagementServices/addParticipant/addParticipant.cs
+++ b/application/CohortManager/src/Functions/ParticipantManagementServices/addParticipant/addParticipant.cs
@@ -105,7 +105,7 @@ public class AddParticipantFunction
         }
         catch (Exception ex)
         {
-            _logger.LogInformation($"Unable to call function.\nMessage: {ex.Message}\nStack Trace: {ex.StackTrace}");
+            _logger.LogInformation(ex,$"Unable to call function.\nMessage: {ex.Message}\nStack Trace: {ex.StackTrace}");
             await _handleException.CreateSystemExceptionLog(ex, basicParticipantCsvRecord.Participant, basicParticipantCsvRecord.FileName);
             return _createResponse.CreateHttpResponse(HttpStatusCode.InternalServerError, req);
         }

--- a/application/CohortManager/src/Functions/Shared/Data/Database/IParticipantManagerData.cs
+++ b/application/CohortManager/src/Functions/Shared/Data/Database/IParticipantManagerData.cs
@@ -7,6 +7,6 @@ public interface IParticipantManagerData
 {
     bool UpdateParticipantAsEligible(Participant participant, char isActive);
     bool UpdateParticipantDetails(ParticipantCsvRecord participantCsvRecord);
-    Participant GetParticipant(string NhsNumber);
+    Participant GetParticipant(string nhsNumber, string screeningId);
     Participant GetParticipantFromIDAndScreeningService(RetrieveParticipantRequestBody retrieveParticipantRequestBody);
 }

--- a/application/CohortManager/src/Functions/Shared/Data/Database/ParticipantManagerData.cs
+++ b/application/CohortManager/src/Functions/Shared/Data/Database/ParticipantManagerData.cs
@@ -28,7 +28,7 @@ public class ParticipantManagerData : IParticipantManagerData
     {
         try
         {
-            var Participant = GetParticipant(participant.NhsNumber);
+            var Participant = GetParticipant(participant.NhsNumber, participant.ScreeningId);
 
             var recordUpdateTime = DateTime.Now;
 
@@ -91,7 +91,7 @@ public class ParticipantManagerData : IParticipantManagerData
     #endregion
 
     #region  get methods
-    public Participant GetParticipant(string NhsNumber)
+    public Participant GetParticipant(string nhsNumber, string screeningId)
     {
         var SQL = "SELECT " +
             "[PARTICIPANT_MANAGEMENT].[PARTICIPANT_ID], " +
@@ -104,11 +104,13 @@ public class ParticipantManagerData : IParticipantManagerData
             "[PARTICIPANT_MANAGEMENT].[RECORD_INSERT_DATETIME], " +
             "[PARTICIPANT_MANAGEMENT].[RECORD_UPDATE_DATETIME] " +
         "FROM [dbo].[PARTICIPANT_MANAGEMENT] " +
-        "WHERE [PARTICIPANT_MANAGEMENT].[NHS_NUMBER] = @NhsNumber";
+        "WHERE [PARTICIPANT_MANAGEMENT].[NHS_NUMBER] = @NhsNumber " +
+        "AND [PARTICIPANT_MANAGEMENT].[SCREENING_ID] = @ScreeningId";
 
         var parameters = new Dictionary<string, object>
         {
-            {"@NhsNumber", NhsNumber }
+            {"@NhsNumber", nhsNumber },
+            {"@ScreeningId", screeningId}
         };
 
         var command = CreateCommand(parameters);

--- a/application/CohortManager/src/Functions/screeningDataServices/createParticipant/createParticipant.cs
+++ b/application/CohortManager/src/Functions/screeningDataServices/createParticipant/createParticipant.cs
@@ -42,7 +42,7 @@ public class CreateParticipant
                 participantCsvRecord = JsonSerializer.Deserialize<ParticipantCsvRecord>(requestBody);
             }
 
-            var existingParticipantData = _participantManagerData.GetParticipant(participantCsvRecord.Participant.NhsNumber);
+            var existingParticipantData = _participantManagerData.GetParticipant(participantCsvRecord.Participant.NhsNumber, participantCsvRecord.Participant.ScreeningId);
             var response = await ValidateData(existingParticipantData, participantCsvRecord.Participant, participantCsvRecord.FileName);
             if (response.IsFatal)
             {
@@ -66,7 +66,7 @@ public class CreateParticipant
         }
         catch (Exception ex)
         {
-            _logger.LogError("Failed to make the CreateParticipant request\nMessage: {Message}", ex.Message);
+            _logger.LogError(ex,"Failed to make the CreateParticipant request\nMessage: {Message}", ex.Message);
             await _handleException.CreateSystemExceptionLog(ex, participantCsvRecord.Participant, participantCsvRecord.FileName);
             return _createResponse.CreateHttpResponse(HttpStatusCode.InternalServerError, req);
         }
@@ -86,7 +86,7 @@ public class CreateParticipant
         }
         catch (Exception ex)
         {
-            _logger.LogInformation($"Lookup validation failed.\nMessage: {ex.Message}\nParticipant: {newParticipant}");
+            _logger.LogInformation(ex,$"Lookup validation failed.\nMessage: {ex.Message}\nParticipant: {newParticipant}");
             return null;
         }
     }

--- a/application/CohortManager/src/Functions/screeningDataServices/markParticipantAsIneligible/markParticipantAsIneligible.cs
+++ b/application/CohortManager/src/Functions/screeningDataServices/markParticipantAsIneligible/markParticipantAsIneligible.cs
@@ -1,5 +1,6 @@
 namespace NHS.CohortManager.ScreeningDataServices;
 
+using System.Collections.Concurrent;
 using System.Net;
 using System.Text;
 using System.Text.Json;
@@ -50,7 +51,7 @@ public class MarkParticipantAsIneligible
         var participantData = requestBody.Participant;
 
         // Check if a participant with the supplied NHS Number already exists
-        var existingParticipantData = _participantManagerData.GetParticipant(participantData.NhsNumber);
+        var existingParticipantData = _participantManagerData.GetParticipant(participantData.NhsNumber, participantData.ScreeningId);
         var response = await ValidateData(existingParticipantData, participantData, requestBody.FileName);
         if (response.IsFatal)
         {
@@ -79,7 +80,7 @@ public class MarkParticipantAsIneligible
         }
         catch (Exception ex)
         {
-            _logger.LogError($"an error occurred: {ex}");
+            _logger.LogError(ex,$"an error occurred: {ex}");
             await _handleException.CreateSystemExceptionLog(ex, participantData, requestBody.FileName);
             return _createResponse.CreateHttpResponse(HttpStatusCode.BadRequest, req);
         }
@@ -99,7 +100,7 @@ public class MarkParticipantAsIneligible
         }
         catch (Exception ex)
         {
-            _logger.LogError($"Lookup validation failed.\nMessage: {ex.Message}\nParticipant: {newParticipant}");
+            _logger.LogError(ex,$"Lookup validation failed.\nMessage: {ex.Message}\nParticipant: {newParticipant}");
             return null;
         }
     }

--- a/application/CohortManager/src/Functions/screeningDataServices/updateParticipantDetails/updateParticipantDetails.cs
+++ b/application/CohortManager/src/Functions/screeningDataServices/updateParticipantDetails/updateParticipantDetails.cs
@@ -42,7 +42,7 @@ public class UpdateParticipantDetails
                 participantCsvRecord = JsonSerializer.Deserialize<ParticipantCsvRecord>(requestBody);
             }
 
-            var existingParticipantData = _participantManagerData.GetParticipant(participantCsvRecord.Participant.NhsNumber);
+            var existingParticipantData = _participantManagerData.GetParticipant(participantCsvRecord.Participant.NhsNumber, participantCsvRecord.Participant.ScreeningId);
             var response = await ValidateData(existingParticipantData, participantCsvRecord.Participant, participantCsvRecord.FileName);
             if (response.IsFatal)
             {
@@ -66,7 +66,7 @@ public class UpdateParticipantDetails
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex.Message, ex);
+            _logger.LogError(ex,ex.Message, ex);
             await _handleException.CreateSystemExceptionLog(ex, participantCsvRecord.Participant, participantCsvRecord.FileName);
             return _createResponse.CreateHttpResponse(HttpStatusCode.InternalServerError, req);
         }
@@ -85,7 +85,7 @@ public class UpdateParticipantDetails
         }
         catch (Exception ex)
         {
-            _logger.LogInformation($"Lookup validation failed.\nMessage: {ex.Message}\nParticipant: {newParticipant}");
+            _logger.LogInformation(ex,$"Lookup validation failed.\nMessage: {ex.Message}\nParticipant: {newParticipant}");
             return null;
         }
     }

--- a/tests/CohortDistributionTests/CreateCohortDistributionTests/CreateCohortDistributionTests.cs
+++ b/tests/CohortDistributionTests/CreateCohortDistributionTests/CreateCohortDistributionTests.cs
@@ -217,6 +217,6 @@ public class CreateCohortDistributionTests
     private void ParticipantException(bool hasException)
     {
         var participant = new Participant() { ExceptionFlag = hasException ? Exists.Yes.ToString() : Exists.No.ToString() };
-        _participantManagerData.Setup(x => x.GetParticipant(It.IsAny<string>())).Returns(participant);
+        _participantManagerData.Setup(x => x.GetParticipant(It.IsAny<string>(),It.IsAny<string>())).Returns(participant);
     }
 }

--- a/tests/ParticipantManagementServicesTests/addParticipantTest/AddParticipantTestClass.cs
+++ b/tests/ParticipantManagementServicesTests/addParticipantTest/AddParticipantTestClass.cs
@@ -249,7 +249,7 @@ public class AddNewParticipantTestClass
             LogLevel.Information,
             0,
             It.Is<It.IsAnyType>((state, type) => state.ToString().Contains("Unable to call function")),
-            null,
+            It.IsAny<Exception>(),
             (Func<object, Exception, string>)It.IsAny<object>()
             ));
     }
@@ -277,7 +277,7 @@ public class AddNewParticipantTestClass
             LogLevel.Information,
             0,
             It.Is<It.IsAnyType>((state, type) => state.ToString().Contains("Unable to call function")),
-            null,
+            It.IsAny<Exception>(),
             (Func<object, Exception, string>)It.IsAny<object>()
             ));
     }

--- a/tests/screeningDataServicesTests/MarkParticipantAsIneligibleTests/MarkParticipantAsIneligibleTests.cs
+++ b/tests/screeningDataServicesTests/MarkParticipantAsIneligibleTests/MarkParticipantAsIneligibleTests.cs
@@ -44,7 +44,7 @@ public class MarkParticipantAsIneligibleTests
 
         _function = new MarkParticipantAsIneligible(_mockLogger.Object, _createResponse.Object, _mockUpdateParticipantData.Object, _callFunction.Object, _handleException.Object);
 
-        _mockUpdateParticipantData.Setup(x => x.GetParticipant(It.IsAny<string>())).Returns(new Participant());
+        _mockUpdateParticipantData.Setup(x => x.GetParticipant(It.IsAny<string>(),It.IsAny<string>())).Returns(new Participant());
 
         _request.Setup(r => r.CreateResponse()).Returns(() =>
             {

--- a/tests/screeningDataServicesTests/updateParticipantDetailsTests/updateParticipantDetails.cs
+++ b/tests/screeningDataServicesTests/updateParticipantDetailsTests/updateParticipantDetails.cs
@@ -152,6 +152,7 @@ public class UpdateParticipantDetailsTests
     {
         // Arrange
         var nhsId = "123456";
+        var screeningId = "1";
         var expectedParticipantId = 123456;
         _moqDataReader.SetupSequence(reader => reader.Read())
         .Returns(true)
@@ -164,7 +165,7 @@ public class UpdateParticipantDetailsTests
         var sut = new ParticipantManagerData(_mockDBConnection.Object, _databaseHelperMock.Object, _loggerMock.Object);
 
         // Act
-        var result = sut.GetParticipant(nhsId);
+        var result = sut.GetParticipant(nhsId,screeningId);
 
         // Assert
         Assert.AreEqual(nhsId, result.NhsNumber);
@@ -175,6 +176,7 @@ public class UpdateParticipantDetailsTests
     {
         // Arrange
         var nhsId = "123456";
+        var screeningId = "1";
 
         _moqDataReader.SetupSequence(reader => reader.Read())
             .Returns(true)
@@ -187,7 +189,7 @@ public class UpdateParticipantDetailsTests
         var sut = new ParticipantManagerData(_mockDBConnection.Object, _databaseHelperMock.Object, _loggerMock.Object);
 
         // Act
-        var result = sut.GetParticipant(nhsId);
+        var result = sut.GetParticipant(nhsId,screeningId);
 
         // Assert
         Assert.AreEqual("123456", result.NhsNumber);
@@ -256,7 +258,9 @@ public class UpdateParticipantDetailsTests
             EmailAddress = "john.doe@example.com",
             PreferredLanguage = "English",
             IsInterpreterRequired = "0",
-            RecordType = Actions.Amended
+            RecordType = Actions.Amended,
+            ScreeningId = "1"
+
         };
     }
 }


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Changed the lookup function for pulling participants from the participant management table to use both the NHS Number and the ScreeningId

## Context

<!-- Why is this change required? What problem does it solve? -->

[DTOSS-4049](https://nhsd-jira.digital.nhs.uk/browse/DTOSS-4049)

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [X] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
