### PR TITLE
feat: new way of deploying storage accounts and containers

### DIFF
--- a/infrastructure/environments/development.tfvars.config
+++ b/infrastructure/environments/development.tfvars.config
@@ -32,25 +32,46 @@ resource_groups_audit = {
 }
 storage_accounts = {
 
-  fnapp = {
-    name_suffix                   = "fnappstor"
-    resource_group_key            = "cohman"
-    account_tier                  = "Standard"
-    replication_type              = "LRS"
-    public_network_access_enabled = true
+  resource_group_key = "cohman"
+  sa_config = {
+    fnapp = {
+      name_suffix                   = "fnappstor"
+      account_tier                  = "Standard"
+      replication_type              = "LRS"
+      public_network_access_enabled = true
+    }
+
+    file_exceptions = {
+      name_suffix                   = "filexptns"
+      account_tier                  = "Standard"
+      replication_type              = "LRS"
+      public_network_access_enabled = true
+    }
   }
 
-  file_exceptions = {
-    name_suffix                   = "filexptns"
-    resource_group_key            = "cohman"
-    account_tier                  = "Standard"
-    replication_type              = "LRS"
-    public_network_access_enabled = true
+  cont_config = {
+    file-exceptions = {
+      sa_key           = "file_exceptions"
+      cont_name        = "file-exceptions"
+      cont_access_type = "private"
+    }
+    config = {
+      sa_key           = "file_exceptions"
+      cont_name        = "config"
+      cont_access_type = "private"
+    }
+    inbound = {
+      sa_key           = "file_exceptions"
+      cont_name        = "inbound"
+      cont_access_type = "private"
+    }
 
-    cont_name        = "file-exceptions"
-    cont_access_type = "private"
+    inbound-posion = {
+      sa_key           = "file_exceptions"
+      cont_name        = "inbound-posion"
+      cont_access_type = "private"
+    }
   }
-
 }
 
 key_vault = {

--- a/infrastructure/environments/nft.tfvars.config
+++ b/infrastructure/environments/nft.tfvars.config
@@ -32,25 +32,22 @@ resource_groups_audit = {
 }
 storage_accounts = {
 
-  fnapp = {
-    name_suffix                   = "fnappstor"
-    resource_group_key            = "cohman"
-    account_tier                  = "Standard"
-    replication_type              = "LRS"
-    public_network_access_enabled = true
+  resource_group_key = "cohman"
+  sa_config = {
+    fnapp = {
+      name_suffix                   = "fnappstor"
+      account_tier                  = "Standard"
+      replication_type              = "LRS"
+      public_network_access_enabled = true
+    }
+
+    file_exceptions = {
+      name_suffix                   = "filexptns"
+      account_tier                  = "Standard"
+      replication_type              = "LRS"
+      public_network_access_enabled = true
+    }
   }
-
-  file_exceptions = {
-    name_suffix                   = "filexptns"
-    resource_group_key            = "cohman"
-    account_tier                  = "Standard"
-    replication_type              = "LRS"
-    public_network_access_enabled = true
-
-    cont_name        = "file-exceptions"
-    cont_access_type = "private"
-  }
-
 }
 
 key_vault = {

--- a/infrastructure/environments/nft.tfvars.config
+++ b/infrastructure/environments/nft.tfvars.config
@@ -48,6 +48,30 @@ storage_accounts = {
       public_network_access_enabled = true
     }
   }
+
+  cont_config = {
+    file-exceptions = {
+      sa_key           = "file_exceptions"
+      cont_name        = "file-exceptions"
+      cont_access_type = "private"
+    }
+    config = {
+      sa_key           = "file_exceptions"
+      cont_name        = "config"
+      cont_access_type = "private"
+    }
+    inbound = {
+      sa_key           = "file_exceptions"
+      cont_name        = "inbound"
+      cont_access_type = "private"
+    }
+
+    inbound-posion = {
+      sa_key           = "file_exceptions"
+      cont_name        = "inbound-posion"
+      cont_access_type = "private"
+    }
+  }
 }
 
 key_vault = {

--- a/infrastructure/fnapp.tf
+++ b/infrastructure/fnapp.tf
@@ -13,8 +13,8 @@ module "functionapp" {
   location            = module.baseline.resource_group_locations[var.function_app.resource_group_key]
 
   asp_id     = module.app-plan.app_service_plan_id
-  sa_name    = module.storage.storage_account_name
-  sa_prm_key = module.storage.storage_account_primary_access_key
+  sa_name    = module.storage.storage_account_names["fnapp"]
+  sa_prm_key = module.storage.storage_account_primary_access_keys["fnapp"]
 
   ai_connstring        = module.app_insights.ai_connection_string_audit
   gl_worker_32bit      = var.function_app.gl_worker_32bit
@@ -30,7 +30,7 @@ module "functionapp" {
   enable_appsrv_storage = var.function_app.gl_enable_appsrv_storage
 
   #Specific FNApp settings:
-  caasfolder_STORAGE = module.storage.sa_fe_primary_connection_string
+  caasfolder_STORAGE = module.storage.storage_account_primary_connection_strings["file_exceptions"]
   db_name            = var.sqlserver.dbs.cohman.db_name_suffix
 
   tags = var.tags

--- a/infrastructure/modules/storage/main.tf
+++ b/infrastructure/modules/storage/main.tf
@@ -1,11 +1,12 @@
 resource "azurerm_storage_account" "sa" {
+  for_each = var.storage_accounts
 
-  name                          = var.name
+  name                          = substr("${var.names.storage-account}${lower(each.value.name_suffix)}", 0, 24)
   resource_group_name           = var.resource_group_name
   location                      = var.location
-  account_tier                  = var.account_tier
-  account_replication_type      = var.sa_replication_type
-  public_network_access_enabled = var.public_access
+  account_tier                  = each.value.account_tier
+  account_replication_type      = each.value.replication_type
+  public_network_access_enabled = each.value.public_network_access_enabled
 
   tags = var.tags
 
@@ -14,24 +15,11 @@ resource "azurerm_storage_account" "sa" {
   }
 }
 
-resource "azurerm_storage_account" "fileexception" {
 
-  name                          = var.fe_name
-  resource_group_name           = var.fe_resource_group_name
-  location                      = var.fe_location
-  account_tier                  = var.fe_account_tier
-  account_replication_type      = var.fe_sa_replication_type
-  public_network_access_enabled = var.fe_public_access
+resource "azurerm_storage_container" "container" {
+  for_each = var.containers
 
-  tags = var.tags
-
-  lifecycle {
-    ignore_changes = [tags]
-  }
-}
-
-resource "azurerm_storage_container" "example" {
-  name                  = var.fe_cont_name # "vhds"
-  storage_account_name  = azurerm_storage_account.fileexception.name
-  container_access_type = var.fe_cont_access_type # "private"
+  name                  = each.value.cont_name
+  storage_account_name  = azurerm_storage_account.sa[each.value.sa_key].name
+  container_access_type = each.value.cont_access_type
 }

--- a/infrastructure/modules/storage/output.tf
+++ b/infrastructure/modules/storage/output.tf
@@ -1,14 +1,15 @@
 
-output "storage_account_name" {
-  value = azurerm_storage_account.sa.name
+output "storage_account_names" {
+  description = "The names of the created Storage Accounts"
+  value       = { for k, sa in azurerm_storage_account.sa : k => sa.name }
 }
 
-output "storage_account_primary_access_key" {
+output "storage_account_primary_connection_strings" {
   sensitive = true
-  value     = azurerm_storage_account.sa.primary_access_key
+  value     = { for k, sa in azurerm_storage_account.sa : k => sa.primary_connection_string }
 }
 
-output "sa_fe_primary_connection_string" {
+output "storage_account_primary_access_keys" {
   sensitive = true
-  value     = azurerm_storage_account.fileexception.primary_connection_string
+  value     = { for k, sa in azurerm_storage_account.sa : k => sa.primary_access_key }
 }

--- a/infrastructure/modules/storage/variables.tf
+++ b/infrastructure/modules/storage/variables.tf
@@ -9,71 +9,21 @@ variable "location" {
   description = "The location/region where the Storage Account is created."
 }
 
-variable "name" {
-  type        = string
-  description = "The name of the Storage Account."
+variable "storage_accounts" {
+  description = "Definition of Storage Accounts configuration"
 }
 
-variable "account_tier" {
-  description = "Defines the Tier to use for this storage account."
-  default     = {}
+variable "containers" {
+  description = "Definition of Containers configuration"
 }
 
-variable "sa_replication_type" {
-  description = "Defines the type of replication to use for this storage account."
-  default     = {}
+variable "names" {
+  type        = map(string)
+  description = "The basic part of the Storage Account name."
 }
-
-variable "public_access" {
-  description = "Whether the public network access is enabled."
-  default     = {}
-}
-
 
 variable "tags" {
   type        = map(string)
   description = "Resource tags to be applied throughout the deployment."
   default     = {}
 }
-
-### File Exceptions
-variable "fe_name" {
-  type        = string
-  description = "The name of the Storage Account."
-}
-
-variable "fe_resource_group_name" {
-  type        = string
-  description = "The name of the resource group in which to create the Storage Account. Changing this forces a new resource to be created."
-}
-
-variable "fe_location" {
-  type        = string
-  description = "The location/region where the Storage Account is created."
-}
-
-variable "fe_account_tier" {
-  description = "Defines the Tier to use for this storage account."
-  default     = {}
-}
-
-variable "fe_sa_replication_type" {
-  description = "Defines the type of replication to use for this storage account."
-  default     = {}
-}
-
-variable "fe_public_access" {
-  description = "Whether the public network access is enabled."
-  default     = {}
-}
-
-variable "fe_cont_name" {
-  type        = string
-  description = "The name of the Container which should be created within the Storage Account. Changing this forces a new resource to be created."
-}
-
-variable "fe_cont_access_type" {
-  type        = string
-  description = "The Access Level configured for this Container. Possible values are blob, container or private. Defaults to private."
-}
-

--- a/infrastructure/storage.tf
+++ b/infrastructure/storage.tf
@@ -1,27 +1,14 @@
 module "storage" {
   source = ".//modules/storage"
 
-  name                = substr("${module.config.names.storage-account}${lower(var.storage_accounts.fnapp.name_suffix)}", 0, 24)
-  resource_group_name = module.baseline.resource_group_names[var.storage_accounts.fnapp.resource_group_key]
-  location            = module.baseline.resource_group_locations[var.storage_accounts.fnapp.resource_group_key]
+  names = module.config.names
 
-  account_tier        = var.storage_accounts.fnapp.account_tier
-  sa_replication_type = var.storage_accounts.fnapp.replication_type
-  public_access       = var.storage_accounts.fnapp.public_network_access_enabled
+  resource_group_name = module.baseline.resource_group_names[var.storage_accounts.resource_group_key]
+  location            = module.baseline.resource_group_locations[var.storage_accounts.resource_group_key]
+
+  storage_accounts = var.storage_accounts.sa_config
+  containers       = var.storage_accounts.cont_config
 
   tags = var.tags
-
-  ## File exception
-
-  fe_name                = substr("${module.config.names.storage-account}${lower(var.storage_accounts.file_exceptions.name_suffix)}", 0, 24)
-  fe_resource_group_name = module.baseline.resource_group_names[var.storage_accounts.file_exceptions.resource_group_key]
-  fe_location            = module.baseline.resource_group_locations[var.storage_accounts.file_exceptions.resource_group_key]
-
-  fe_account_tier        = var.storage_accounts.file_exceptions.account_tier
-  fe_sa_replication_type = var.storage_accounts.file_exceptions.replication_type
-  fe_public_access       = var.storage_accounts.file_exceptions.public_network_access_enabled
-
-  fe_cont_name        = var.storage_accounts.file_exceptions.cont_name
-  fe_cont_access_type = var.storage_accounts.file_exceptions.cont_access_type
 
 }

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -54,22 +54,18 @@ variable "resource_groups_audit" {
 variable "storage_accounts" {
   description = "Configuration for the Storage Account, currently used for Function Apps"
   type = object({
-    fnapp = object({
+    resource_group_key = optional(string, "cohman")
+    sa_config = map(object({
       name_suffix                   = optional(string, "fnappstor")
-      resource_group_key            = optional(string, "cohman")
       account_tier                  = optional(string, "Standard")
       replication_type              = optional(string, "LRS")
       public_network_access_enabled = optional(bool, true)
-    })
-    file_exceptions = object({
-      name_suffix                   = optional(string, "filexptns")
-      resource_group_key            = optional(string, "cohman")
-      account_tier                  = optional(string, "Standard")
-      replication_type              = optional(string, "LRS")
-      public_network_access_enabled = optional(bool, true)
-      cont_name                     = optional(string, "file-exceptions")
-      cont_access_type              = optional(string, "private")
-    })
+    }))
+    cont_config = map(object({
+      sa_key           = optional(string, "file_exceptions")
+      cont_name        = optional(string, "config")
+      cont_access_type = optional(string, "private")
+    }))
   })
 }
 


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

This PR includes a new way of deploying storage accounts and containers, using for_each and a refactored storage_accounts map in TFVARS files.

## Context

The goal of this change is to be able to deploy new storage accounts in the most flexible way.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [X] Refactoring (non-breaking change)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [X] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [X] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
