### PR TITLE
fix: demographics rule

### DIFF
--- a/application/CohortManager/rules/Breast_Screening_cohortRules.json
+++ b/application/CohortManager/rules/Breast_Screening_cohortRules.json
@@ -33,8 +33,8 @@
               "Expression": "newParticipant.RecordType == Actions.New OR !new string[] { \"HMP\", \"MHI\" }.Contains(newParticipant.CurrentPosting) OR newParticipant.CurrentPosting == existingParticipant.CurrentPosting"
             },
             {
-              "RuleName": "35.Demographics.NonFatal",
-              "Expression": "newParticipant.RecordType != Actions.Amended OR (newParticipant.FamilyName == existingParticipant.FamilyName AND newParticipant.Gender == existingParticipant.Gender) OR (newParticipant.FamilyName == existingParticipant.FamilyName AND newParticipant.DateOfBirth == existingParticipant.DateOfBirth) OR (newParticipant.Gender == existingParticipant.Gender AND newParticipant.DateOfBirth == existingParticipant.DateOfBirth)"
+              "RuleName": "35.TooManyDemographicsFieldsChanged.NonFatal",
+              "Expression": "existingParticipant.ParticipantId == null || ((newParticipant.FamilyName == existingParticipant.FamilyName AND newParticipant.Gender == existingParticipant.Gender) OR (newParticipant.FamilyName == existingParticipant.FamilyName AND newParticipant.DateOfBirth == existingParticipant.DateOfBirth) OR (newParticipant.Gender== existingParticipant.Gender AND newParticipant.DateOfBirth == existingParticipant.DateOfBirth))"
             }
         ]
     }

--- a/application/CohortManager/src/Functions/ScreeningValidationService/LookupValidation/LookupValidation.cs
+++ b/application/CohortManager/src/Functions/ScreeningValidationService/LookupValidation/LookupValidation.cs
@@ -55,6 +55,9 @@ public class LookupValidation
         {
             var existingParticipant = requestBody.ExistingParticipant;
             newParticipant = requestBody.NewParticipant;
+            System.Console.WriteLine("record type: " + newParticipant.RecordType);
+            System.Console.WriteLine(existingParticipant.ParticipantId == null);
+            System.Console.WriteLine("Existing participant ID: " + existingParticipant.ParticipantId);
 
             var ruleFileName = $"{newParticipant.ScreeningName}_{GetValidationRulesName(requestBody.RulesType)}".Replace(" ", "_");
             _logger.LogInformation("ruleFileName {ruleFileName}", ruleFileName);

--- a/application/CohortManager/src/Functions/ScreeningValidationService/LookupValidation/LookupValidation.cs
+++ b/application/CohortManager/src/Functions/ScreeningValidationService/LookupValidation/LookupValidation.cs
@@ -55,9 +55,6 @@ public class LookupValidation
         {
             var existingParticipant = requestBody.ExistingParticipant;
             newParticipant = requestBody.NewParticipant;
-            System.Console.WriteLine("record type: " + newParticipant.RecordType);
-            System.Console.WriteLine(existingParticipant.ParticipantId == null);
-            System.Console.WriteLine("Existing participant ID: " + existingParticipant.ParticipantId);
 
             var ruleFileName = $"{newParticipant.ScreeningName}_{GetValidationRulesName(requestBody.RulesType)}".Replace(" ", "_");
             _logger.LogInformation("ruleFileName {ruleFileName}", ruleFileName);

--- a/tests/ScreeningValidationServiceTests/LookupValidation/LookupValidationTests.cs
+++ b/tests/ScreeningValidationServiceTests/LookupValidation/LookupValidationTests.cs
@@ -262,7 +262,7 @@ public class LookupValidationTests
         // Assert
         Assert.AreEqual(HttpStatusCode.Created, result.StatusCode);
         _exceptionHandler.Verify(handleException => handleException.CreateValidationExceptionLog(
-            It.Is<IEnumerable<RuleResultTree>>(r => r.Any(x => x.Rule.RuleName == "35.Demographics.NonFatal")),
+            It.Is<IEnumerable<RuleResultTree>>(r => r.Any(x => x.Rule.RuleName == "35.TooManyDemographicsFieldsChanged.NonFatal")),
             It.IsAny<ParticipantCsvRecord>()),
             Times.Once());
     }
@@ -295,7 +295,7 @@ public class LookupValidationTests
 
         // Assert
         _exceptionHandler.Verify(handleException => handleException.CreateValidationExceptionLog(
-            It.Is<IEnumerable<RuleResultTree>>(r => r.Any(x => x.Rule.RuleName == "35.Demographics")),
+            It.Is<IEnumerable<RuleResultTree>>(r => r.Any(x => x.Rule.RuleName == "35.TooManyDemographicsFieldsChanged")),
             It.IsAny<ParticipantCsvRecord>()),
             Times.Never());
     }

--- a/tests/ScreeningValidationServiceTests/LookupValidation/LookupValidationTests.cs
+++ b/tests/ScreeningValidationServiceTests/LookupValidation/LookupValidationTests.cs
@@ -240,7 +240,7 @@ public class LookupValidationTests
     [DataRow("Smith", Gender.Female, "19700101", "Jones", Gender.Female, "19700102")]   // New Family Name & Date of Birth
     [DataRow("Smith", Gender.Female, "19700101", "Smith", Gender.Male, "19700102")]     // New Gender & Date of Birth
     [DataRow("Smith", Gender.Female, "19700101", "Jones", Gender.Male, "19700102")]     // New Family Name, Gender & Date of Birth
-    public async Task Run_Should_Return_Created_And_Create_Exception_When_Demographics_Rule_Fails(
+    public async Task Run_MultipleDemographicsFieldsChanged_DemographicsRuleFails(
     string existingFamilyName, Gender existingGender, string existingDateOfBirth, string newFamilyName,
     Gender newGender, string newDateOfBirth)
     {
@@ -248,6 +248,7 @@ public class LookupValidationTests
         SetupRules("CohortRules");
         _requestBody.NewParticipant.RecordType = Actions.Amended;
         _requestBody.ExistingParticipant.FamilyName = existingFamilyName;
+        _requestBody.ExistingParticipant.ParticipantId = "1234567";
         _requestBody.ExistingParticipant.Gender = existingGender;
         _requestBody.ExistingParticipant.DateOfBirth = existingDateOfBirth;
         _requestBody.NewParticipant.FamilyName = newFamilyName;
@@ -274,7 +275,7 @@ public class LookupValidationTests
     [DataRow(Actions.Amended, "Smith", Gender.Female, "19700101", "Smith", Gender.Female, "19700102")]  // New Date of Birth Only
     [DataRow(Actions.Amended, "Smith", Gender.Female, "19700101", "Smith", Gender.Female, "19700101")]  // No Change
     [DataRow(Actions.New, "", new Gender(), "", "Smith", Gender.Female, "19700101")]                    // New Record Type
-    public async Task Run_Should_Not_Create_Exception_When_Demographics_Rule_Passes(string recordType,
+    public async Task Run_OneFieldChanged_DemographicsRulePasses(string recordType,
         string existingFamilyName, Gender existingGender, string existingDateOfBirth, string newFamilyName,
         Gender newGender, string newDateOfBirth)
     {
@@ -282,6 +283,7 @@ public class LookupValidationTests
         SetupRules("CohortRules");
         _requestBody.NewParticipant.RecordType = recordType;
         _requestBody.ExistingParticipant.FamilyName = existingFamilyName;
+        _requestBody.ExistingParticipant.ParticipantId = "1234567";
         _requestBody.ExistingParticipant.Gender = existingGender;
         _requestBody.ExistingParticipant.DateOfBirth = existingDateOfBirth;
         _requestBody.NewParticipant.FamilyName = newFamilyName;


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description
- fixed the demographics rule bug
- renamed rule to TooManyDemographicsFieldsChanged
<!-- Describe your changes in detail. -->

## Context
[DTOSS-4755](https://nhsd-jira.digital.nhs.uk/browse/DTOSS-4755)

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [X] I have followed the code style of the project
- [X] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [X] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
