### PR TITLE
fix: file locking and concurrency issue on windows machines

### DIFF
--- a/application/CohortManager/src/Functions/CaasIntegration/receiveCaasFile/receiveCaasFile.cs
+++ b/application/CohortManager/src/Functions/CaasIntegration/receiveCaasFile/receiveCaasFile.cs
@@ -61,7 +61,7 @@ public class ReceiveCaasFile
             var rowNumber = 0;
             var batchSize = Convert.ToInt32(Environment.GetEnvironmentVariable("BatchSize"));
 
-            downloadFilePath = Path.Combine(Path.GetTempPath(), name);
+            downloadFilePath = Path.Combine(Path.GetRandomFileName(), name);
 
             _logger.LogInformation("Downloading file from the blob, file: {Name}.", name);
             await using (var fileStream = File.Create(downloadFilePath))

--- a/tests/CaasIntegrationTests/receiveCaasFileTest/ReceiveCaasFileTests.cs
+++ b/tests/CaasIntegrationTests/receiveCaasFileTest/ReceiveCaasFileTests.cs
@@ -69,8 +69,7 @@ public class ReceiveCaasFileTests
         _mockIReceiveCaasFileHelper.Setup(x => x.GetNumberOfRecordsFromFileName(_blobName)).Returns(Task.FromResult<int?>(1));
         _mockIReceiveCaasFileHelper.Setup(x => x.MapParticipant(_participantsParquetMap, _participant, _blobName, It.IsAny<int>())).Returns(Task.FromResult<Participant?>(_participant));
         _mockIReceiveCaasFileHelper.Setup(x => x.SerializeParquetFile(It.IsAny<List<Cohort>>(), _cohort, _blobName, 1));
-        // Act
-        await _receiveCaasFileInstance.Run(fileSteam, _blobName);
+
 
         // Act
         await _receiveCaasFileInstance.Run(fileSteam, _blobName);


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

file locking and concurrency issue on windows machines
Removed duplicate run call in test 

## Context

Unit tests failing due to temp path being locked on windows machines.


## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
