### PR TITLE
feat: name transformations

### DIFF
--- a/application/CohortManager/Set-up/azurite/Dockerfile
+++ b/application/CohortManager/Set-up/azurite/Dockerfile
@@ -4,5 +4,6 @@ COPY ./Set-up/azurite .
 COPY ./rules ./rules
 
 RUN pip install azure-storage-blob==12.22.0
+RUN pip install azure-storage-queue
 
 CMD python3 -u ./azurite-setup.py

--- a/application/CohortManager/Set-up/azurite/azurite-setup.py
+++ b/application/CohortManager/Set-up/azurite/azurite-setup.py
@@ -3,20 +3,24 @@
 
 import os
 from azure.storage.blob import BlobServiceClient, BlobClient
+from azure.storage.queue import QueueServiceClient
 from azure.core.exceptions import ResourceExistsError
 
 def setup_azurite():
     connect_str = os.getenv("AZURITE_CONNECTION_STRING")
     blob_service_client = BlobServiceClient.from_connection_string(connect_str)
+    queue_service_client = QueueServiceClient.from_connection_string(connect_str)
     print("Connected to Azurite")
 
     try:
         blob_service_client.create_container("inbound")
         blob_service_client.create_container("rules")
         blob_service_client.create_container("file-exceptions")
-        print("Blob containers created")
+        queue_service_client.create_queue("add-participant-queue")
+        queue_service_client.create_queue("add-participant-queue-poison")
+        print("Queues & blob containers created")
     except ResourceExistsError:
-        print("Blob containers already exist")
+        print("Queues & blob containers already exist")
 
     rules_client = blob_service_client.get_container_client("rules")
 

--- a/application/CohortManager/Set-up/azurite/parquet-editor.py
+++ b/application/CohortManager/Set-up/azurite/parquet-editor.py
@@ -2,6 +2,8 @@ import argparse
 import sys
 from send_sample_file import send_sample_file
 import pandas as pd
+import numpy as np
+from fastparquet import write
 
 parser = argparse.ArgumentParser(description='An script that allows you to edit parquet files',
                                 formatter_class=argparse.RawTextHelpFormatter,
@@ -72,14 +74,18 @@ for i in range(len(args.c)):
     value = args.v[i]
     column_type = df[column_name].dtype
 
+
     if column_name not in df.columns:
         sys.exit(f"Column {column_name} not in schema, exiting")
 
-    match schema[column_name]:
-        case "Int64":
-            value = int(value)
-        case "boolean":
-            value = bool(value)
+    if value == "null":
+        value = ""
+    else:
+        match schema[column_name]:
+            case "Int64":
+                value = int(value)
+            case "boolean":
+                value = bool(value)
 
     if args.r:
         df.at[args.r[0], column_name] = value

--- a/application/CohortManager/compose.yaml
+++ b/application/CohortManager/compose.yaml
@@ -61,7 +61,7 @@ services:
       - MeshPassword = ${MESHPASSWORD}
       - MeshSharedKey = ${MESHSHAREDKEY}
       - MeshKeyPassphrase = ${MESHKEYPASSPHRASE}
-      - ASPNETCORE_URLS=http://*:7060
+      - ASPNETCORE_URLS=http://*:7059
     depends_on:
       - azurite
 
@@ -89,6 +89,7 @@ services:
       dockerfile: CaasIntegration/processCaasFile/Dockerfile
     environment:
       - ASPNETCORE_URLS=http://*:7061
+      - AzureWebJobsStorage=UseDevelopmentStorage=true
       - PMSAddParticipant=http://localhost:7062/api/addParticipant
       - PMSRemoveParticipant=http://localhost:7063/api/RemoveParticipant
       - PMSUpdateParticipant=http://localhost:7065/api/updateParticipant
@@ -104,6 +105,7 @@ services:
       dockerfile: ParticipantManagementServices/addParticipant/Dockerfile
     environment:
       - ASPNETCORE_URLS=http://*:7062
+      - AzureWebJobsStorage=UseDevelopmentStorage=true
       - DSaddParticipant=http://localhost:7066/api/CreateParticipant
       - DSmarkParticipantAsEligible=http://localhost:7067/api/markParticipantAsEligible
       - DemographicURIGet=http://localhost:7076/api/DemographicDataFunction

--- a/application/CohortManager/rules/Breast_Screening_staticRules.json
+++ b/application/CohortManager/rules/Breast_Screening_staticRules.json
@@ -100,7 +100,7 @@
       },
       {
         "RuleName": "39.FamilyName.NonFatal",
-        "Expression": "!string.IsNullOrEmpty(participant.FamilyName)",
+        "Expression": "participant.RecordType == Actions.Amended && !string.IsNullOrEmpty(participant.FamilyName)",
         "Actions": {
           "OnFailure": {
             "Name": "OutputExpression",
@@ -112,7 +112,7 @@
       },
       {
         "RuleName": "40.FirstName.NonFatal",
-        "Expression": "!string.IsNullOrEmpty(participant.FirstName)",
+        "Expression": "participant.RecordType == Actions.Amended && !string.IsNullOrEmpty(participant.FirstName)",
         "Actions": {
           "OnFailure": {
             "Name": "OutputExpression",

--- a/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/Program.cs
+++ b/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/Program.cs
@@ -1,4 +1,5 @@
 using Common;
+using Data.Database;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
@@ -7,7 +8,9 @@ var host = new HostBuilder()
     .ConfigureServices(services =>
     {
         services.AddSingleton<ICreateResponse, CreateResponse>();
+        services.AddScoped<IBsTransformationLookups, BsTransformationLookups>();
     })
+    .AddDatabaseConnection()
     .AddExceptionHandler()
     .Build();
 

--- a/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/TransformDataService.cs
+++ b/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/TransformDataService.cs
@@ -25,11 +25,14 @@ public class TransformDataService
     private readonly ILogger<TransformDataService> _logger;
     private readonly ICreateResponse _createResponse;
     private readonly IExceptionHandler _exceptionHandler;
-    public TransformDataService(ICreateResponse createResponse, IExceptionHandler exceptionHandler, ILogger<TransformDataService> logger)
+    private IBsTransformationLookups _transformationLookups;
+    public TransformDataService(ICreateResponse createResponse, IExceptionHandler exceptionHandler,
+                                ILogger<TransformDataService> logger, IBsTransformationLookups transformationLookups)
     {
         _createResponse = createResponse;
         _exceptionHandler = exceptionHandler;
         _logger = logger;
+        _transformationLookups = transformationLookups;
     }
 
     [Function("TransformDataService")]
@@ -61,23 +64,14 @@ public class TransformDataService
             var transformString = new TransformString();
             participant = await transformString.TransformStringFields(participant);
 
+            // Database lookup transformations
+            participant = await LookupTransformations(participant);
+
             // Other transformation rules
             participant = await TransformParticipantAsync(participant);
 
             // Name prefix transformation
             participant.NamePrefix = await TransformNamePrefixAsync(participant.NamePrefix);
-
-            // address transformation
-            if (!string.IsNullOrEmpty(participant.Postcode) &&
-                string.IsNullOrEmpty(participant.AddressLine1) &&
-                string.IsNullOrEmpty(participant.AddressLine2) &&
-                string.IsNullOrEmpty(participant.AddressLine3) &&
-                string.IsNullOrEmpty(participant.AddressLine4) &&
-                string.IsNullOrEmpty(participant.AddressLine5))
-            {
-                GetMissingAddress getMissingAddress = new(participant, new SqlConnection(Environment.GetEnvironmentVariable("DtOsDatabaseConnectionString")));
-                participant = getMissingAddress.GetAddress();
-            }
 
             var response = JsonSerializer.Serialize(participant);
             return _createResponse.CreateHttpResponse(HttpStatusCode.OK, req, response);
@@ -95,12 +89,16 @@ public class TransformDataService
         string json = await File.ReadAllTextAsync("transformRules.json");
         var rules = JsonSerializer.Deserialize<Workflow[]>(json);
         var action = new Dictionary<string, Func<ActionBase>>{{"TransformAction", () => new TransformAction()}};
-        var reSettings = new ReSettings {CustomActions = action};
+        var reSettings = new ReSettings
+        {
+            CustomActions = action,
+            CustomTypes = [typeof(Actions)]
+        };
 
         var re = new RulesEngine.RulesEngine(rules, reSettings);
 
         var ruleParameters = new[] {
-            new RuleParameter("participant", participant),
+            new RuleParameter("participant", participant)
         };
 
         var resultList = await re.ExecuteAllRulesAsync("TransformData", ruleParameters);
@@ -136,6 +134,61 @@ public class TransformDataService
                                                     .FirstOrDefault()
                                                     ?? null;
 
+
         return namePrefix;
+    }
+
+    /// <summary>
+    /// Performs transformations that require database lookups using the BsTransformationLookups class
+    /// </summary>
+    /// <param name="participant">The CohortDistributionParticipant to be transformed.</param>
+    /// <returns>The transformed participant</returns>
+    public async Task<CohortDistributionParticipant> LookupTransformations(CohortDistributionParticipant participant) {
+        // Set up rules engine
+        string json = await File.ReadAllTextAsync("lookupTransformationRules.json");
+        var rules = JsonSerializer.Deserialize<Workflow[]>(json);
+        var reSettings = new ReSettings {CustomTypes = [typeof(Actions)]};
+        var re = new RulesEngine.RulesEngine(rules, reSettings);
+
+        var ruleParameters = new[] {
+            new RuleParameter("participant", participant),
+            new RuleParameter("transformationLookups", _transformationLookups)
+        };
+
+        // Execute rules
+        var rulesList = await re.ExecuteAllRulesAsync("LookupTransformations", ruleParameters);
+
+        participant.FirstName = GetTransformedData<string>(rulesList, "FirstName", participant.FirstName);
+        participant.FamilyName = GetTransformedData<string>(rulesList, "FamilyName", participant.FamilyName);
+
+        // address transformation
+        if (!string.IsNullOrEmpty(participant.Postcode) &&
+            string.IsNullOrEmpty(participant.AddressLine1) &&
+            string.IsNullOrEmpty(participant.AddressLine2) &&
+            string.IsNullOrEmpty(participant.AddressLine3) &&
+            string.IsNullOrEmpty(participant.AddressLine4) &&
+            string.IsNullOrEmpty(participant.AddressLine5))
+        {
+            participant = _transformationLookups.GetAddress(participant);
+        }
+
+        return participant;
+    }
+
+    /// <summary>
+    /// Gets the result of the transformation from the rule output and assigns it to the relevant field.
+    /// Only being used for the rules that require database lookup as the other assignment method does not work.
+    /// </summary>
+    /// <param name="results">The rule result tree produced from the rule execution</param>
+    /// <param name="field">The name of the field</param>
+    /// <param name="currentValue">The current value of the field in the participant</param>
+    /// <returns>The transformed value, or the current value if null</returns>
+    private T GetTransformedData<T>(List<RuleResultTree> results, string field, T currentValue)
+    {
+        // The field is the 3rd part of the rule
+        var result = results.Find(x => x.Rule.RuleName.Split('.')[2] == field);
+        if (result == null) return currentValue;
+
+        return result.ActionResult.Output == null ? currentValue : (T)result.ActionResult.Output;
     }
 }

--- a/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/TransformDataService.csproj
+++ b/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/TransformDataService.csproj
@@ -31,6 +31,9 @@
         <None Update="characterRules.json">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="lookupTransformationRules.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     </ItemGroup>
     <ItemGroup>
     <Using Include="System.Threading.ExecutionContext" Alias="ExecutionContext" />

--- a/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/lookupTransformationRules.json
+++ b/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/lookupTransformationRules.json
@@ -1,0 +1,35 @@
+[
+  {
+    "WorkflowName": "LookupTransformations",
+    "GlobalParams": [{
+      "Name": "IsAmendRecord",
+      "Expression": "participant.RecordType == \"AMENDED\""
+    }],
+    "Rules": [
+      {
+        "RuleName": "13.Other.FamilyName.DoesNotExist",
+        "Expression": "IsAmendRecord && string.IsNullOrEmpty(participant.FamilyName)",
+        "Actions": {
+        "OnSuccess": {
+            "Name": "OutputExpression",
+            "Context": {
+              "Expression": "transformationLookups.GetFamilyName(participant.ParticipantId)"
+            }
+          }
+        }
+      },
+      {
+        "RuleName": "14.Other.FirstName.DoesNotExist",
+        "Expression": "IsAmendRecord && string.IsNullOrEmpty(participant.FirstName)",
+        "Actions": {
+          "OnSuccess": {
+            "Name": "OutputExpression",
+            "Context": {
+              "Expression": "transformationLookups.GetGivenName(participant.ParticipantId)"
+            }
+          }
+        }
+      }
+    ]
+  }
+]

--- a/application/CohortManager/src/Functions/Shared/Data/Database/BsTransformationLookups.cs
+++ b/application/CohortManager/src/Functions/Shared/Data/Database/BsTransformationLookups.cs
@@ -1,0 +1,99 @@
+namespace Data.Database;
+
+using System.Data;
+using Model;
+using Microsoft.Data.SqlClient;
+
+/// <summary>
+/// Various methods used for transformations the require looking up data from the database.
+/// </summary>
+public class BsTransformationLookups : IBsTransformationLookups
+{
+    private IDbConnection _connection;
+    private string _connectionString;
+
+    public BsTransformationLookups(IDbConnection IdbConnection)
+    {
+        _connectionString = Environment.GetEnvironmentVariable("DtOsDatabaseConnectionString") ?? string.Empty;
+        _connection = IdbConnection;
+    }
+
+    public string GetGivenName(string participantId)
+    {
+        return GetName(participantId, "GIVEN_NAME");
+    }
+
+    public string GetFamilyName(string participantId)
+    {
+        return GetName(participantId, "FAMILY_NAME");
+    }
+
+    /// <summary>
+    /// Used in rules 13 & 14 in the "Other" transformations.
+    /// Gets the participant's previous family/ given name if an Amend record comes in without one.
+    /// Will get the family or given name depending on which method it is called from.
+    /// </summary>
+    /// <param name="participantId">The participant's ID.</param>
+    /// <param name="nameType">which name to retrieve, acceptable values are "FAMILY_NAME" and "GIVEN_NAME".</param>
+    /// <returns>string, the participant's family/ given name.<returns>
+    private string GetName(string participantId, string nameType)
+    {
+        string sql = $"SELECT TOP 1 {nameType} FROM [dbo].[BS_COHORT_DISTRIBUTION] WHERE PARTICIPANT_ID = @participantId AND" +
+                    $" {nameType} IS NOT NULL ORDER BY BS_COHORT_DISTRIBUTION_ID DESC";
+
+        using (_connection = new SqlConnection(_connectionString))
+        {
+            _connection.Open();
+            using (SqlCommand command = new SqlCommand(sql, (SqlConnection)_connection))
+            {
+                command.Parameters.AddWithValue("@ParticipantId", participantId);
+                using (SqlDataReader reader = command.ExecuteReader())
+                {
+                    if (reader.Read())
+                    {
+                        return reader.GetString(0) ?? string.Empty;
+                    }
+                }
+            }
+        }
+        return string.Empty;
+    }
+
+    /// <summary>
+    /// Used in the transformations, gets the participant's address if a record comes in with a valid postcode but no address.
+    /// </summary>
+    /// <param name="participant">The participant.</param>
+    /// <returns>CohortDistributionParticipant, the transformed participant.<returns>
+    public CohortDistributionParticipant GetAddress(CohortDistributionParticipant participant)
+    {
+        string sql = $"SELECT POST_CODE, ADDRESS_LINE_1, ADDRESS_LINE_2, ADDRESS_LINE_3, ADDRESS_LINE_4, ADDRESS_LINE_5 " +
+                    $"FROM [dbo].[BS_COHORT_DISTRIBUTION] " +
+                    $"WHERE PARTICIPANT_ID = @ParticipantId";
+        using (_connection)
+        {
+            _connection.Open();
+            using (SqlCommand command = new SqlCommand(sql, (SqlConnection)_connection))
+            {
+                command.Parameters.AddWithValue("@ParticipantId", participant.ParticipantId);
+                using (SqlDataReader reader = command.ExecuteReader())
+                {
+                    while (reader.Read())
+                    {
+                        if (participant.Postcode != reader["POST_CODE"] as string)
+                        {
+                            throw new ArgumentException("Participant has an empty address and postcode does not match existing data");
+                        }
+
+                        participant.AddressLine1 = reader["ADDRESS_LINE_1"] as string ?? null;
+                        participant.AddressLine2 = reader["ADDRESS_LINE_2"] as string ?? null;
+                        participant.AddressLine3 = reader["ADDRESS_LINE_3"] as string ?? null;
+                        participant.AddressLine4 = reader["ADDRESS_LINE_4"] as string ?? null;
+                        participant.AddressLine5 = reader["ADDRESS_LINE_5"] as string ?? null;
+                    }
+                }
+            }
+        }
+        return participant;
+    }
+
+}

--- a/application/CohortManager/src/Functions/Shared/Data/Database/IBsTransformationLookups.cs
+++ b/application/CohortManager/src/Functions/Shared/Data/Database/IBsTransformationLookups.cs
@@ -1,0 +1,9 @@
+namespace Data.Database;
+
+using Model;
+
+public interface IBsTransformationLookups {
+    public string GetGivenName(string participantId);
+    public string GetFamilyName(string participantId);
+    public CohortDistributionParticipant GetAddress(CohortDistributionParticipant participant);
+}

--- a/tests/TransformDataServiceTests/TransformDataServiceTests.cs
+++ b/tests/TransformDataServiceTests/TransformDataServiceTests.cs
@@ -26,6 +26,7 @@ public class TransformDataServiceTests
     private readonly TransformDataService _function;
     private readonly Mock<ICreateResponse> _createResponse = new();
     private readonly Mock<IExceptionHandler> _handleException = new();
+    private readonly Mock<IBsTransformationLookups> _transformationLookups = new();
 
     public TransformDataServiceTests()
     {
@@ -44,7 +45,10 @@ public class TransformDataServiceTests
             ServiceProvider = "1"
         };
 
-        _function = new TransformDataService(_createResponse.Object, _handleException.Object, _logger.Object);
+        _transformationLookups.Setup(x => x.GetGivenName(It.IsAny<string>())).Returns("A first name");
+        _transformationLookups.Setup(x => x.GetFamilyName(It.IsAny<string>())).Returns("A last name");
+
+        _function = new TransformDataService(_createResponse.Object, _handleException.Object, _logger.Object, _transformationLookups.Object);
 
         _request.Setup(r => r.CreateResponse()).Returns(() =>
         {
@@ -364,6 +368,34 @@ public class TransformDataServiceTests
         string responseBody = await AssertionHelper.ReadResponseBodyAsync(result);
         Assert.AreEqual(JsonSerializer.Serialize(expectedResponse), responseBody);
         Assert.AreEqual(HttpStatusCode.OK, result.StatusCode);
+    }
+
+    [TestMethod]
+    public async Task Run_AmendRecordHasNullName_GetPreviousNameFromDb()
+    {
+        // Arrange
+        _requestBody.Participant.RecordType = Actions.Amended;
+        _requestBody.Participant.FirstName = null;
+
+        var json = JsonSerializer.Serialize(_requestBody);
+        SetUpRequestBody(json);
+
+        // Act
+        var result = await _function.RunAsync(_request.Object);
+
+        // Assert
+        var expectedResponse = new CohortDistributionParticipant
+        {
+            RecordType = Actions.Amended,
+            NhsNumber = "1",
+            FirstName = "A first name",
+            FamilyName = "Smith",
+            NamePrefix = "MR",
+            Gender = Gender.Male
+        };
+
+        string responseBody = await AssertionHelper.ReadResponseBodyAsync(result);
+        Assert.AreEqual(JsonSerializer.Serialize(expectedResponse), responseBody);
     }
 
     private void SetUpRequestBody(string json)


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description
- added new queues to docker
- added ability to set cells to null with the parquet editor
- name transformation

<!-- Describe your changes in detail. -->

## Context
[DTOSS-4285](https://nhsd-jira.digital.nhs.uk/browse/DTOSS-4285)
[DTOSS-4286](https://nhsd-jira.digital.nhs.uk/browse/DTOSS-4286)

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [X] I have followed the code style of the project
- [X] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [X] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
