### PR TITLE
feat: Remove validation rule 67 for HMP and MHI

### DIFF
--- a/application/CohortManager/rules/Breast_Screening_cohortRules.json
+++ b/application/CohortManager/rules/Breast_Screening_cohortRules.json
@@ -3,10 +3,6 @@
         "WorkflowName": "Common",
         "Rules": [
             {
-              "RuleName": "67.CurrentPostingIsHMPOrMHIAndDoesNotMatchExistingRecord.NonFatal",
-              "Expression": "newParticipant.RecordType == Actions.New OR !new string[] { \"HMP\", \"MHI\" }.Contains(newParticipant.CurrentPosting) OR newParticipant.CurrentPosting == existingParticipant.CurrentPosting"
-            },
-            {
               "RuleName": "35.TooManyDemographicsFieldsChanged.NonFatal",
               "Expression": "existingParticipant.ParticipantId == null || ((newParticipant.FamilyName == existingParticipant.FamilyName AND newParticipant.Gender == existingParticipant.Gender) OR (newParticipant.FamilyName == existingParticipant.FamilyName AND newParticipant.DateOfBirth == existingParticipant.DateOfBirth) OR (newParticipant.Gender== existingParticipant.Gender AND newParticipant.DateOfBirth == existingParticipant.DateOfBirth))"
             },

--- a/tests/ScreeningValidationServiceTests/LookupValidation/LookupValidationTests.cs
+++ b/tests/ScreeningValidationServiceTests/LookupValidation/LookupValidationTests.cs
@@ -345,54 +345,6 @@ public class LookupValidationTests
     }
 
     [TestMethod]
-    [DataRow(Actions.Amended, "MHI")]
-    [DataRow(Actions.Removed, "MHI")]
-    public async Task Run_InvalidCurrentPosting_CreatesException(string recordType, string currentPosting)
-    {
-        // Arrange
-        SetupRules("CohortRules");
-        _requestBody.NewParticipant.RecordType = recordType;
-        _requestBody.NewParticipant.CurrentPosting = currentPosting;
-        _requestBody.ExistingParticipant.CurrentPosting = "HMP";
-        var json = JsonSerializer.Serialize(_requestBody);
-        SetUpRequestBody(json);
-
-        // Act
-        var result = await _sut.RunAsync(_request.Object);
-
-        // Assert
-        Assert.AreEqual(HttpStatusCode.Created, result.StatusCode);
-        _exceptionHandler.Verify(handleException => handleException.CreateValidationExceptionLog(
-            It.Is<IEnumerable<RuleResultTree>>(r => r.Any(x => x.Rule.RuleName == "67.CurrentPostingIsHMPOrMHIAndDoesNotMatchExistingRecord.NonFatal")),
-            It.IsAny<ParticipantCsvRecord>()),
-            Times.Once());
-    }
-
-    [TestMethod]
-    [DataRow(Actions.New, "ABC")]
-    [DataRow(Actions.Amended, "ABC")]
-    [DataRow(Actions.Amended, "HMP")]
-    public async Task Run_ValidCurrentPosting_DoesNotCreateException(string recordType, string currentPosting)
-    {
-        // Arrange
-        SetupRules("CohortRules");
-        _requestBody.NewParticipant.RecordType = recordType;
-        _requestBody.NewParticipant.CurrentPosting = currentPosting;
-        _requestBody.ExistingParticipant.CurrentPosting = "HMP";
-        var json = JsonSerializer.Serialize(_requestBody);
-        SetUpRequestBody(json);
-
-        // Act
-        await _sut.RunAsync(_request.Object);
-
-        // Assert
-        _exceptionHandler.Verify(handleException => handleException.CreateValidationExceptionLog(
-            It.Is<IEnumerable<RuleResultTree>>(r => r.Any(x => x.Rule.RuleName == "67.CurrentPostingIsHMPOrMHIAndDoesNotMatchExistingRecord.NonFatal")),
-            It.IsAny<ParticipantCsvRecord>()),
-            Times.Never());
-    }
-
-    [TestMethod]
     [DataRow("ABC")] // Invalid CurrentPosting
     public async Task Run_CurrentPosting_CreatesException(string currentPosting)
     {


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description
Removed validation rule 67 for HMP and MHI from cohort_rules.json and removed the associated unit tests
<!-- Describe your changes in detail. -->

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [X] I have followed the code style of the project
- [X] I have removed tests to cover my changes
- [X] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [X] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
