### PR TITLE
fix: remove hardcoded Gender and DeathStatus

### DIFF
--- a/application/CohortManager/src/Functions/Shared/Common/ReceiveCaasFileHelper.cs
+++ b/application/CohortManager/src/Functions/Shared/Common/ReceiveCaasFileHelper.cs
@@ -81,7 +81,7 @@ public class ReceiveCaasFileHelper : IReceiveCaasFileHelper
                 FamilyName = Convert.ToString(rec.SurnamePrefix),
                 PreviousFamilyName = Convert.ToString(rec.PreviousSurnamePrefix),
                 DateOfBirth = Convert.ToString(rec.DateOfBirth),
-                Gender = getEnumValue<Gender>(Gender.Male),
+                Gender = (Gender)rec.Gender.GetValueOrDefault(),
                 AddressLine1 = Convert.ToString(rec.AddressLine1),
                 AddressLine2 = Convert.ToString(rec.AddressLine2),
                 AddressLine3 = Convert.ToString(rec.AddressLine3),
@@ -93,7 +93,7 @@ public class ReceiveCaasFileHelper : IReceiveCaasFileHelper
                 ReasonForRemoval = Convert.ToString(rec.ReasonForRemoval),
                 ReasonForRemovalEffectiveFromDate = rec.ReasonForRemovalEffectiveFromDate,
                 DateOfDeath = Convert.ToString(rec.DateOfDeath),
-                DeathStatus = getEnumValue<Status>(Status.Formal),
+                DeathStatus = (Status)rec.DeathStatus.GetValueOrDefault(),
                 TelephoneNumber = Convert.ToString(rec.TelephoneNumber),
                 MobileNumber = Convert.ToString(rec.MobileNumber),
                 MobileNumberEffectiveFromDate = Convert.ToString(rec.MobileNumberEffectiveFromDate),
@@ -159,14 +159,5 @@ public class ReceiveCaasFileHelper : IReceiveCaasFileHelper
             return false;
         }
         return true;
-    }
-
-    private T? getEnumValue<T>(T type)
-    {
-        if (Enum.IsDefined(typeof(T), Convert.ToInt16(type)))
-        {
-            return (T)Enum.ToObject(typeof(T), Convert.ToInt16(type));
-        }
-        return default;
     }
 }


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

<!-- Describe your changes in detail. -->
Remove hardcoded values for gender and death status when mapping the parquet file to participant object and use the supplied values instead.
## Context
[DTOSS-5646](https://nhsd-jira.digital.nhs.uk/browse/DTOSS-5646)
<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
