### PR TITLE
feat: Transformation exceptions

### DIFF
--- a/application/CohortManager/compose.yaml
+++ b/application/CohortManager/compose.yaml
@@ -134,10 +134,12 @@ services:
       dockerfile: ParticipantManagementServices/RemoveParticipant/Dockerfile
     environment:
       - ASPNETCORE_URLS=http://*:7063
+      - AzureWebJobsStorage=UseDevelopmentStorage=true
       - markParticipantAsIneligible=http://localhost:7068/api/markParticipantAsIneligible
       - ExceptionFunctionURL=http://localhost:7070/api/CreateException
       - DemographicURIGet=http://localhost:7076/api/DemographicDataFunction
       - RemoveCohortDistributionURL=http://localhost:7079/api/RemoveCohortDistributionData
+      - CohortQueueName=cohort-distribution-queue
 
   update-participant:
     container_name: update-participant
@@ -147,6 +149,7 @@ services:
       dockerfile: ParticipantManagementServices/updateParticipant/Dockerfile
     environment:
       - ASPNETCORE_URLS=http://*:7065
+      - AzureWebJobsStorage=UseDevelopmentStorage=true
       - UpdateParticipant=http://localhost:7069/api/updateParticipantDetails
       - StaticValidationURL=http://localhost:7074/api/StaticValidation
       - DemographicURIGet=http://localhost:7076/api/DemographicDataFunction
@@ -154,6 +157,7 @@ services:
       - DSmarkParticipantAsEligible=http://localhost:7067/api/markParticipantAsEligible
       - markParticipantAsIneligible=http://localhost:7068/api/markParticipantAsIneligible
       - CohortDistributionServiceURL=http://localhost:7082/api/CreateCohortDistribution
+      - CohortQueueName=cohort-distribution-queue
 
   # Screening Data Service
   create-participant:

--- a/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/TransformAction.cs
+++ b/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/TransformAction.cs
@@ -20,48 +20,41 @@ class TransformAction : ActionBase
 {
     public override async ValueTask<object> Run(ActionContext context, RuleParameter[] ruleParameters)
     {
-        try{
-            var transformFields = context.GetContext<List<TransformFields>>("transformFields");
-            var participant = (CohortDistributionParticipant)ruleParameters.Where(rule => rule.Name == "participant").Select(result => result.Value).FirstOrDefault();
-            var bsoCode = ruleParameters.Where(rule => rule.Name == "bsoCode").Select(result => result.Value).FirstOrDefault();
+        var transformFields = context.GetContext<List<TransformFields>>("transformFields");
+        var participant = (CohortDistributionParticipant)ruleParameters.Where(rule => rule.Name == "participant").Select(result => result.Value).FirstOrDefault();
+        var bsoCode = ruleParameters.Where(rule => rule.Name == "bsoCode").Select(result => result.Value).FirstOrDefault();
 
-            foreach (var transformField in transformFields)
-            {
-                var property = typeof(CohortDistributionParticipant).GetProperty(transformField.field);
-
-                if (transformField.isExpression)
-                {
-                    EvaluateExpression(property!, transformField.value, participant, bsoCode);
-                }
-                else
-                {
-                    dynamic value;
-
-                    switch (property!.PropertyType.Name)
-                    {
-                        case "string":
-                            value = transformField.value;
-                            break;
-                        case "int":
-                            value = int.Parse(transformField.value);
-                            break;
-                        case "Nullable`1":
-                            value = Enum.Parse<Gender>(transformField.value);
-                            break;
-                        default:
-                            value = transformField.value;
-                            break;
-                    }
-                    property.SetValue(participant, value);
-                }
-            }
-            return participant;
-        }
-        catch(Exception ex)
+        foreach (var transformField in transformFields)
         {
-            throw;
-        }
+            var property = typeof(CohortDistributionParticipant).GetProperty(transformField.field);
 
+            if (transformField.isExpression)
+            {
+                EvaluateExpression(property!, transformField.value, participant, bsoCode);
+            }
+            else
+            {
+                dynamic value;
+
+                switch (property!.PropertyType.Name)
+                {
+                    case "string":
+                        value = transformField.value;
+                        break;
+                    case "int":
+                        value = int.Parse(transformField.value);
+                        break;
+                    case "Nullable`1":
+                        value = Enum.Parse<Gender>(transformField.value);
+                        break;
+                    default:
+                        value = transformField.value;
+                        break;
+                }
+                property.SetValue(participant, value);
+            }
+        }
+        return participant;
     }
 
     private static void EvaluateExpression(PropertyInfo property, string expression, CohortDistributionParticipant participant, object bsoCode)

--- a/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/TransformString.cs
+++ b/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/TransformString.cs
@@ -50,7 +50,7 @@ public class TransformString
             // Special characters that need to be handled separately
             if (stringField.Contains(@"\E\") || stringField.Contains(@"\T\"))
             {
-                throw new ArgumentException("Participant contains illegal characters");
+                throw new System.ComponentModel.DataAnnotations.ValidationException("Participant contains illegal characters");
             }
 
             var transformedField = await TransformCharactersAsync(stringField);
@@ -58,7 +58,7 @@ public class TransformString
             // Check to see if there are any unhandled invalid chars
             if (!Regex.IsMatch(transformedField, allowedCharacters))
             {
-                throw new ArgumentException("Participant contains illegal characters");
+                throw new System.ComponentModel.DataAnnotations.ValidationException("Participant contains illegal characters");
             }
             return transformedField;
         }

--- a/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/transformRules.json
+++ b/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/transformRules.json
@@ -18,7 +18,7 @@
     "Rules": [
       {
         "RuleName": "1.Truncate.NamePrefix.ExceedsMaximumLength",
-        "Expression": "participant.NamePrefix.Length > 35",
+        "Expression": "!string.IsNullOrEmpty(participant.NamePrefix) && participant.NamePrefix.Length > 35",
         "Actions": {
           "OnSuccess": {
             "Name": "TransformAction",
@@ -36,7 +36,7 @@
       },
       {
         "RuleName": "2.Truncate.FirstName.ExceedsMaximumLength",
-        "Expression": "participant.FirstName.Length > 35",
+        "Expression": "!string.IsNullOrEmpty(participant.FirstName) && participant.FirstName.Length > 35",
         "Actions": {
           "OnSuccess": {
             "Name": "TransformAction",
@@ -54,7 +54,7 @@
       },
       {
         "RuleName": "3.Truncate.OtherGivenNames.ExceedsMaximumLength",
-        "Expression": "participant.OtherGivenNames.Length > 100",
+        "Expression": "!string.IsNullOrEmpty(participant.OtherGivenNames) && participant.OtherGivenNames.Length > 100",
         "Actions": {
           "OnSuccess": {
             "Name": "TransformAction",
@@ -72,7 +72,7 @@
       },
       {
         "RuleName": "4.Truncate.FamilyName.ExceedsMaximumLength",
-        "Expression": "participant.FamilyName.Length > 35",
+        "Expression": "!string.IsNullOrEmpty(participant.FamilyName) && participant.FamilyName.Length > 35",
         "Actions": {
           "OnSuccess": {
             "Name": "TransformAction",
@@ -90,7 +90,7 @@
       },
       {
         "RuleName": "5.Truncate.PreviousFamilyName.ExceedsMaximumLength",
-        "Expression": "participant.PreviousFamilyName.Length > 35",
+        "Expression": "!string.IsNullOrEmpty(participant.PreviousFamilyName) && participant.PreviousFamilyName.Length > 35",
         "Actions": {
           "OnSuccess": {
             "Name": "TransformAction",
@@ -108,7 +108,7 @@
       },
       {
         "RuleName": "6.Truncate.AddressLine1.ExceedsMaximumLength",
-        "Expression": "participant.AddressLine1.Length > 35",
+        "Expression": "!string.IsNullOrEmpty(participant.AddressLine1) && participant.AddressLine1.Length > 35",
         "Actions": {
           "OnSuccess": {
             "Name": "TransformAction",
@@ -126,7 +126,7 @@
       },
       {
         "RuleName": "7.Truncate.AddressLine2.ExceedsMaximumLength",
-        "Expression": "participant.AddressLine2.Length > 35",
+        "Expression": "!string.IsNullOrEmpty(participant.AddressLine2) && participant.AddressLine2.Length > 35",
         "Actions": {
           "OnSuccess": {
             "Name": "TransformAction",
@@ -144,7 +144,7 @@
       },
       {
         "RuleName": "8.Truncate.AddressLine3.ExceedsMaximumLength",
-        "Expression": "participant.AddressLine3.Length > 35",
+        "Expression": "!string.IsNullOrEmpty(participant.AddressLine3) && participant.AddressLine3.Length > 35",
         "Actions": {
           "OnSuccess": {
             "Name": "TransformAction",
@@ -162,7 +162,7 @@
       },
       {
         "RuleName": "9.Truncate.AddressLine4.ExceedsMaximumLength",
-        "Expression": "participant.AddressLine4.Length > 35",
+        "Expression": "!string.IsNullOrEmpty(participant.AddressLine4) && participant.AddressLine4.Length > 35",
         "Actions": {
           "OnSuccess": {
             "Name": "TransformAction",
@@ -180,7 +180,7 @@
       },
       {
         "RuleName": "10.Truncate.AddressLine5.ExceedsMaximumLength",
-        "Expression": "participant.AddressLine5.Length > 35",
+        "Expression": "!string.IsNullOrEmpty(participant.AddressLine5) && participant.AddressLine5.Length > 35",
         "Actions": {
           "OnSuccess": {
             "Name": "TransformAction",
@@ -198,7 +198,7 @@
       },
       {
         "RuleName": "13.Truncate.Postcode.ExceedsMaximumLength",
-        "Expression": "participant.Postcode.Length > 35",
+        "Expression": "!string.IsNullOrEmpty(participant.Postcode) && participant.Postcode.Length > 35",
         "Actions": {
           "OnSuccess": {
             "Name": "TransformAction",
@@ -216,7 +216,7 @@
       },
       {
         "RuleName": "14.Truncate.TelephoneNumber.ExceedsMaximumLength",
-        "Expression": "participant.TelephoneNumber.Length > 32",
+        "Expression": "!string.IsNullOrEmpty(participant.TelephoneNumber) && participant.TelephoneNumber.Length > 32",
         "Actions": {
           "OnSuccess": {
             "Name": "TransformAction",
@@ -234,7 +234,7 @@
       },
       {
         "RuleName": "15.Truncate.MobileNumber.ExceedsMaximumLength",
-        "Expression": "participant.MobileNumber.Length > 32",
+        "Expression": "!string.IsNullOrEmpty(participant.MobileNumber) && participant.MobileNumber.Length > 32",
         "Actions": {
           "OnSuccess": {
             "Name": "TransformAction",
@@ -252,7 +252,7 @@
       },
       {
         "RuleName": "16.Truncate.EmailAddress.ExceedsMaximumLength",
-        "Expression": "participant.EmailAddress.Length > 90",
+        "Expression": "!string.IsNullOrEmpty(participant.EmailAddress) && participant.EmailAddress.Length > 90",
         "Actions": {
           "OnSuccess": {
             "Name": "TransformAction",

--- a/application/CohortManager/src/Functions/ScreeningValidationService/StaticValidation/Breast_Screening_staticRules.json
+++ b/application/CohortManager/src/Functions/ScreeningValidationService/StaticValidation/Breast_Screening_staticRules.json
@@ -100,24 +100,24 @@
       },
       {
         "RuleName": "39.FamilyName.NonFatal",
-        "Expression": "!string.IsNullOrEmpty(participant.FamilyName)",
+        "Expression": "!(participant.RecordType != Actions.Amended && string.IsNullOrEmpty(participant.FamilyName))",
         "Actions": {
           "OnFailure": {
             "Name": "OutputExpression",
             "Context": {
-              "Expression": "Name value missing"
+              "Expression": "Family Name value missing"
             }
           }
         }
       },
       {
         "RuleName": "40.FirstName.NonFatal",
-        "Expression": "!string.IsNullOrEmpty(participant.FirstName)",
+        "Expression": "!(participant.RecordType != Actions.Amended && string.IsNullOrEmpty(participant.FirstName))",
         "Actions": {
           "OnFailure": {
             "Name": "OutputExpression",
             "Context": {
-              "Expression": "Name value missing"
+              "Expression": "First Name value missing"
             }
           }
         }

--- a/application/CohortManager/src/Functions/Shared/Common/Interfaces/IExceptionHandler.cs
+++ b/application/CohortManager/src/Functions/Shared/Common/Interfaces/IExceptionHandler.cs
@@ -12,4 +12,5 @@ public interface IExceptionHandler
     Task CreateSystemExceptionLogFromNhsNumber(Exception exception, string nhsNumber, string fileName, string screeningName, string errorRecord);
     Task<bool> CreateRecordValidationExceptionLog(string nhsNumber, string fileName, string errorDescription, string screeningName, string errorRecord);
     Task CreateDeletedRecordException(BasicParticipantCsvRecord participantCsvRecord);
+    Task CreateTransformationExceptionLog(IEnumerable<RuleResultTree> transformationErrors, CohortDistributionParticipant participant);
 }


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description
- exceptions during the transformation process will now be raised to the exceptions table with the rule name that has caused the exception, and the record will not be sent to the cohort distribution table
- changed truncation transformations so they do not operate on null values (which would cause an exception)
- changed name validations that were changed on a previous ticket on the wrong file due to the rules duplication
- updated docker env variables

<!-- Describe your changes in detail. -->

## Context
previously exceptions that occurred in the transformation rules engine were ignored, it has been decided that they should be raised to the exception table and the record should not be processed further

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [X] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [X] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
