### PR TITLE
fix: postcode null bug

### DIFF
--- a/application/CohortManager/src/Functions/ScreeningValidationService/StaticValidation/Breast_Screening_staticRules.json
+++ b/application/CohortManager/src/Functions/ScreeningValidationService/StaticValidation/Breast_Screening_staticRules.json
@@ -52,7 +52,7 @@
       },
       {
         "RuleName": "30.Postcode.NonFatal",
-        "Expression": "Regex.IsMatch(participant.Postcode, \"^([A-Z]{1,2}[0-9][A-Z0-9]? ?[0-9][A-Z]{2})$\", RegexOptions.IgnoreCase)",
+        "Expression": "string.IsNullOrEmpty(participant.Postcode) OR Regex.IsMatch(participant.Postcode, \"^([A-Z]{1,2}[0-9][A-Z0-9]? ?[0-9][A-Z]{2})$\", RegexOptions.IgnoreCase)",
         "Actions": {
           "OnFailure": {
             "Name": "OutputExpression",

--- a/tests/ScreeningValidationServiceTests/StaticValidation/StaticValidationTests.cs
+++ b/tests/ScreeningValidationServiceTests/StaticValidation/StaticValidationTests.cs
@@ -302,6 +302,8 @@ public class StaticValidationTests
     [DataRow("B33 8TH")]
     [DataRow("CR2 6XH")]
     [DataRow("LS10 1LT")]
+    [DataRow("")]
+    [DataRow(null)]
     public async Task Run_Should_Not_Create_Exception_When_Postcode_Rule_Passes(string postcode)
     {
         // Arrange


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Postcode validation rule was throwing exceptions when its null or empty

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [x] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
