### PR TITLE
fix: refactor batching to use batch size to set batch size

### DIFF
--- a/application/CohortManager/src/Functions/CaasIntegration/receiveCaasFile/receiveCaasFile.cs
+++ b/application/CohortManager/src/Functions/CaasIntegration/receiveCaasFile/receiveCaasFile.cs
@@ -35,8 +35,7 @@ public class ReceiveCaasFile
     public async Task Run([BlobTrigger("inbound/{name}", Connection = "caasfolder_STORAGE")] Stream blobStream, string name)
     {
         var downloadFilePath = string.Empty;
-        int.TryParse(Environment.GetEnvironmentVariable("recordThresholdForBatching"), out var recordThresholdForBatching);
-        int.TryParse(Environment.GetEnvironmentVariable("batchDivisionFactor"), out var batchDivisionFactor);
+        int.TryParse(Environment.GetEnvironmentVariable("BatchSize"), out var BatchSize);
         try
         {
             FileNameParser fileNameParser = new FileNameParser(name);
@@ -72,26 +71,21 @@ public class ReceiveCaasFile
                     var countOfRecords = values.Length;
                     var allTasks = new List<Task>();
 
-                    if (countOfRecords >= recordThresholdForBatching)
-                    {
-                        //split list of all into N amount of chunks to be processed as batches.
-                        var chunkSize = countOfRecords / batchDivisionFactor;
-                        var chunks = listOfAllValues.Chunk(chunkSize).ToList();
 
-                        foreach (var chunk in chunks)
-                        {
-                            var batch = chunk.ToList();
-                            allTasks.Add(
-                                _processCaasFile.ProcessRecords(batch, options, screeningService, name)
-                            );
-                        }
-                        // process each batches
-                        Task.WaitAll(allTasks.ToArray());
-                    }
-                    else
+                    //split list of all into N amount of chunks to be processed as batches.
+
+                    var chunks = listOfAllValues.Chunk(BatchSize).ToList();
+
+                    foreach (var chunk in chunks)
                     {
-                        await _processCaasFile.ProcessRecords(listOfAllValues, options, screeningService, name);
+                        var batch = chunk.ToList();
+                        allTasks.Add(
+                            _processCaasFile.ProcessRecords(batch, options, screeningService, name)
+                        );
                     }
+                    // process each batches
+                    Task.WaitAll(allTasks.ToArray());
+
                     // dispose of all lists and variables from memory because they are no longer needed
                     listOfAllValues = null;
                     values = null;


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Change batching logic to just use a batch size. 
Fixes issues where batch size would be set to zeo

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
