### PR TITLE
fix: azurite setup script not updated after rule move

### DIFF
--- a/application/CohortManager/Set-up/azurite/Dockerfile
+++ b/application/CohortManager/Set-up/azurite/Dockerfile
@@ -1,7 +1,6 @@
 FROM python:3.12
 
 COPY ./Set-up/azurite .
-COPY ./rules ./rules
 
 RUN pip install azure-storage-blob==12.22.0
 RUN pip install azure-storage-queue

--- a/application/CohortManager/Set-up/azurite/azurite-setup.py
+++ b/application/CohortManager/Set-up/azurite/azurite-setup.py
@@ -14,21 +14,11 @@ def setup_azurite():
 
     try:
         blob_service_client.create_container("inbound")
-        blob_service_client.create_container("rules")
         blob_service_client.create_container("file-exceptions")
         queue_service_client.create_queue("add-participant-queue")
         queue_service_client.create_queue("add-participant-queue-poison")
         print("Queues & blob containers created")
     except ResourceExistsError:
         print("Queues & blob containers already exist")
-
-    rules_client = blob_service_client.get_container_client("rules")
-
-    for file in os.listdir("../../rules"):
-        blob_client = rules_client.get_blob_client(file)
-        with open(f"../../rules/{file}", "rb") as data:
-            blob_client.upload_blob(data)
-
-    print("Rules uploaded to blob container")
 
 setup_azurite()

--- a/application/CohortManager/compose.yaml
+++ b/application/CohortManager/compose.yaml
@@ -86,7 +86,6 @@ services:
       - AddQueueName=add-participant-queue
       - BatchSize=3500
       - DtOsDatabaseConnectionString=Server=localhost,1433;Database=${DB_NAME};User Id=SA;Password=${PASSWORD};TrustServerCertificate=True
-      - AddQueueName=add-participant-queue
       - recordThresholdForBatching=3
       - batchDivisionFactor=5
     depends_on:


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description
- Removed the part of the azurite setup where rules are added
- Removed duplicate env variable in the compose.yaml

<!-- Describe your changes in detail. -->

## Context
Rules were moved out of the rules folder into the respective function's folder, but the azurite setup script was not updated accordingly

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [X] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [X] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
