### PR TITLE
fix: surface transform string error in exception

### DIFF
--- a/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/TransformDataService.cs
+++ b/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/TransformDataService.cs
@@ -81,7 +81,7 @@ public class TransformDataService
         }
         catch (TransformationException ex)
         {
-            _logger.LogWarning("An error occured during transformation", ex);
+            _logger.LogWarning(ex, "An error occurred during transformation");
             return _createResponse.CreateHttpResponse(HttpStatusCode.BadRequest, req);
         }
         catch (Exception ex)
@@ -96,7 +96,7 @@ public class TransformDataService
     {
         string json = await File.ReadAllTextAsync("transformRules.json");
         var rules = JsonSerializer.Deserialize<Workflow[]>(json);
-        var actions = new Dictionary<string, Func<ActionBase>> {{"TransformAction", () => new TransformAction()}};
+        var actions = new Dictionary<string, Func<ActionBase>> { { "TransformAction", () => new TransformAction() } };
         var reSettings = new ReSettings
         {
             CustomActions = actions,

--- a/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/TransformString.cs
+++ b/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/TransformString.cs
@@ -50,7 +50,7 @@ public class TransformString
             // Special characters that need to be handled separately
             if (stringField.Contains(@"\E\") || stringField.Contains(@"\T\"))
             {
-                throw new TransformationException("Participant contains illegal characters");
+                throw new ArgumentException("Participant contains illegal characters");
             }
 
             var transformedField = await TransformCharactersAsync(stringField);


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

<!-- Describe your changes in detail. -->
A couple of minor changes in here: 

1. Small change to use the error message from the character transformation rule when we encounter the `\E\` or `\T\` special cases when raising the exception.
2. Another change to show the exception in the warning log in the `TransformDataServices` function.

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
