### PR TITLE
fix: prevent RetrieveBSOCode lookup with null postcode

### DIFF
--- a/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/transformRules.json
+++ b/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/transformRules.json
@@ -16,7 +16,7 @@
       },
       {
         "Name": "bsoCode",
-        "Expression": "dbLookup.RetrieveBSOCode(participant.Postcode)"
+        "Expression": "!string.IsNullOrEmpty(participant.Postcode) ? dbLookup.RetrieveBSOCode(participant.Postcode) : \"\""
       }
     ],
     "Rules": [

--- a/tests/UnitTests/TransformDataServiceTests/TransformDataServiceTests.cs
+++ b/tests/UnitTests/TransformDataServiceTests/TransformDataServiceTests.cs
@@ -502,7 +502,7 @@ public class TransformDataServiceTests
         // Arrange
         var reasonForRemovalEffectiveFromDate = "2/10/2024";
         var addressLine = "address";
-        var bsoCode = "ELD";
+        var bsoCode = !string.IsNullOrEmpty(postcode) ? "ELD" : "";
 
         _requestBody.Participant.PrimaryCareProvider = "Y00090";
         _requestBody.Participant.ReasonForRemoval = reasonForRemoval;


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

<!-- Describe your changes in detail. -->

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes
Fixes a bug where the RetrieveBSOCode db lookup was trying to use a null postcode.
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
