### PR TITLE
fix: some illegal chars not throwing exceptions

### DIFF
--- a/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/TransformString.cs
+++ b/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/TransformString.cs
@@ -36,7 +36,7 @@ public class TransformString
         return participant;
     }
 
-    private async Task<string> CheckParticipantCharactersAsync(string stringField)
+    public async Task<string> CheckParticipantCharactersAsync(string stringField)
     {
         string allowedCharacters = @"^[a-zA-Z0-9\d\s.,\-()\/='+:?!""%&;<>*]+$";
 
@@ -58,7 +58,7 @@ public class TransformString
             // Check to see if there are any unhandled invalid chars
             if (!Regex.IsMatch(transformedField, allowedCharacters))
             {
-                throw new TransformationException("Participant contains illegal characters");
+                throw new ArgumentException("Participant contains illegal characters");
             }
             return transformedField;
         }

--- a/tests/UnitTests/TransformDataServiceTests/TransformDataServiceTests.cs
+++ b/tests/UnitTests/TransformDataServiceTests/TransformDataServiceTests.cs
@@ -348,6 +348,19 @@ public class TransformDataServiceTests
         Assert.AreEqual(HttpStatusCode.OK, result.StatusCode);
     }
 
+
+    [DataRow("Bob\\E\\")]
+    [DataRow("Bob\\T\\")]
+    [DataRow("Bob€")]
+    public async Task Run_ExceptionalCharsInParticipant_RaisesException(string name)
+    {
+        // Arrange
+        var sut = new TransformString();
+
+        // Act & Assert
+        Assert.ThrowsException<ArgumentException>(() => sut.CheckParticipantCharactersAsync(name));
+    }
+
     [TestMethod]
     public async Task Run_RfrIsDeaAndDateOfDeathIsNull_SetDateOfDeathToRfrDate()
     {


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description
- Changed exception type so exceptional chars are handled correctly
- Added tests for exceptional chars

<!-- Describe your changes in detail. -->

## Context
Illegal characters that do not have a transformation rule should raise an exception if they are found, this was happening but the exception message was not being sent to the DB

[DTOSS-6054](https://nhsd-jira.digital.nhs.uk/browse/DTOSS-6054)

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [X] I have followed the code style of the project
- [X] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [X] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
