### PR TITLE
fix: reason for removal bug fix

### DIFF
--- a/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/transformRules.json
+++ b/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/transformRules.json
@@ -292,7 +292,7 @@
       },
       {
         "RuleName": "00.Other.InvalidFlag.TrueAndNoPrimaryCareProvider",
-        "Expression": "!string.IsNullOrEmpty(participant.PrimaryCareProvider) && transformLookups.ParticipantIsInvalid(participant.ParticipantId)",
+        "Expression": "!string.IsNullOrEmpty(participant.PrimaryCareProvider) && transformLookups.ParticipantIsInvalid(participant.NhsNumber)",
         "Actions": {
           "OnSuccess": {
             "Name": "TransformAction",

--- a/application/CohortManager/src/Functions/Shared/Data/Database/BsTransformationLookups.cs
+++ b/application/CohortManager/src/Functions/Shared/Data/Database/BsTransformationLookups.cs
@@ -95,23 +95,23 @@ public class BsTransformationLookups : IBsTransformationLookups
         }
         return participant;
     }
-    
+
     /// <summary>
     /// Used in
     /// </summary>
     /// <param name="participant">The participant.</param>
     /// <returns>CohortDistributionParticipant, the transformed participant.<returns>
-    public bool ParticipantIsInvalid(string participantId)
+    public bool ParticipantIsInvalid(string nhsNumber)
     {
         string sql = $"SELECT PARTICIPANT_ID FROM [dbo].[PARTICIPANT_DEMOGRAPHIC] " +
-                    $"WHERE PARTICIPANT_ID = @ParticipantId AND INVALID_FLAG = 1";
+                    $"WHERE NHS_NUMBER = @NhsNumber AND INVALID_FLAG = 1";
 
         using (_connection = new SqlConnection(_connectionString))
         {
             _connection.Open();
             using (SqlCommand command = new SqlCommand(sql, (SqlConnection)_connection))
             {
-                command.Parameters.AddWithValue("@ParticipantId", participantId);
+                command.Parameters.AddWithValue("@NhsNumber", nhsNumber);
                 using (SqlDataReader reader = command.ExecuteReader())
                 {
                     return reader.Read();


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

- DB Lookup for Invalid Flag was using participant ID which is not consistent between Participant_managment and Participant_Demographic

## Context

[DTOSS-6184](https://nhsd-jira.digital.nhs.uk/browse/DTOSS-6184)

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
