### PR TITLE
feat: dev/nft participant-demographic-data-service configuration

### DIFF
--- a/infrastructure/environments/development.tfvars.config
+++ b/infrastructure/environments/development.tfvars.config
@@ -722,6 +722,18 @@ function_apps = {
       ]
     }
 
+    ParticipantDemographicDataService = {
+      name_suffix                  = "participant-demographic-data-service"
+      function_endpoint_name       = "ParticipantDemographicDataService"
+      db_connection_string         = "DtOsDatabaseConnectionString"
+      app_urls = [
+        {
+          env_var_name     = "ExceptionFunctionURL"
+          function_app_key = "CreateException"
+        }
+      ]
+    }
+
   }
 }
 

--- a/infrastructure/environments/nft.tfvars.config
+++ b/infrastructure/environments/nft.tfvars.config
@@ -723,6 +723,18 @@ function_apps = {
       ]
     }
 
+    ParticipantDemographicDataService = {
+      name_suffix                  = "participant-demographic-data-service"
+      function_endpoint_name       = "ParticipantDemographicDataService"
+      db_connection_string         = "DtOsDatabaseConnectionString"
+      app_urls = [
+        {
+          env_var_name     = "ExceptionFunctionURL"
+          function_app_key = "CreateException"
+        }
+      ]
+    }
+
   }
 }
 

--- a/scripts/deployment/get-docker-names.sh
+++ b/scripts/deployment/get-docker-names.sh
@@ -28,6 +28,7 @@ declare -A docker_functions_map=(
     ["screeningDataServices/LanguageCodesDataService"]="language-code-data-service"
     ["screeningDataServices/markParticipantAsEligible"]="mark-participant-as-eligible"
     ["screeningDataServices/markParticipantAsIneligible"]="mark-participant-as-ineligible"
+    ["screeningDataServices/ParticipantDemographicDataService"]="participant-demographic-data-service"
     ["screeningDataServices/ParticipantManagementDataService"]="participant-management-data-service"
     ["screeningDataServices/updateParticipantDetails"]="update-participant-details"
     ["ScreeningValidationService/FileValidation"]="file-validation"


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

This PR includes the Development/NFT infra definition of the new function used by Cohort Manager: `participant-demographic-data-service-configuration`.

## Context

Successful Dev plan:
https://dev.azure.com/nhse-dtos/dtos-cohort-manager/_build/results?buildId=10442&view=logs&j=ced2749f-787a-529b-d064-72b5c61df22f&t=a8ef944f-7917-542a-f805-14b39eb0c11c

Successful NFT plan:
https://dev.azure.com/nhse-dtos/dtos-cohort-manager/_build/results?buildId=10443&view=logs&j=ced2749f-787a-529b-d064-72b5c61df22f&t=a8ef944f-7917-542a-f805-14b39eb0c11c

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [X] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [X] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
