### PR TITLE
fix: HRH Transform rule

### DIFF
--- a/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/namePrefixRules.json
+++ b/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/namePrefixRules.json
@@ -628,7 +628,7 @@
       },
       {
         "RuleName": "54.NamePrefix.HisRoyalHighness",
-        "Expression": "namePrefix == \"HIS ROYAL HGHNESS\"",
+        "Expression": "namePrefix == \"HIS ROYAL HIGHNESS\"",
         "Actions": {
           "OnSuccess": {
             "Name": "OutputExpression",
@@ -640,7 +640,7 @@
       },
       {
         "RuleName": "55.NamePrefix.HerRoyalHighness",
-        "Expression": "namePrefix == \"HER ROYAL HGHNESS\"",
+        "Expression": "namePrefix == \"HER ROYAL HIGHNESS\"",
         "Actions": {
           "OnSuccess": {
             "Name": "OutputExpression",


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Checked the PI Validation rules, there was no instance where highness was spelt hghnness

## Context

[DTOSS-6047](https://nhsd-jira.digital.nhs.uk/browse/DTOSS-6047)

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
