### PR TITLE
test: increase coverage on static validation

### DIFF
--- a/infrastructure/tf-audit/variables.tf
+++ b/infrastructure/tf-audit/variables.tf
@@ -79,11 +79,11 @@ variable "app_insights" {
 variable "law" {
   description = "Configuration of the Log Analytics Workspace"
   type = object({
-    name                = optional(string, "cohman")
-    law_sku             = optional(string, "PerGB2018")
-    retention_days      = optional(number, 30)
-    export_enabled      = optional(bool, false)
-    export_table_names  = optional(list(string), [])
+    name               = optional(string, "cohman")
+    law_sku            = optional(string, "PerGB2018")
+    retention_days     = optional(number, 30)
+    export_enabled     = optional(bool, false)
+    export_table_names = optional(list(string), [])
   })
 }
 

--- a/tests/UnitTests/ScreeningDataServicesTests/ValidationExceptionDataTests/GetValidationExceptionTests/GetValidationExceptionsTests.cs
+++ b/tests/UnitTests/ScreeningDataServicesTests/ValidationExceptionDataTests/GetValidationExceptionTests/GetValidationExceptionsTests.cs
@@ -16,9 +16,9 @@ public class GetValidationExceptionsTests : DatabaseTestBaseSetup<GetValidationE
     private readonly Dictionary<string, string> columnToClassPropertyMapping;
     private readonly Mock<PaginationService<ValidationException>> _paginationServiceMock = new();
 
-    public GetValidationExceptionsTests(): base((conn, logger, transaction, command, response) => null)
+    public GetValidationExceptionsTests() : base((conn, logger, transaction, command, response) => null)
     {
-        columnToClassPropertyMapping = new Dictionary<string, string>{{ "EXCEPTION_ID", "ExceptionId" }};
+        columnToClassPropertyMapping = new Dictionary<string, string> { { "EXCEPTION_ID", "ExceptionId" } };
         _exceptionList = new List<ValidationException>
         {
             new ValidationException { ExceptionId = 1 },
@@ -45,7 +45,7 @@ public class GetValidationExceptionsTests : DatabaseTestBaseSetup<GetValidationE
     {
         // Arrange
         var exceptionId = 0;
-        _validationDataMock.Setup(s => s.GetAllExceptions()).Returns(_exceptionList);
+        _validationDataMock.Setup(s => s.GetAllExceptions(false)).Returns(_exceptionList);
         _httpParserHelperMock.Setup(s => s.GetQueryParameterAsInt(It.IsAny<HttpRequestData>(), It.IsAny<string>())).Returns(exceptionId);
         SetupRequestWithQueryParams([]);
 
@@ -55,7 +55,7 @@ public class GetValidationExceptionsTests : DatabaseTestBaseSetup<GetValidationE
         // Assert
         Assert.IsNotNull(result);
         Assert.AreEqual(HttpStatusCode.OK, result.StatusCode);
-        _validationDataMock.Verify(v => v.GetAllExceptions(), Times.Once);
+        _validationDataMock.Verify(v => v.GetAllExceptions(false), Times.Once);
     }
 
     [TestMethod]

--- a/tests/UnitTests/ScreeningValidationServiceTests/StaticValidation/StaticValidationTests.cs
+++ b/tests/UnitTests/ScreeningValidationServiceTests/StaticValidation/StaticValidationTests.cs
@@ -13,6 +13,7 @@ using Model.Enums;
 using Moq;
 using NHS.CohortManager.ScreeningValidationService;
 using RulesEngine.Models;
+using NHS.CohortManager.Tests.TestUtils;
 
 [TestClass]
 public class StaticValidationTests
@@ -1367,4 +1368,38 @@ public class StaticValidationTests
             Times.Once());
     }
     #endregion
+
+    [TestMethod]
+    public async Task Run_ValidParticipantFile_ReturnsOK()
+    {
+        // Arrange
+        _participantCsvRecord.Participant.NhsNumber = "1211111881";
+        _participantCsvRecord.Participant.RecordType = Actions.New;
+        _participantCsvRecord.Participant.AddressLine1 = "Address1";
+        _participantCsvRecord.Participant.AddressLine2 = "Address2";
+        _participantCsvRecord.Participant.AddressLine3 = "Address3";
+        _participantCsvRecord.Participant.AddressLine4 = "Address4";
+        _participantCsvRecord.Participant.AddressLine5 = "Address5";
+        _participantCsvRecord.Participant.PrimaryCareProvider = "E85121";
+        _participantCsvRecord.Participant.DateOfBirth = "20130112";
+        _participantCsvRecord.Participant.FirstName = "Test";
+        _participantCsvRecord.Participant.FamilyName = "Test";
+        _participantCsvRecord.Participant.InvalidFlag = "1";
+        _participantCsvRecord.Participant.IsInterpreterRequired = "0";
+        _participantCsvRecord.Participant.CurrentPosting = "ABC";
+        var json = JsonSerializer.Serialize(_participantCsvRecord);
+        SetUpRequestBody(json);
+
+        // Act
+        var result = await _function.RunAsync(_request.Object);
+
+        // Assert
+        string responseBody = await AssertionHelper.ReadResponseBodyAsync(result);
+        Assert.AreEqual(JsonSerializer.Serialize(new ValidationExceptionLog()
+        {
+            IsFatal = false,
+            CreatedException = false
+        }), responseBody);
+        Assert.AreEqual(HttpStatusCode.OK, result.StatusCode);
+    }
 }

--- a/tests/UnitTests/ScreeningValidationServiceTests/StaticValidation/StaticValidationTests.csproj
+++ b/tests/UnitTests/ScreeningValidationServiceTests/StaticValidation/StaticValidationTests.csproj
@@ -25,6 +25,7 @@
     <ProjectReference Include="..\..\..\..\application\CohortManager\src\Functions\ScreeningValidationService\LookupValidation\LookupValidation.csproj" />
     <ProjectReference Include="..\..\..\..\application\CohortManager\src\Functions\ScreeningValidationService\StaticValidation\StaticValidation.csproj" />
     <ProjectReference Include="..\..\..\..\application\CohortManager\src\Functions\ScreeningValidationService\FileValidation\FileValidation.csproj" />
+    <ProjectReference Include="..\..\..\TestUtils\TestUtils.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

<!-- Describe your changes in detail. -->
Adds a unit test to increase the coverage on static validation.

Also formatted a terraform file that was failing the pipeline lint check.

Also fixes a couple of failing unit tests.
## Context
[DTOSS-6391](https://nhsd-jira.digital.nhs.uk/browse/DTOSS-6391)
<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [x] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
