### PR TITLE
fix: rename lookup rule 36 and update logic 

### DIFF
--- a/application/CohortManager/src/Functions/ScreeningValidationService/LookupValidation/Breast_Screening_lookupRules.json
+++ b/application/CohortManager/src/Functions/ScreeningValidationService/LookupValidation/Breast_Screening_lookupRules.json
@@ -25,7 +25,7 @@
         "LocalParams": [
           {
             "Name": "ValidatePostingCategories",
-            "Expression": "string.IsNullOrEmpty(newParticipant.CurrentPosting) OR dbLookup.ValidatePostingCategories(newParticipant.CurrentPosting)"
+            "Expression": "string.IsNullOrEmpty(newParticipant.CurrentPosting) OR newParticipant.CurrentPosting == \"CYM\" OR dbLookup.ValidatePostingCategories(newParticipant.CurrentPosting)"
           },
           {
             "Name": "PrimaryCareProviderValid",

--- a/application/CohortManager/src/Functions/ScreeningValidationService/LookupValidation/Breast_Screening_lookupRules.json
+++ b/application/CohortManager/src/Functions/ScreeningValidationService/LookupValidation/Breast_Screening_lookupRules.json
@@ -21,18 +21,18 @@
         }
       },
       {
-        "RuleName": "36.CurrentPostingAndPrimaryProvider.NonFatal",
+        "RuleName": "36-45.CurrentPostingAndPrimaryProvider.NonFatal",
         "LocalParams": [
           {
-            "Name": "ValidatePostingCategories",
-            "Expression": "string.IsNullOrEmpty(newParticipant.CurrentPosting) OR newParticipant.CurrentPosting == \"CYM\" OR dbLookup.ValidatePostingCategories(newParticipant.CurrentPosting)"
+            "Name": "ValidPostingCategory",
+            "Expression": "dbLookup.ValidatePostingCategories(newParticipant.CurrentPosting)"
           },
           {
-            "Name": "PrimaryCareProviderValid",
-            "Expression": "string.IsNullOrEmpty(newParticipant.PrimaryCareProvider) OR dbLookup.CheckIfPrimaryCareProviderExists(newParticipant.PrimaryCareProvider)"
+            "Name": "InvalidPrimaryCareProvider",
+            "Expression": "!string.IsNullOrEmpty(newParticipant.PrimaryCareProvider) AND !dbLookup.CheckIfPrimaryCareProviderExists(newParticipant.PrimaryCareProvider)"
           }
         ],
-        "Expression": "ValidCurrentPosting AND PrimaryCareProviderValid AND ValidatePostingCategories"
+        "Expression": "!(ValidPostingCategory AND InvalidPrimaryCareProvider)"
       },
       {
         "RuleName": "58.CurrentPosting.NonFatal",

--- a/application/CohortManager/src/Functions/ScreeningValidationService/LookupValidation/Breast_Screening_lookupRules.json
+++ b/application/CohortManager/src/Functions/ScreeningValidationService/LookupValidation/Breast_Screening_lookupRules.json
@@ -21,7 +21,7 @@
         }
       },
       {
-        "RuleName": "36-45.CurrentPostingAndPrimaryProvider.NonFatal",
+        "RuleName": "3645.CurrentPostingAndPrimaryProvider.NonFatal",
         "LocalParams": [
           {
             "Name": "ValidPostingCategory",

--- a/tests/UnitTests/ScreeningValidationServiceTests/LookupValidation/LookupValidationTests.cs
+++ b/tests/UnitTests/ScreeningValidationServiceTests/LookupValidation/LookupValidationTests.cs
@@ -419,7 +419,7 @@ public class LookupValidationTests
 
         // Assert
         _exceptionHandler.Verify(handleException => handleException.CreateValidationExceptionLog(
-            It.Is<IEnumerable<RuleResultTree>>(r => r.Any(x => x.Rule.RuleName == "36-45.CurrentPostingAndPrimaryProvider.NonFatal")),
+            It.Is<IEnumerable<RuleResultTree>>(r => r.Any(x => x.Rule.RuleName == "3645.CurrentPostingAndPrimaryProvider.NonFatal")),
             It.IsAny<ParticipantCsvRecord>()),
             Times.Once());
     }
@@ -427,6 +427,7 @@ public class LookupValidationTests
     [TestMethod]
     [DataRow("InvalidCurrentPosting", "InvalidPCP")]
     [DataRow("ValidCurrentPosting", "ValidPCP")]
+    [DataRow("InvalidCurrentPosting", "ValidPCP")]
     [DataRow("ValidCurrentPosting", null)]
     [DataRow("InvalidCurrentPosting", null)]
     public async Task Run_CurrentPostingAndPrimaryProvider_DoesNotCreateException(string currentPosting, string primaryCareProvider)
@@ -446,7 +447,7 @@ public class LookupValidationTests
 
         // Assert
         _exceptionHandler.Verify(handleException => handleException.CreateValidationExceptionLog(
-            It.Is<IEnumerable<RuleResultTree>>(r => r.Any(x => x.Rule.RuleName == "36-45.CurrentPostingAndPrimaryProvider.NonFatal")),
+            It.Is<IEnumerable<RuleResultTree>>(r => r.Any(x => x.Rule.RuleName == "3645.CurrentPostingAndPrimaryProvider.NonFatal")),
             It.IsAny<ParticipantCsvRecord>()),
             Times.Never());
     }

--- a/tests/UnitTests/ScreeningValidationServiceTests/LookupValidation/LookupValidationTests.cs
+++ b/tests/UnitTests/ScreeningValidationServiceTests/LookupValidation/LookupValidationTests.cs
@@ -102,7 +102,7 @@ public class LookupValidationTests
         }
         _readRules.Setup(x => x.GetRulesFromDirectory(It.IsAny<string>()))
         .Returns(Task.FromResult<string>(json));
-        _sut = new LookupValidation(_createResponse, _exceptionHandler.Object, _mockLogger.Object,_lookupValidation.Object,_readRules.Object);
+        _sut = new LookupValidation(_createResponse, _exceptionHandler.Object, _mockLogger.Object, _lookupValidation.Object, _readRules.Object);
 
 
     }
@@ -404,6 +404,7 @@ public class LookupValidationTests
     [DataRow("InvalidCurrentPosting", "ValidPCP")]
     [DataRow("ValidCurrentPosting", "InvalidPCP")]
     [DataRow("InvalidCurrentPosting", "InvalidPCP")]
+    [DataRow("CYM", "InvalidPCP")]
     public async Task Run_CurrentPostingAndPrimaryProvider_CreatesException(string currentPosting, string primaryCareProvider)
     {
         // Arrange
@@ -432,6 +433,7 @@ public class LookupValidationTests
     [DataRow("ValidCurrentPosting", null)]
     [DataRow(null, "ValidPCP")]
     [DataRow(null, null)]
+    [DataRow("CYM", "ValidPCP")]
     public async Task Run_CurrentPostingAndPrimaryProvider_DoesNotCreateException(string currentPosting, string primaryCareProvider)
     {
         // Arrange
@@ -441,7 +443,7 @@ public class LookupValidationTests
         var json = JsonSerializer.Serialize(_requestBody);
         SetUpRequestBody(json);
 
-        _lookupValidation.Setup(x => x.CheckIfCurrentPostingExists(It.IsAny<string>())).Returns(currentPosting == "ValidCurrentPosting");
+        _lookupValidation.Setup(x => x.CheckIfCurrentPostingExists(It.IsAny<string>())).Returns(!string.IsNullOrEmpty(currentPosting));
         _lookupValidation.Setup(x => x.ValidatePostingCategories(It.IsAny<string>())).Returns(currentPosting == "ValidCurrentPosting");
         _lookupValidation.Setup(x => x.CheckIfPrimaryCareProviderExists(It.IsAny<string>())).Returns(primaryCareProvider == "ValidPCP");
 

--- a/tests/UnitTests/ScreeningValidationServiceTests/LookupValidation/LookupValidationTests.cs
+++ b/tests/UnitTests/ScreeningValidationServiceTests/LookupValidation/LookupValidationTests.cs
@@ -401,10 +401,7 @@ public class LookupValidationTests
     }
 
     [TestMethod]
-    [DataRow("InvalidCurrentPosting", "ValidPCP")]
     [DataRow("ValidCurrentPosting", "InvalidPCP")]
-    [DataRow("InvalidCurrentPosting", "InvalidPCP")]
-    [DataRow("CYM", "InvalidPCP")]
     public async Task Run_CurrentPostingAndPrimaryProvider_CreatesException(string currentPosting, string primaryCareProvider)
     {
         // Arrange
@@ -414,7 +411,6 @@ public class LookupValidationTests
         var json = JsonSerializer.Serialize(_requestBody);
         SetUpRequestBody(json);
 
-        _lookupValidation.Setup(x => x.CheckIfCurrentPostingExists(It.IsAny<string>())).Returns(currentPosting == "ValidCurrentPosting");
         _lookupValidation.Setup(x => x.ValidatePostingCategories(It.IsAny<string>())).Returns(currentPosting == "ValidCurrentPosting");
         _lookupValidation.Setup(x => x.CheckIfPrimaryCareProviderExists(It.IsAny<string>())).Returns(primaryCareProvider == "ValidPCP");
 
@@ -423,17 +419,16 @@ public class LookupValidationTests
 
         // Assert
         _exceptionHandler.Verify(handleException => handleException.CreateValidationExceptionLog(
-            It.Is<IEnumerable<RuleResultTree>>(r => r.Any(x => x.Rule.RuleName == "36.CurrentPostingAndPrimaryProvider.NonFatal")),
+            It.Is<IEnumerable<RuleResultTree>>(r => r.Any(x => x.Rule.RuleName == "36-45.CurrentPostingAndPrimaryProvider.NonFatal")),
             It.IsAny<ParticipantCsvRecord>()),
             Times.Once());
     }
 
     [TestMethod]
+    [DataRow("InvalidCurrentPosting", "InvalidPCP")]
     [DataRow("ValidCurrentPosting", "ValidPCP")]
     [DataRow("ValidCurrentPosting", null)]
-    [DataRow(null, "ValidPCP")]
-    [DataRow(null, null)]
-    [DataRow("CYM", "ValidPCP")]
+    [DataRow("InvalidCurrentPosting", null)]
     public async Task Run_CurrentPostingAndPrimaryProvider_DoesNotCreateException(string currentPosting, string primaryCareProvider)
     {
         // Arrange
@@ -443,7 +438,6 @@ public class LookupValidationTests
         var json = JsonSerializer.Serialize(_requestBody);
         SetUpRequestBody(json);
 
-        _lookupValidation.Setup(x => x.CheckIfCurrentPostingExists(It.IsAny<string>())).Returns(!string.IsNullOrEmpty(currentPosting));
         _lookupValidation.Setup(x => x.ValidatePostingCategories(It.IsAny<string>())).Returns(currentPosting == "ValidCurrentPosting");
         _lookupValidation.Setup(x => x.CheckIfPrimaryCareProviderExists(It.IsAny<string>())).Returns(primaryCareProvider == "ValidPCP");
 
@@ -452,7 +446,7 @@ public class LookupValidationTests
 
         // Assert
         _exceptionHandler.Verify(handleException => handleException.CreateValidationExceptionLog(
-            It.Is<IEnumerable<RuleResultTree>>(r => r.Any(x => x.Rule.RuleName == "36.CurrentPostingAndPrimaryProvider.NonFatal")),
+            It.Is<IEnumerable<RuleResultTree>>(r => r.Any(x => x.Rule.RuleName == "36-45.CurrentPostingAndPrimaryProvider.NonFatal")),
             It.IsAny<ParticipantCsvRecord>()),
             Times.Never());
     }


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

<!-- Describe your changes in detail. -->

This PR makes the following changes to the existing lookup rule `36.CurrentPostingAndPrimaryProvider.NonFatal`:

1. Renames it to `3645.CurrentPostingAndPrimaryProvider.NonFatal`. This is to differentiate this rule from the other rule 36, and use the rule number 45 from the spreadsheet.
2. Adds this new logic:
    - IF `posting_category` is either "ENGLAND", "DMS" or "IOM"
    - AND the `primary_care_provider` is !null
    - AND the `primary_care_provider` is not in the lookup table
    - THEN raise exception
3. Updates unit tests

## Context
[DTOSS-6291](https://nhsd-jira.digital.nhs.uk/browse/DTOSS-6291)
<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [x] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
