### PR TITLE
fix: check for null primary care provider before excluded SMU db lookup

### DIFF
--- a/application/CohortManager/src/Functions/ScreeningValidationService/LookupValidation/Breast_Screening_cohortRules.json
+++ b/application/CohortManager/src/Functions/ScreeningValidationService/LookupValidation/Breast_Screening_cohortRules.json
@@ -38,11 +38,11 @@
         "LocalParams": [
           {
             "Name": "existingParticipantPosting",
-            "Expression": "!(existingParticipant.CurrentPosting == \"DMS\" AND dbLookup.CheckIfPrimaryCareProviderInExcludedSmuList(existingParticipant.PrimaryCareProvider)) OR (dbLookup.RetrievePostingCategory(existingParticipant.CurrentPosting) == \"WALES\")"
+            "Expression": "!(existingParticipant.CurrentPosting == \"DMS\" AND !string.IsNullOrEmpty(existingParticipant.PrimaryCareProvider) AND dbLookup.CheckIfPrimaryCareProviderInExcludedSmuList(existingParticipant.PrimaryCareProvider)) OR (dbLookup.RetrievePostingCategory(existingParticipant.CurrentPosting) == \"WALES\")"
           },
           {
             "Name": "newParticipantPosting",
-            "Expression": "!(newParticipant.CurrentPosting == \"DMS\" AND dbLookup.CheckIfPrimaryCareProviderInExcludedSmuList(newParticipant.PrimaryCareProvider)) OR (dbLookup.RetrievePostingCategory(newParticipant.CurrentPosting) == \"WALES\")"
+            "Expression": "!(newParticipant.CurrentPosting == \"DMS\" AND !string.IsNullOrEmpty(newParticipant.PrimaryCareProvider) AND dbLookup.CheckIfPrimaryCareProviderInExcludedSmuList(newParticipant.PrimaryCareProvider)) OR (dbLookup.RetrievePostingCategory(newParticipant.CurrentPosting) == \"WALES\")"
           }
         ],
         "Expression": "existingParticipantPosting AND newParticipantPosting",

--- a/application/CohortManager/src/Functions/ScreeningValidationService/LookupValidation/LookupValidation.cs
+++ b/application/CohortManager/src/Functions/ScreeningValidationService/LookupValidation/LookupValidation.cs
@@ -97,15 +97,6 @@ public class LookupValidation
 
             var exceptions = resultList.Where(i => !string.IsNullOrWhiteSpace(i.ExceptionMessage));
 
-            foreach (var exp in exceptions)
-            {
-                _logger.LogError($"There was an error while executing rule {exp.Rule.RuleName} ExceptionMessage : {exp.ExceptionMessage}");
-            }
-
-
-            LoggingRulesTemp(existingParticipant, "Existing Participant");
-            LoggingRulesTemp(newParticipant, "New Participant");
-
             if (validationErrors.Any())
             {
 
@@ -133,16 +124,6 @@ public class LookupValidation
             return _createResponse.CreateHttpResponse(HttpStatusCode.InternalServerError, req);
 
         }
-    }
-
-    private void LoggingRulesTemp(Participant participant, string type)
-    {
-        _logger.LogInformation($"type: {type} current Posting :{participant.CurrentPosting}");
-        var result = !string.IsNullOrEmpty(participant.PrimaryCareProvider) ? _dataLookup.CheckIfPrimaryCareProviderInExcludedSmuList(participant.PrimaryCareProvider) : false;
-        _logger.LogInformation($"type: {type} Primary Care provider in SMU excluded list :{result.ToString()}");
-        var result2 = _dataLookup.RetrievePostingCategory(participant.CurrentPosting);
-        _logger.LogInformation($"type: {type} Current Posting Category :{result2}");
-
     }
 
     private string GetValidationRulesName(RulesType rulesType)

--- a/application/CohortManager/src/Functions/ScreeningValidationService/LookupValidation/LookupValidation.cs
+++ b/application/CohortManager/src/Functions/ScreeningValidationService/LookupValidation/LookupValidation.cs
@@ -95,8 +95,6 @@ public class LookupValidation
             // Validation rules are logically reversed
             var validationErrors = resultList.Where(x => !x.IsSuccess);
 
-            var exceptions = resultList.Where(i => !string.IsNullOrWhiteSpace(i.ExceptionMessage));
-
             if (validationErrors.Any())
             {
 

--- a/application/CohortManager/src/Functions/ScreeningValidationService/LookupValidation/LookupValidation.cs
+++ b/application/CohortManager/src/Functions/ScreeningValidationService/LookupValidation/LookupValidation.cs
@@ -97,14 +97,14 @@ public class LookupValidation
 
             var exceptions = resultList.Where(i => !string.IsNullOrWhiteSpace(i.ExceptionMessage));
 
-            foreach(var exp in exceptions)
+            foreach (var exp in exceptions)
             {
                 _logger.LogError($"There was an error while executing rule {exp.Rule.RuleName} ExceptionMessage : {exp.ExceptionMessage}");
             }
 
 
-            LoggingRulesTemp(existingParticipant,"Existing Participant");
-            LoggingRulesTemp(newParticipant,"New Participant");
+            LoggingRulesTemp(existingParticipant, "Existing Participant");
+            LoggingRulesTemp(newParticipant, "New Participant");
 
             if (validationErrors.Any())
             {
@@ -138,7 +138,7 @@ public class LookupValidation
     private void LoggingRulesTemp(Participant participant, string type)
     {
         _logger.LogInformation($"type: {type} current Posting :{participant.CurrentPosting}");
-        var result = _dataLookup.CheckIfPrimaryCareProviderInExcludedSmuList(participant.PrimaryCareProvider);
+        var result = !string.IsNullOrEmpty(participant.PrimaryCareProvider) ? _dataLookup.CheckIfPrimaryCareProviderInExcludedSmuList(participant.PrimaryCareProvider) : false;
         _logger.LogInformation($"type: {type} Primary Care provider in SMU excluded list :{result.ToString()}");
         var result2 = _dataLookup.RetrievePostingCategory(participant.CurrentPosting);
         _logger.LogInformation($"type: {type} Current Posting Category :{result2}");

--- a/application/CohortManager/src/Functions/screeningDataServices/ExcludedSMULookupDataService/ExcludedSMULookupDataServices.cs
+++ b/application/CohortManager/src/Functions/screeningDataServices/ExcludedSMULookupDataService/ExcludedSMULookupDataServices.cs
@@ -24,11 +24,11 @@ public class ExcludedSMULookupDataService
     }
 
     [Function("ExcludedSMULookupDataService")]
-    public async Task<HttpResponseData> Run([HttpTrigger(AuthorizationLevel.Anonymous, "get", "post", "put", "delete", Route = "ExcludedSMULookupDataService/{*key}")] HttpRequestData req, string? key)
+    public async Task<HttpResponseData> Run([HttpTrigger(AuthorizationLevel.Anonymous, "get", "post", "put", "delete", Route = "ExcludedSMUDataService/{*key}")] HttpRequestData req, string? key)
     {
         try
         {
-            _logger.LogInformation("DataService Request Received Method: {Method}, DataObject {DataType} " ,req.Method,typeof(ExcludedSMULookup));
+            _logger.LogInformation("DataService Request Received Method: {Method}, DataObject {DataType} ", req.Method, typeof(ExcludedSMULookup));
             var result = await _requestHandler.HandleRequest(req, key);
             return result;
         }

--- a/tests/UnitTests/ScreeningValidationServiceTests/LookupValidation/LookupValidationTests.cs
+++ b/tests/UnitTests/ScreeningValidationServiceTests/LookupValidation/LookupValidationTests.cs
@@ -607,23 +607,26 @@ public class LookupValidationTests
     #endregion
 
     [TestMethod]
-    [DataRow("DMS", false, "", "ABC", true, "")]
-    [DataRow("DMS", false, "", "ABC", true, "WALES")]
-    [DataRow("DMS", true, "WALES", "DMS", true, "WALES")]
-    public async Task Run_ParticipantLocationRemainingOutsideOfCohort_ShouldNotThrowException(string existingCurrentPosting, bool existingPrimaryCareProviderInExcludedSmuList, string existingPostingCategory, string newCurrentPosting, bool newPrimaryCareProviderInExcludedSmuList, string newPostingCategory)
+    [DataRow("DMS", "ValidPCP", "", "ABC", "ExcludedPCP", "")]
+    [DataRow("DMS", "ValidPCP", "", "ABC", "ExcludedPCP", "WALES")]
+    [DataRow("DMS", "ExcludedPCP", "WALES", "DMS", "ExcludedPCP", "WALES")]
+    [DataRow("DMS", null, "WALES", "DMS", null, "WALES")]
+    public async Task Run_ParticipantLocationRemainingOutsideOfCohort_ShouldNotThrowException(string existingCurrentPosting, string existingPrimaryCareProvider, string existingPostingCategory, string newCurrentPosting, string newPrimaryCareProvider, string newPostingCategory)
     {
         // Arrange
         SetupRules("CohortRules");
 
         _requestBody.NewParticipant.RecordType = Actions.Amended;
         _requestBody.NewParticipant.CurrentPosting = newCurrentPosting;
+        _requestBody.NewParticipant.PrimaryCareProvider = newPrimaryCareProvider;
         _requestBody.ExistingParticipant.CurrentPosting = existingCurrentPosting;
+        _requestBody.ExistingParticipant.PrimaryCareProvider = existingPrimaryCareProvider;
 
         var json = JsonSerializer.Serialize(_requestBody);
         SetUpRequestBody(json);
 
-        _lookupValidation.Setup(x => x.CheckIfPrimaryCareProviderInExcludedSmuList(It.IsAny<string>())).Returns(newPrimaryCareProviderInExcludedSmuList);
-        _lookupValidation.Setup(x => x.CheckIfPrimaryCareProviderInExcludedSmuList(It.IsAny<string>())).Returns(existingPrimaryCareProviderInExcludedSmuList);
+        _lookupValidation.Setup(x => x.CheckIfPrimaryCareProviderInExcludedSmuList(It.IsAny<string>())).Returns(newPrimaryCareProvider == "ExcludedPCP");
+        _lookupValidation.Setup(x => x.CheckIfPrimaryCareProviderInExcludedSmuList(It.IsAny<string>())).Returns(existingPrimaryCareProvider == "ExcludedPCP");
         _lookupValidation.Setup(x => x.RetrievePostingCategory(It.IsAny<string>())).Returns(newPostingCategory);
         _lookupValidation.Setup(x => x.RetrievePostingCategory(It.IsAny<string>())).Returns(existingPostingCategory);
 
@@ -638,21 +641,23 @@ public class LookupValidationTests
     }
 
     [TestMethod]
-    [DataRow("DMS", true, "", "DMS", true, "")]
-    public async Task Run_ParticipantLocationRemainingOutsideOfCohort_ShouldThrowException(string existingCurrentPosting, bool existingPrimaryCareProviderInExcludedSmuList, string existingPostingCategory, string newCurrentPosting, bool newPrimaryCareProviderInExcludedSmuList, string newPostingCategory)
+    [DataRow("DMS", "ExcludedPCP", "", "DMS", "ExcludedPCP", "")]
+    public async Task Run_ParticipantLocationRemainingOutsideOfCohort_ShouldThrowException(string existingCurrentPosting, string existingPrimaryCareProvider, string existingPostingCategory, string newCurrentPosting, string newPrimaryCareProvider, string newPostingCategory)
     {
         // Arrange
         SetupRules("CohortRules");
 
         _requestBody.NewParticipant.RecordType = Actions.Amended;
         _requestBody.NewParticipant.CurrentPosting = newCurrentPosting;
+        _requestBody.NewParticipant.PrimaryCareProvider = newPrimaryCareProvider;
         _requestBody.ExistingParticipant.CurrentPosting = existingCurrentPosting;
+        _requestBody.ExistingParticipant.PrimaryCareProvider = existingPrimaryCareProvider;
 
         var json = JsonSerializer.Serialize(_requestBody);
         SetUpRequestBody(json);
 
-        _lookupValidation.Setup(x => x.CheckIfPrimaryCareProviderInExcludedSmuList(It.IsAny<string>())).Returns(newPrimaryCareProviderInExcludedSmuList);
-        _lookupValidation.Setup(x => x.CheckIfPrimaryCareProviderInExcludedSmuList(It.IsAny<string>())).Returns(existingPrimaryCareProviderInExcludedSmuList);
+        _lookupValidation.Setup(x => x.CheckIfPrimaryCareProviderInExcludedSmuList(It.IsAny<string>())).Returns(newPrimaryCareProvider == "ExcludedPCP");
+        _lookupValidation.Setup(x => x.CheckIfPrimaryCareProviderInExcludedSmuList(It.IsAny<string>())).Returns(existingPrimaryCareProvider == "ExcludedPCP");
         _lookupValidation.Setup(x => x.RetrievePostingCategory(It.IsAny<string>())).Returns(newPostingCategory);
         _lookupValidation.Setup(x => x.RetrievePostingCategory(It.IsAny<string>())).Returns(existingPostingCategory);
 


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

<!-- Describe your changes in detail. -->
Fixes an error when rule 51 receives a null primary care provider.

This is valid and should not cause rule 51 to raise an exception.

Updates the unit tests to reflect this.

Also removes some temp logging in LookupValidation function.

And fixes the URL in Excluded SMU lookup.
## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [x] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
