### PR TITLE
fix: dtoss 6456 increase unit test coverage mark participant as ineligible

### DIFF
--- a/tests/UnitTests/ScreeningDataServicesTests/MarkParticipantAsIneligibleTests/MarkParticipantAsIneligibleTests.cs
+++ b/tests/UnitTests/ScreeningDataServicesTests/MarkParticipantAsIneligibleTests/MarkParticipantAsIneligibleTests.cs
@@ -170,7 +170,7 @@ public class MarkParticipantAsIneligibleTests
     }
 
     [TestMethod]
-    public async Task Run_Should_Return_BadRequest_When_UpdateParticipantAsEligible_Response_Is_Fatal()
+    public async Task Run_UpdateParticipantAsEligible_Response_Is_Fatal()
     {
         // Arrange
         var json = JsonSerializer.Serialize(_requestBody);

--- a/tests/UnitTests/ScreeningDataServicesTests/MarkParticipantAsIneligibleTests/MarkParticipantAsIneligibleTests.cs
+++ b/tests/UnitTests/ScreeningDataServicesTests/MarkParticipantAsIneligibleTests/MarkParticipantAsIneligibleTests.cs
@@ -169,6 +169,32 @@ public class MarkParticipantAsIneligibleTests
         Assert.AreEqual(HttpStatusCode.BadRequest, result.StatusCode);
     }
 
+    [TestMethod]
+    public async Task Run_Should_Return_BadRequest_When_UpdateParticipantAsEligible_Response_Is_Fatal()
+    {
+        // Arrange
+        var json = JsonSerializer.Serialize(_requestBody);
+        SetUpRequestBody(json);
+
+        _webResponse.Setup(x => x.StatusCode).Returns(HttpStatusCode.OK);
+        _callFunction.Setup(call => call.SendPost(It.Is<string>(s => s.Contains("LookupValidationURL")), It.IsAny<string>()))
+            .Returns(Task.FromResult<HttpWebResponse>(_webResponse.Object));
+
+        _callFunction.Setup(x => x.GetResponseText(It.IsAny<HttpWebResponse>())).Returns(Task.FromResult<string>(
+            JsonSerializer.Serialize(new ValidationExceptionLog()
+            {
+                IsFatal = true,
+                CreatedException = true
+            })));
+
+        // Act
+        var result = await _function.RunAsync(_request.Object);
+
+        // Assert
+        Assert.AreEqual(HttpStatusCode.BadRequest, result.StatusCode);
+    }
+
+
     private void SetUpRequestBody(string json)
     {
         var byteArray = Encoding.ASCII.GetBytes(json);


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

<!-- Describe your changes in detail. -->

## Context

Added new tests to increase test coverage to 84%.
https://nhsd-jira.digital.nhs.uk/browse/DTOSS-6456

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
