### PR TITLE
fix: 1st requestId Bug

### DIFF
--- a/application/CohortManager/src/Functions/Shared/Data/Database/CreateCohortDistributionData.cs
+++ b/application/CohortManager/src/Functions/Shared/Data/Database/CreateCohortDistributionData.cs
@@ -530,12 +530,14 @@ public class CreateCohortDistributionData : ICreateCohortDistributionData
             " WHERE CREATED_DATETIME >= ( " +
             " SELECT CREATED_DATETIME " +
             " FROM [dbo].[BS_SELECT_REQUEST_AUDIT] " +
-            " WHERE REQUEST_ID = @lastRequestId)" +
+            " WHERE REQUEST_ID = @RequestId)" +
+            " AND STATUS_CODE != @StatusCode " +
             " ORDER BY CREATED_DATETIME ASC";
 
         var parameters = new Dictionary<string, object>
         {
-            {"@LastRequestId", requestId},
+            {"@RequestId", requestId},
+            {"@StatusCode", HttpStatusCode.NoContent.ToString()}
         };
 
         using var command = CreateCommand(parameters);

--- a/application/CohortManager/src/Functions/Shared/Data/Database/CreateCohortDistributionData.cs
+++ b/application/CohortManager/src/Functions/Shared/Data/Database/CreateCohortDistributionData.cs
@@ -527,7 +527,7 @@ public class CreateCohortDistributionData : ICreateCohortDistributionData
     {
         var sql = "SELECT TOP 1 [REQUEST_ID], [STATUS_CODE], [CREATED_DATETIME] " +
             " FROM [dbo].[BS_SELECT_REQUEST_AUDIT] " +
-            " WHERE CREATED_DATETIME > ( " +
+            " WHERE CREATED_DATETIME >= ( " +
             " SELECT CREATED_DATETIME " +
             " FROM [dbo].[BS_SELECT_REQUEST_AUDIT] " +
             " WHERE REQUEST_ID = @lastRequestId)" +


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

1st request not returning 2nd due to time logic 
SQL refactored to include all statusCodes Except 204 no content 

## Context

Bug raised by testers exposed 1st requestId issue. 

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
