### PR TITLE
fix: unhandled exception being caught

### DIFF
--- a/application/CohortManager/src/Functions/ParticipantManagementServices/addParticipant/addParticipant.cs
+++ b/application/CohortManager/src/Functions/ParticipantManagementServices/addParticipant/addParticipant.cs
@@ -139,8 +139,8 @@ public class AddParticipantFunction
         }
         catch (Exception ex)
         {
-            _logger.LogInformation(ex, "Static validation failed.\nMessage: {Message}\nParticipant: {ParticipantCsvRecord}", ex.Message, participantCsvRecord);
-            return null;
+            _logger.LogInformation(ex, "API Call to Static validation failed.\nMessage: {Message}\nParticipant: {ParticipantCsvRecord}", ex.Message, participantCsvRecord);
+            throw;
         }
     }
 }

--- a/application/CohortManager/src/Functions/ParticipantManagementServices/addParticipant/addParticipant.cs
+++ b/application/CohortManager/src/Functions/ParticipantManagementServices/addParticipant/addParticipant.cs
@@ -117,30 +117,23 @@ public class AddParticipantFunction
     {
         var json = JsonSerializer.Serialize(participantCsvRecord);
 
-        try
+        if (string.IsNullOrWhiteSpace(participantCsvRecord.Participant.ScreeningName))
         {
-            if (string.IsNullOrWhiteSpace(participantCsvRecord.Participant.ScreeningName))
+            var errorDescription = $"A record with Nhs Number: {participantCsvRecord.Participant.NhsNumber} has invalid screening name and therefore cannot be processed by the static validation function";
+            await _handleException.CreateRecordValidationExceptionLog(participantCsvRecord.Participant.NhsNumber, participantCsvRecord.FileName, errorDescription, "", JsonSerializer.Serialize(participantCsvRecord.Participant));
+
+            return new ValidationExceptionLog()
             {
-                var errorDescription = $"A record with Nhs Number: {participantCsvRecord.Participant.NhsNumber} has invalid screening name and therefore cannot be processed by the static validation function";
-                await _handleException.CreateRecordValidationExceptionLog(participantCsvRecord.Participant.NhsNumber, participantCsvRecord.FileName, errorDescription, "", JsonSerializer.Serialize(participantCsvRecord.Participant));
-
-                return new ValidationExceptionLog()
-                {
-                    IsFatal = false,
-                    CreatedException = true
-                };
-            }
-
-            var response = await _callFunction.SendPost(Environment.GetEnvironmentVariable("StaticValidationURL"), json);
-            var responseBodyJson = await _callFunction.GetResponseText(response);
-            var responseBody = JsonSerializer.Deserialize<ValidationExceptionLog>(responseBodyJson);
-
-            return responseBody;
+                IsFatal = false,
+                CreatedException = true
+            };
         }
-        catch (Exception ex)
-        {
-            _logger.LogInformation(ex, "API Call to Static validation failed.\nMessage: {Message}\nParticipant: {ParticipantCsvRecord}", ex.Message, participantCsvRecord);
-            throw;
-        }
+
+        var response = await _callFunction.SendPost(Environment.GetEnvironmentVariable("StaticValidationURL"), json);
+        var responseBodyJson = await _callFunction.GetResponseText(response);
+        var responseBody = JsonSerializer.Deserialize<ValidationExceptionLog>(responseBodyJson);
+
+        return responseBody;
+
     }
 }


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Changed from returning null from method to Rethrowing exception.

## Context

By returning null this was causing a null reference exception which is misleading given it was an http exception.
As the exception couldn't be handled in the catch block we will just re-throw the exception so it doens't cause further misleading exception.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
