### PR TITLE
fix: Removed screeningServiceId and references 

### DIFF
--- a/application/CohortManager/src/Functions/CohortDistributionServices/RetrieveCohortDistribution/RetrieveCohortDistribution.cs
+++ b/application/CohortManager/src/Functions/CohortDistributionServices/RetrieveCohortDistribution/RetrieveCohortDistribution.cs
@@ -43,7 +43,6 @@ public class RetrieveCohortDistributionData
     public async Task<HttpResponseData> Run([HttpTrigger(AuthorizationLevel.Anonymous, "get")] HttpRequestData req)
     {
         var requestId = req.Query["requestId"];
-        int screeningServiceId = _httpParserHelper.GetQueryParameterAsInt(req, "screeningServiceId");
         int rowCount = _httpParserHelper.GetQueryParameterAsInt(req, "rowCount");
         var cohortDistributionParticipants = new List<CohortDistributionParticipantDto>();
 
@@ -61,7 +60,7 @@ public class RetrieveCohortDistributionData
             if (cohortDistributionParticipants.Count == 0)
             {
                 cohortDistributionParticipants = _createCohortDistributionData
-                .GetUnextractedCohortDistributionParticipantsByScreeningServiceId(screeningServiceId, rowCount);
+                .GetUnextractedCohortDistributionParticipantsByScreeningServiceId(rowCount);
             }
 
             return cohortDistributionParticipants.Count == 0

--- a/application/CohortManager/src/Functions/Shared/Common/Interfaces/ICreateCohortDistributionData.cs
+++ b/application/CohortManager/src/Functions/Shared/Common/Interfaces/ICreateCohortDistributionData.cs
@@ -6,7 +6,7 @@ using Model.DTO;
 public interface ICreateCohortDistributionData
 {
     bool InsertCohortDistributionData(CohortDistributionParticipant cohortDistributionParticipant);
-    List<CohortDistributionParticipantDto> GetUnextractedCohortDistributionParticipantsByScreeningServiceId(int screeningServiceId, int rowCount);
+    List<CohortDistributionParticipantDto> GetUnextractedCohortDistributionParticipantsByScreeningServiceId(int rowCount);
     bool UpdateCohortParticipantAsInactive(string NhsNumber);
     CohortDistributionParticipant GetLastCohortDistributionParticipant(string NhsNumber);
     List<CohortDistributionParticipantDto> GetCohortDistributionParticipantsByRequestId(string requestId);

--- a/application/CohortManager/src/Functions/Shared/Data/Database/CreateCohortDistributionData.cs
+++ b/application/CohortManager/src/Functions/Shared/Data/Database/CreateCohortDistributionData.cs
@@ -149,7 +149,7 @@ public class CreateCohortDistributionData : ICreateCohortDistributionData
         return UpdateRecords(SQLToExecuteInOrder);
     }
 
-    public List<CohortDistributionParticipantDto> GetUnextractedCohortDistributionParticipantsByScreeningServiceId(int screeningServiceId, int rowCount)
+    public List<CohortDistributionParticipantDto> GetUnextractedCohortDistributionParticipantsByScreeningServiceId(int rowCount)
     {
         var SQL = "SELECT TOP (@RowCount)" +
             " bcd.[PARTICIPANT_ID], " +
@@ -202,7 +202,7 @@ public class CreateCohortDistributionData : ICreateCohortDistributionData
 
         var listOfAllParticipants = GetParticipant(command);
         var requestId = Guid.NewGuid().ToString();
-        if (MarkCohortDistributionParticipantsAsExtracted(listOfAllParticipants, requestId, screeningServiceId))
+        if (MarkCohortDistributionParticipantsAsExtracted(listOfAllParticipants, requestId))
         {
             LogRequestAudit(requestId, (int)HttpStatusCode.OK);
             return CohortDistributionParticipantDto(listOfAllParticipants);
@@ -478,7 +478,7 @@ public class CreateCohortDistributionData : ICreateCohortDistributionData
         });
     }
 
-    private bool MarkCohortDistributionParticipantsAsExtracted(List<CohortDistributionParticipant> cohortParticipants, string requestId, int screeningServiceId)
+    private bool MarkCohortDistributionParticipantsAsExtracted(List<CohortDistributionParticipant> cohortParticipants, string requestId)
     {
         if (cohortParticipants == null || cohortParticipants.Count == 0) return false;
 
@@ -504,7 +504,6 @@ public class CreateCohortDistributionData : ICreateCohortDistributionData
 
             participant.Extracted = "1";
             participant.RequestId = requestId;
-            participant.ScreeningServiceId = screeningServiceId.ToString();
             participant.ScreeningAcronym = nameof(ServiceProvider.BSS);
             participant.ScreeningName = EnumHelper.GetDisplayName(ServiceProvider.BSS);
         }

--- a/application/CohortManager/src/Functions/Shared/Model/CohortDistributionParticipant.cs
+++ b/application/CohortManager/src/Functions/Shared/Model/CohortDistributionParticipant.cs
@@ -37,7 +37,6 @@ public class CohortDistributionParticipant
     public string? RecordInsertDateTime { get; set; }
     public string? RecordUpdateDateTime { get; set; }
     public string? Extracted { get; set; }
-    public int? ServiceProviderId { get; set; }
     public string? ScreeningAcronym { get; set; }
     public string? ScreeningServiceId { get; set; }
     public string? ScreeningName { get; set; }

--- a/tests/UnitTests/CohortDistributionTests/CohortDistributionDataTests/AddCohortDistributionTests.cs
+++ b/tests/UnitTests/CohortDistributionTests/CohortDistributionDataTests/AddCohortDistributionTests.cs
@@ -4,7 +4,6 @@ using System.Data;
 using Data.Database;
 using Microsoft.Extensions.Logging;
 using Model;
-using Model.Enums;
 using Moq;
 [TestClass]
 public class AddCohortDistributionTests
@@ -17,9 +16,7 @@ public class AddCohortDistributionTests
     private readonly Mock<IDbDataParameter> _mockParameter = new();
     private readonly Mock<IDbTransaction> _mockTransaction = new();
     private readonly CreateCohortDistributionData _createCohortDistributionData;
-    private const int serviceProviderId = (int)ServiceProvider.BSS;
     private readonly string _requestId = new Guid().ToString();
-    private const int _rowCount = 1;
 
     public AddCohortDistributionTests()
     {
@@ -95,7 +92,7 @@ public class AddCohortDistributionTests
         var rowCount = 1;
 
         // Act
-        var result = _createCohortDistributionData.GetUnextractedCohortDistributionParticipantsByScreeningServiceId(serviceProviderId, rowCount);
+        var result = _createCohortDistributionData.GetUnextractedCohortDistributionParticipantsByScreeningServiceId(rowCount);
 
         // Assert
         Assert.AreEqual("1", result.FirstOrDefault()?.ParticipantId);
@@ -116,7 +113,7 @@ public class AddCohortDistributionTests
         var rowCount = 1;
 
         // Act
-        var result = _createCohortDistributionData.GetUnextractedCohortDistributionParticipantsByScreeningServiceId(serviceProviderId, rowCount);
+        var result = _createCohortDistributionData.GetUnextractedCohortDistributionParticipantsByScreeningServiceId(rowCount);
 
         // Assert
         _commandMock.Verify(x => x.ExecuteNonQuery(), Times.AtLeast(2));
@@ -136,7 +133,7 @@ public class AddCohortDistributionTests
         var rowCount = 0;
 
         // Act
-        var result = _createCohortDistributionData.GetUnextractedCohortDistributionParticipantsByScreeningServiceId(serviceProviderId, rowCount);
+        var result = _createCohortDistributionData.GetUnextractedCohortDistributionParticipantsByScreeningServiceId(rowCount);
 
         // Assert
         Assert.IsNotNull(result);


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Removed ScreeningServiceId as we are only calling BS table 
Updated tests 
Updated documentation 
## Context

https://nhsd-jira.digital.nhs.uk/browse/DTOSS-6726
https://nhsd-confluence.digital.nhs.uk/display/DTS/%3C%3CWIP%3E%3E+Release+0+Cohort+Manager+API+Design

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [x] I have added tests to cover my changes
- [x] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
