### PR TITLE
feat: DTOSS-4567-static-validations-separated-into-different-workflows

### DIFF
--- a/application/CohortManager/src/Functions/ScreeningValidationService/StaticValidation/Breast_Screening_staticRules.json
+++ b/application/CohortManager/src/Functions/ScreeningValidationService/StaticValidation/Breast_Screening_staticRules.json
@@ -63,18 +63,6 @@
         }
       },
       {
-        "RuleName": "71.NewParticipantWithNoAddress.NonFatal",
-        "Expression": "!(participant.RecordType == Actions.New AND string.IsNullOrEmpty(participant.AddressLine1) AND string.IsNullOrEmpty(participant.AddressLine2) AND string.IsNullOrEmpty(participant.AddressLine3) AND string.IsNullOrEmpty(participant.AddressLine4) AND string.IsNullOrEmpty(participant.AddressLine5))",
-        "Actions": {
-          "OnFailure": {
-            "Name": "OutputExpression",
-            "Context": {
-              "Expression": "\"Address is missing\""
-            }
-          }
-        }
-      },
-      {
         "RuleName": "3.PrimaryCareProviderAndReasonForRemoval.NonFatal",
         "Expression": "(string.IsNullOrEmpty(participant.PrimaryCareProvider) AND !string.IsNullOrEmpty(participant.ReasonForRemoval)) OR (!string.IsNullOrEmpty(participant.PrimaryCareProvider) AND string.IsNullOrEmpty(participant.ReasonForRemoval))",
         "Actions": {
@@ -130,32 +118,6 @@
             "Name": "OutputExpression",
             "Context": {
               "Expression": "\"GP practice code invalid\""
-            }
-          }
-        }
-      },
-      {
-        "RuleName": "66.DeathStatus.NonFatal",
-        "LocalParams": [
-          {
-            "Name": "IsUpdateRequest",
-            "Expression": "participant.RecordType == Actions.Amended"
-          },
-          {
-            "Name": "DeathStatusFormal",
-            "Expression": "participant.DeathStatus != null && participant.DeathStatus == Status.Formal"
-          },
-          {
-            "Name": "ReasonForRemovalNotDEA",
-            "Expression": "string.isNullOrEmpty(participant.ReasonForRemoval) OR participant.ReasonForRemoval  != \"DEA\""
-          }
-        ],
-        "Expression": "IsUpdateRequest ? !(DeathStatusFormal && ReasonForRemovalNotDEA) : true",
-        "Actions": {
-          "OnFailure": {
-            "Name": "OutputExpression",
-            "Context": {
-              "Expression": "\"Invalid death status\""
             }
           }
         }
@@ -312,6 +274,54 @@
             "Name": "OutputExpression",
             "Context": {
               "Expression": "\"Invalid eligibility flag.\""
+            }
+          }
+        }
+      }
+    ]
+  },
+  {
+    "WorkflowName": "ADD",
+    "Rules": [
+      {
+        "RuleName": "71.NewParticipantWithNoAddress.NonFatal",
+        "Expression": "!(participant.RecordType == Actions.New AND string.IsNullOrEmpty(participant.AddressLine1) AND string.IsNullOrEmpty(participant.AddressLine2) AND string.IsNullOrEmpty(participant.AddressLine3) AND string.IsNullOrEmpty(participant.AddressLine4) AND string.IsNullOrEmpty(participant.AddressLine5))",
+        "Actions": {
+          "OnFailure": {
+            "Name": "OutputExpression",
+            "Context": {
+              "Expression": "\"Address is missing\""
+            }
+          }
+        }
+      }
+    ]
+  },
+  {
+    "WorkflowName": "AMENDED",
+    "Rules": [
+      {
+        "RuleName": "66.DeathStatus.NonFatal",
+        "LocalParams": [
+          {
+            "Name": "IsUpdateRequest",
+            "Expression": "participant.RecordType == Actions.Amended"
+          },
+          {
+            "Name": "DeathStatusFormal",
+            "Expression": "participant.DeathStatus != null && participant.DeathStatus == Status.Formal"
+          },
+          {
+            "Name": "ReasonForRemovalNotDEA",
+            "Expression": "string.isNullOrEmpty(participant.ReasonForRemoval) OR participant.ReasonForRemoval  != \"DEA\""
+          }
+        ],
+        "Expression": "IsUpdateRequest ? !(DeathStatusFormal && ReasonForRemovalNotDEA) : true",
+        "Actions": {
+          "OnFailure": {
+            "Name": "OutputExpression",
+            "Context": {
+              "Expression": "\"Invalid death status\""
             }
           }
         }

--- a/application/CohortManager/src/Functions/ScreeningValidationService/StaticValidation/StaticValidation.cs
+++ b/application/CohortManager/src/Functions/ScreeningValidationService/StaticValidation/StaticValidation.cs
@@ -60,6 +60,14 @@ public class StaticValidation
                 new RuleParameter("participant", participantCsvRecord.Participant),
             };
             var resultList = await re.ExecuteAllRulesAsync("Common", ruleParameters);
+
+             if (re.GetAllRegisteredWorkflowNames().Contains(participantCsvRecord.Participant.RecordType))
+            {
+                _logger.LogInformation("Executing workflow {RecordType}", participantCsvRecord.Participant.RecordType);
+                var ActionResults = await re.ExecuteAllRulesAsync(participantCsvRecord.Participant.RecordType, ruleParameters);
+                resultList.AddRange(ActionResults);
+            }
+
             var validationErrors = resultList.Where(x => !x.IsSuccess);
 
             await RemoveOldValidationRecord(participantCsvRecord.Participant.NhsNumber, participantCsvRecord.Participant.ScreeningName);


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description
-  Static rules are segregated into different workflows namely- Common, ADD and AMENDED

## Context
[DTOSS-4567](https://nhsd-jira.digital.nhs.uk/browse/DTOSS-4567)

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
