### PR TITLE
test: add CreateException unit tests

### DIFF
--- a/application/CohortManager/src/Functions/ExceptionHandling/CreateException/CreateException.cs
+++ b/application/CohortManager/src/Functions/ExceptionHandling/CreateException/CreateException.cs
@@ -10,12 +10,12 @@ using Model;
 using Common;
 using Data.Database;
 
-public class CreateExceptionRecord
+public class CreateException
 {
-    private readonly ILogger<CreateExceptionRecord> _logger;
+    private readonly ILogger<CreateException> _logger;
     private readonly IValidationExceptionData _validationData;
     private readonly ICreateResponse _createResponse;
-    public CreateExceptionRecord(ILogger<CreateExceptionRecord> logger, IValidationExceptionData validationExceptionData, ICreateResponse createResponse)
+    public CreateException(ILogger<CreateException> logger, IValidationExceptionData validationExceptionData, ICreateResponse createResponse)
     {
         _logger = logger;
         _validationData = validationExceptionData;

--- a/application/CohortManager/src/Functions/ExceptionHandling/CreateException/CreateException.cs
+++ b/application/CohortManager/src/Functions/ExceptionHandling/CreateException/CreateException.cs
@@ -22,7 +22,7 @@ public class CreateExceptionRecord
         _createResponse = createResponse;
     }
 
-    [Function("CreateExceptionRecord")]
+    [Function("CreateException")]
     public async Task<HttpResponseData> RunAsync([HttpTrigger(AuthorizationLevel.Anonymous, "get", "post")] HttpRequestData req)
     {
         ValidationException exception;

--- a/application/CohortManager/src/Functions/ExceptionHandling/CreateException/CreateException.cs
+++ b/application/CohortManager/src/Functions/ExceptionHandling/CreateException/CreateException.cs
@@ -10,48 +10,44 @@ using Model;
 using Common;
 using Data.Database;
 
-public class CreateException
+public class CreateExceptionRecord
 {
-    private readonly ILogger<CreateException> _logger;
+    private readonly ILogger<CreateExceptionRecord> _logger;
     private readonly IValidationExceptionData _validationData;
-
     private readonly ICreateResponse _createResponse;
-    public CreateException(ILogger<CreateException> logger, IValidationExceptionData validationExceptionData, ICreateResponse createResponse)
+    public CreateExceptionRecord(ILogger<CreateExceptionRecord> logger, IValidationExceptionData validationExceptionData, ICreateResponse createResponse)
     {
         _logger = logger;
         _validationData = validationExceptionData;
         _createResponse = createResponse;
     }
 
-    [Function("CreateException")]
+    [Function("CreateExceptionRecord")]
     public async Task<HttpResponseData> RunAsync([HttpTrigger(AuthorizationLevel.Anonymous, "get", "post")] HttpRequestData req)
     {
+        ValidationException exception;
+
         try
         {
-            ValidationException exception;
-            var requestBody = "";
-
             using (var reader = new StreamReader(req.Body, Encoding.UTF8))
             {
-                requestBody = await reader.ReadToEndAsync();
+                var requestBody = await reader.ReadToEndAsync();
                 exception = JsonSerializer.Deserialize<ValidationException>(requestBody);
             }
-            if (!string.IsNullOrEmpty(requestBody))
-            {
-                if (_validationData.Create(exception))
-                {
-                    return _createResponse.CreateHttpResponse(HttpStatusCode.OK, req);
-                }
-            }
-            return req.CreateResponse(HttpStatusCode.BadRequest);
-
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "there has been an error while creating an exception record: {Message}", ex.Message);
-            return req.CreateResponse(HttpStatusCode.InternalServerError);
+            _logger.LogError(ex, ex.Message);
+            return _createResponse.CreateHttpResponse(HttpStatusCode.BadRequest, req);
         }
 
+        if (_validationData.Create(exception))
+        {
+            _logger.LogInformation("The exception record has been created successfully");
+            return _createResponse.CreateHttpResponse(HttpStatusCode.Created, req);
+        }
+
+        _logger.LogError("The exception record was not inserted into the database: {Exception}", exception);
+        return _createResponse.CreateHttpResponse(HttpStatusCode.InternalServerError, req);
     }
 }
-

--- a/application/CohortManager/src/Functions/Functions.sln
+++ b/application/CohortManager/src/Functions/Functions.sln
@@ -174,6 +174,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ValidateDatesTests", "..\..
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DataServiceTests", "..\..\..\..\tests\UnitTests\DataServiceTests\DataServiceTests.csproj", "{E26B2D73-BD60-4AD8-B403-939ACEDE9429}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CreateExceptionTests", "..\..\..\..\tests\UnitTests\ExceptionHandlingTests\CreateExceptionTests\CreateExceptionTests.csproj", "{190F304E-D716-4A65-985D-042BF7B22460}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -440,6 +442,10 @@ Global
 		{E26B2D73-BD60-4AD8-B403-939ACEDE9429}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E26B2D73-BD60-4AD8-B403-939ACEDE9429}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E26B2D73-BD60-4AD8-B403-939ACEDE9429}.Release|Any CPU.Build.0 = Release|Any CPU
+		{190F304E-D716-4A65-985D-042BF7B22460}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{190F304E-D716-4A65-985D-042BF7B22460}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{190F304E-D716-4A65-985D-042BF7B22460}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{190F304E-D716-4A65-985D-042BF7B22460}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/tests/UnitTests/ExceptionHandlingTests/CreateExceptionTests/CreateExceptionTests.cs
+++ b/tests/UnitTests/ExceptionHandlingTests/CreateExceptionTests/CreateExceptionTests.cs
@@ -1,0 +1,108 @@
+namespace NHS.CohortManager.Tests.UnitTests.CreateExceptionTests;
+
+using System.Net;
+using Microsoft.Extensions.Logging;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Moq;
+using Model;
+using Common;
+using Data.Database;
+using NHS.CohortManager.ExceptionService;
+using System.Text.Json;
+using System.Text;
+
+[TestClass]
+public class CreateExceptionTests
+{
+    private readonly Mock<ILogger<CreateExceptionRecord>> _logger = new();
+    private readonly Mock<FunctionContext> _context = new();
+    private readonly Mock<HttpRequestData> _request;
+    private readonly ValidationException _requestBody;
+    private readonly CreateExceptionRecord _function;
+    private readonly Mock<ICreateResponse> _createResponse = new();
+    private readonly Mock<IValidationExceptionData> _validationExceptionData = new();
+
+    public CreateExceptionTests()
+    {
+        _request = new Mock<HttpRequestData>(_context.Object);
+
+        _requestBody = new ValidationException() { ExceptionId = 1 };
+
+        _function = new CreateExceptionRecord(_logger.Object, _validationExceptionData.Object, _createResponse.Object);
+
+        _request.Setup(r => r.CreateResponse()).Returns(() =>
+        {
+            var response = new Mock<HttpResponseData>(_context.Object);
+            response.SetupProperty(r => r.Headers, new HttpHeadersCollection());
+            response.SetupProperty(r => r.StatusCode);
+            response.SetupProperty(r => r.Body, new MemoryStream());
+            return response.Object;
+        });
+
+        _createResponse.Setup(x => x.CreateHttpResponse(It.IsAny<HttpStatusCode>(), It.IsAny<HttpRequestData>(), It.IsAny<string>()))
+            .Returns((HttpStatusCode statusCode, HttpRequestData req, string ResponseBody) =>
+            {
+                var response = req.CreateResponse(statusCode);
+                response.Headers.Add("Content-Type", "application/json; charset=utf-8");
+                response.WriteString(ResponseBody);
+                return response;
+            });
+
+        var json = JsonSerializer.Serialize(_requestBody);
+        SetUpRequestBody(json);
+    }
+
+    [TestMethod]
+    public async Task Run_EmptyRequest_ReturnBadRequest()
+    {
+        // Arrange
+        SetUpRequestBody(string.Empty);
+
+        // Act
+        var result = await _function.RunAsync(_request.Object);
+
+        // Assert
+        Assert.IsNotNull(result);
+        Assert.AreEqual(HttpStatusCode.BadRequest, result.StatusCode);
+    }
+
+    [TestMethod]
+    public async Task Run_ExceptionRecordCreated_ReturnsCreated()
+    {
+        // Arrange
+        _validationExceptionData.Setup(s => s.Create(It.IsAny<ValidationException>())).Returns(true);
+
+        // Act
+        var result = await _function.RunAsync(_request.Object);
+
+        // Assert
+        Assert.IsNotNull(result);
+        _validationExceptionData.Verify(v => v.Create(It.IsAny<ValidationException>()), Times.Once);
+        Assert.AreEqual(HttpStatusCode.Created, result.StatusCode);
+    }
+
+    [TestMethod]
+    public async Task Run_ExceptionRecordFailedToCreate_ReturnsInternalServerError()
+    {
+        // Arrange
+        _validationExceptionData.Setup(s => s.Create(It.IsAny<ValidationException>())).Returns(false);
+
+        // Act
+        var result = await _function.RunAsync(_request.Object);
+
+        // Assert
+        Assert.IsNotNull(result);
+        _validationExceptionData.Verify(v => v.Create(It.IsAny<ValidationException>()), Times.Once);
+        Assert.AreEqual(HttpStatusCode.InternalServerError, result.StatusCode);
+    }
+
+    private void SetUpRequestBody(string json)
+    {
+        var byteArray = Encoding.ASCII.GetBytes(json);
+        var bodyStream = new MemoryStream(byteArray);
+
+        _request.Setup(r => r.Body).Returns(bodyStream);
+    }
+}
+

--- a/tests/UnitTests/ExceptionHandlingTests/CreateExceptionTests/CreateExceptionTests.cs
+++ b/tests/UnitTests/ExceptionHandlingTests/CreateExceptionTests/CreateExceptionTests.cs
@@ -15,11 +15,11 @@ using System.Text;
 [TestClass]
 public class CreateExceptionTests
 {
-    private readonly Mock<ILogger<CreateExceptionRecord>> _logger = new();
+    private readonly Mock<ILogger<CreateException>> _logger = new();
     private readonly Mock<FunctionContext> _context = new();
     private readonly Mock<HttpRequestData> _request;
     private readonly ValidationException _requestBody;
-    private readonly CreateExceptionRecord _function;
+    private readonly CreateException _function;
     private readonly Mock<ICreateResponse> _createResponse = new();
     private readonly Mock<IValidationExceptionData> _validationExceptionData = new();
 
@@ -29,7 +29,7 @@ public class CreateExceptionTests
 
         _requestBody = new ValidationException() { ExceptionId = 1 };
 
-        _function = new CreateExceptionRecord(_logger.Object, _validationExceptionData.Object, _createResponse.Object);
+        _function = new CreateException(_logger.Object, _validationExceptionData.Object, _createResponse.Object);
 
         _request.Setup(r => r.CreateResponse()).Returns(() =>
         {

--- a/tests/UnitTests/ExceptionHandlingTests/CreateExceptionTests/CreateExceptionTests.csproj
+++ b/tests/UnitTests/ExceptionHandlingTests/CreateExceptionTests/CreateExceptionTests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../../../application/CohortManager/src/Functions/ExceptionHandling/CreateException/CreateException.csproj" />
+    <ProjectReference Include="../../../../application/CohortManager/src/Functions/Shared/Data/Data.csproj" />
+    <ProjectReference Include="../../../../application/CohortManager/src/Functions/Shared/Model/Model.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Adds 100% unit test coverage to `CreateException` function.

Note: the changes to `CreateException` are the same as in my other open [PR](https://github.com/NHSDigital/dtos-cohort-manager/pull/565). This PR simply adds a new test project for coverage.
<!-- Describe your changes in detail. -->

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [x] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
