### PR TITLE
fix: mesh file name bug

### DIFF
--- a/application/CohortManager/src/Functions/Shared/Common/MeshToBlobTransferHandler.cs
+++ b/application/CohortManager/src/Functions/Shared/Common/MeshToBlobTransferHandler.cs
@@ -154,7 +154,7 @@ public class MeshToBlobTransferHandler : IMeshToBlobTransferHandler
             return null;
         }
 
-        string fileName = string.Concat(messageId,"_-_",result.Response.FileAttachments);
+        string fileName = _fileNameFunction(result.Response.MessageMetaData);
         var meshFile = await FileHelpers.ReassembleChunkedFile(result.Response.FileAttachments);
 
         return new BlobFile(meshFile.Content,fileName);

--- a/tests/UnitTests/TransformDataServiceTests/TransformDataServiceTests/TransformDataServiceTests.cs
+++ b/tests/UnitTests/TransformDataServiceTests/TransformDataServiceTests/TransformDataServiceTests.cs
@@ -353,7 +353,7 @@ public class TransformDataServiceTests
     public async Task Run_ExceptionalCharsInParticipant_RaisesException(string name)
     {
         // Arrange
-        var sut = new TransformString(_handleException.Object);
+        var sut = new TransformString();
 
         // Act & Assert
         Assert.ThrowsException<ArgumentException>(() => sut.CheckParticipantCharactersAsync(name));

--- a/tests/UnitTests/TransformDataServiceTests/TransformDataServiceTests/TransformDataServiceTests.cs
+++ b/tests/UnitTests/TransformDataServiceTests/TransformDataServiceTests/TransformDataServiceTests.cs
@@ -353,7 +353,7 @@ public class TransformDataServiceTests
     public async Task Run_ExceptionalCharsInParticipant_RaisesException(string name)
     {
         // Arrange
-        var sut = new TransformString();
+        var sut = new TransformString(_handleException.Object);
 
         // Act & Assert
         Assert.ThrowsException<ArgumentException>(() => sut.CheckParticipantCharactersAsync(name));


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

chunked mesh files were saving with incorrect name
Change to use namefunction to name the file

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
