### PR TITLE
fix: DTOSS-5205 Remove SQLSecurityAuditEvents due to PII data being included in log entries

### DIFF
--- a/infrastructure/tf-core/diagnostic_settings.tf
+++ b/infrastructure/tf-core/diagnostic_settings.tf
@@ -1,8 +1,8 @@
 locals {
-  #APPSERVICEPLAN
+  # APPSERVICEPLAN
   monitor_diagnostic_setting_appserviceplan_metrics = ["AllMetrics"]
 
-  #FUNCTIONAPP
+  # FUNCTIONAPP
   monitor_diagnostic_setting_function_app_enabled_logs = ["AppServiceAuthenticationLogs", "FunctionAppLogs"]
   monitor_diagnostic_setting_function_app_metrics      = ["AllMetrics"]
 
@@ -14,20 +14,21 @@ locals {
   monitor_diagnostic_setting_log_analytics_workspace_enabled_logs = ["SummaryLogs", "Audit"]
   monitor_diagnostic_setting_log_analytics_workspace_metrics      = ["AllMetrics"]
 
-  #SQL SERVER AND DATABASE
-  monitor_diagnostic_setting_database_enabled_logs   = ["SQLSecurityAuditEvents", "SQLInsights", "QueryStoreWaitStatistics", "Errors", "DatabaseWaitStatistics", "Timeouts"]
+  # SQL SERVER AND DATABASE
+  # NOTE: Do not include "SQLSecurityAuditEvents" as this writes SQL statements with PII data to the logs!
+  monitor_diagnostic_setting_database_enabled_logs   = ["SQLInsights", "QueryStoreWaitStatistics", "Errors", "DatabaseWaitStatistics", "Timeouts"]
   monitor_diagnostic_setting_database_metrics        = ["Basic", "InstanceAndAppAdvanced", "WorkloadManagement"]
   monitor_diagnostic_setting_sql_server_enabled_logs = ["SQLSecurityAuditEvents"]
   monitor_diagnostic_setting_sql_server_metrics      = ["Basic", "InstanceAndAppAdvanced", "WorkloadManagement"]
 
-  #STORAGE ACCOUNT
+  # STORAGE ACCOUNT
   monitor_diagnostic_setting_storage_account_enabled_logs = ["StorageWrite", "StorageRead", "StorageDelete"]
   monitor_diagnostic_setting_storage_account_metrics      = ["Capacity", "Transaction"]
 
-  #SUBNET
+  # SUBNET
   monitor_diagnostic_setting_network_security_group_enabled_logs = ["NetworkSecurityGroupEvent", "NetworkSecurityGroupRuleCounter"]
 
-  #VNET
+  # VNET
   monitor_diagnostic_setting_vnet_enabled_logs = ["VMProtectionAlerts"]
   monitor_diagnostic_setting_vnet_metrics      = ["AllMetrics"]
 }


### PR DESCRIPTION

<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Remove SQLSecurityAuditEvents log category due to PII data being included in log entries.

## Context

The SQLSecurityAuditEvents log entries include the SQL statement that triggered the log entry creation and often this includes potentially sensitive information.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
