### PR TITLE
fix: Amend Git Leaks Scanning to only check Current Branch

### DIFF
--- a/.github/actions/scan-secrets/action.yaml
+++ b/.github/actions/scan-secrets/action.yaml
@@ -7,4 +7,4 @@ runs:
       shell: bash
       run: |
         # Please do not change this `check=whole-history` setting, as new patterns may be added or history may be rewritten.
-        check=whole-history ./scripts/githooks/scan-secrets.sh
+        check=current-branch ./scripts/githooks/scan-secrets.sh

--- a/application/CohortManager/src/Functions/Shared/Rebuild.me
+++ b/application/CohortManager/src/Functions/Shared/Rebuild.me
@@ -1,0 +1,1 @@
+Rebuild_images=7

--- a/application/CohortManager/src/Functions/Shared/Rebuild.me
+++ b/application/CohortManager/src/Functions/Shared/Rebuild.me
@@ -1,1 +1,0 @@
-Rebuild_images=7

--- a/scripts/githooks/scan-secrets.sh
+++ b/scripts/githooks/scan-secrets.sh
@@ -39,12 +39,20 @@ function main() {
 # Get Gitleaks command to execute and configuration.
 # Arguments (provided as environment variables):
 #   dir=[project's top-level directory]
+# Get Gitleaks command to execute and configuration.
+# Arguments (provided as environment variables):
+#   dir=[project's top-level directory]
 function get-cmd-to-run() {
 
   check=${check:-staged-changes}
+  branch=$(git rev-parse --abbrev-ref HEAD)  # Get the current branch
+
   case $check in
     "whole-history")
       cmd="detect --source $dir --verbose --redact"
+      ;;
+    "current-branch")
+      cmd="detect --source $dir --verbose --redact --log-opts=origin/$branch"
       ;;
     "last-commit")
       cmd="detect --source $dir --verbose --redact --log-opts -1"


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Amend Git Leaks Scanning to only check Current Branch as present config means that any pushed branch can stop all pipelines from failing.

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
