### PR TITLE
fix: add date format to transformation rule

### DIFF
--- a/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/transformRules.json
+++ b/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/transformRules.json
@@ -292,7 +292,7 @@
                 },
                 {
                   "field": "ReasonForRemovalEffectiveFromDate",
-                  "value": "DateTime.Today.ToString()",
+                  "value": "DateTime.Today.ToString(\"yyyyMMdd\")",
                   "isExpression": true
                 }
               ]


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description
The expected transformation for `ReasonForRemovalEffectiveFromDate` on the `00.Other.InvalidFlag.TrueAndNoPrimaryCareProvider` rule was not happening. 

The date string was failing to parse in the databaseHelper ParseDates method.

Adding an expected format to the date string in the rule fixed the issue.
<!-- Describe your changes in detail. -->

## Context
https://nhsd-jira.digital.nhs.uk/browse/DTOSS-7129
<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
