### PR TITLE
fix: markParticipantAsEligible function to use NHS number to get participant

### DIFF
--- a/application/CohortManager/src/Functions/screeningDataServices/markParticipantAsEligible/markParticipantAsEligible.cs
+++ b/application/CohortManager/src/Functions/screeningDataServices/markParticipantAsEligible/markParticipantAsEligible.cs
@@ -36,17 +36,21 @@ public class MarkParticipantAsEligible
         }
 
         var participant = JsonSerializer.Deserialize<Participant>(postData);
-        var participantId = participant?.ParticipantId;
+        long nhsNumber;
 
         try
         {
             var updated = false;
             if (participant != null)
             {
-                var updtParticipantManagement = _participantManagementClient.GetSingle(participantId).Result;
-                updtParticipantManagement.EligibilityFlag = 1;
+                if (!long.TryParse(participant.NhsNumber, out nhsNumber))
+                {
+                    throw new FormatException("Could not parse NhsNumber");
+                }
+                var updatedParticipantManagement = _participantManagementClient.GetSingleByFilter(x => x.NHSNumber == nhsNumber).Result;
+                updatedParticipantManagement.EligibilityFlag = 1;
 
-                updated = _participantManagementClient.Update(updtParticipantManagement).Result;
+                updated = _participantManagementClient.Update(updatedParticipantManagement).Result;
             }
 
             if (updated)

--- a/tests/UnitTests/ScreeningDataServicesTests/MarkParticipantAsEligibleTests/MarkParticipantAsEligibleTests.cs
+++ b/tests/UnitTests/ScreeningDataServicesTests/MarkParticipantAsEligibleTests/MarkParticipantAsEligibleTests.cs
@@ -10,7 +10,7 @@ using Moq;
 using NHS.CohortManager.Tests.TestUtils;
 using DataServices.Client;
 using System.Text.Json;
-
+using System.Linq.Expressions;
 
 [TestClass]
 public class MarkParticipantAsEligibleTests
@@ -26,15 +26,15 @@ public class MarkParticipantAsEligibleTests
         // Arrange
         var requestBody = new Participant
         {
-            NhsNumber = "NHS1234567",
+            NhsNumber = "1234567890",
             ParticipantId = "123"
         };
         var json = JsonSerializer.Serialize(requestBody);
         var mockRequest = MockHelpers.CreateMockHttpRequestData(json);
         var markParticipantAsEligible = new MarkParticipantAsEligible(_mockLogger.Object, _mockCreateResponse.Object, _mockParticipantManagementClient.Object, _handleException.Object);
 
-        var mockParticipantManagement = new ParticipantManagement { ParticipantId = 123, EligibilityFlag = 0 };
-        _mockParticipantManagementClient.Setup(x => x.GetSingle(It.IsAny<string>())).ReturnsAsync(mockParticipantManagement);
+        var mockParticipantManagement = new ParticipantManagement { NHSNumber = 1234567890, EligibilityFlag = 0 };
+        _mockParticipantManagementClient.Setup(x => x.GetSingleByFilter(It.IsAny<Expression<Func<ParticipantManagement, bool>>>())).ReturnsAsync(mockParticipantManagement);
         _mockParticipantManagementClient.Setup(x => x.Update(It.IsAny<ParticipantManagement>())).ReturnsAsync(true);
 
         // Act
@@ -51,15 +51,15 @@ public class MarkParticipantAsEligibleTests
         // Arrange
         var requestBody = new Participant
         {
-            NhsNumber = "NHS1234567",
+            NhsNumber = "1234567890",
             ParticipantId = "123"
         };
         var json = JsonSerializer.Serialize(requestBody);
         var mockRequest = MockHelpers.CreateMockHttpRequestData(json);
         var markParticipantAsEligible = new MarkParticipantAsEligible(_mockLogger.Object, _mockCreateResponse.Object, _mockParticipantManagementClient.Object, _handleException.Object);
 
-        var mockParticipantManagement = new ParticipantManagement { ParticipantId = 123, EligibilityFlag = 0 };
-        _mockParticipantManagementClient.Setup(x => x.GetSingle(It.IsAny<string>())).ReturnsAsync(mockParticipantManagement);
+        var mockParticipantManagement = new ParticipantManagement { NHSNumber = 1234567890, EligibilityFlag = 0 };
+        _mockParticipantManagementClient.Setup(x => x.GetSingleByFilter(It.IsAny<Expression<Func<ParticipantManagement, bool>>>())).ReturnsAsync(mockParticipantManagement);
         _mockParticipantManagementClient.Setup(x => x.Update(It.IsAny<ParticipantManagement>())).ReturnsAsync(false);
 
         // Act


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

In the markParticipantAsEligible function, the participantId was always null when trying to get the participant, so I've changed it to use GetSingleByFilter with the NHS number instead. 
<!-- Describe your changes in detail. -->

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [x] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
