### PR TITLE
fix: use NHS number and ScreenId to update eligibility flag

### DIFF
--- a/application/CohortManager/src/Functions/screeningDataServices/markParticipantAsEligible/markParticipantAsEligible.cs
+++ b/application/CohortManager/src/Functions/screeningDataServices/markParticipantAsEligible/markParticipantAsEligible.cs
@@ -37,6 +37,7 @@ public class MarkParticipantAsEligible
 
         var participant = JsonSerializer.Deserialize<Participant>(postData);
         long nhsNumber;
+        long screeningId;
 
         try
         {
@@ -47,7 +48,12 @@ public class MarkParticipantAsEligible
                 {
                     throw new FormatException("Could not parse NhsNumber");
                 }
-                var updatedParticipantManagement = _participantManagementClient.GetSingleByFilter(x => x.NHSNumber == nhsNumber).Result;
+                if (!long.TryParse(participant.ScreeningId, out screeningId))
+                {
+                    throw new FormatException("Could not parse ScreeningId");
+                }
+
+                var updatedParticipantManagement = _participantManagementClient.GetSingleByFilter(x => x.NHSNumber == nhsNumber && x.ScreeningId == screeningId).Result;
                 updatedParticipantManagement.EligibilityFlag = 1;
 
                 updated = _participantManagementClient.Update(updatedParticipantManagement).Result;

--- a/application/CohortManager/src/Functions/screeningDataServices/markParticipantAsIneligible/markParticipantAsIneligible.cs
+++ b/application/CohortManager/src/Functions/screeningDataServices/markParticipantAsIneligible/markParticipantAsIneligible.cs
@@ -49,6 +49,8 @@ public class MarkParticipantAsIneligible
             return req.CreateResponse(HttpStatusCode.BadRequest);
         }
         var participantData = requestBody.Participant;
+        long nhsNumber;
+        long screeningId;
 
         // Check if a participant with the supplied NHS Number already exists
         var existingParticipantResult = await _participantManagementClient.GetByFilter(i => i.NHSNumber.ToString() == participantData.NhsNumber && i.ScreeningId.ToString() == participantData.ScreeningId);
@@ -66,9 +68,13 @@ public class MarkParticipantAsIneligible
         try
         {
             var updated = false;
-            var updtParticipantManagement = _participantManagementClient.GetSingle(participantData.ParticipantId).Result;
-            updtParticipantManagement.EligibilityFlag = 0;
-            updated = _participantManagementClient.Update(updtParticipantManagement).Result;
+            if (!long.TryParse(participantData.NhsNumber, out nhsNumber) || !long.TryParse(participantData.ScreeningId, out screeningId) )
+            {
+                throw new FormatException("Could not parse NhsNumber or screeningID");
+            }
+            var updatedParticipantManagement =  _participantManagementClient.GetSingleByFilter(x => x.NHSNumber == nhsNumber && x.ScreeningId == screeningId).Result;
+            updatedParticipantManagement.EligibilityFlag = 0;
+            updated = _participantManagementClient.Update(updatedParticipantManagement).Result;
 
             if (updated)
             {

--- a/tests/UnitTests/ScreeningDataServicesTests/MarkParticipantAsEligibleTests/MarkParticipantAsEligibleTests.cs
+++ b/tests/UnitTests/ScreeningDataServicesTests/MarkParticipantAsEligibleTests/MarkParticipantAsEligibleTests.cs
@@ -27,13 +27,14 @@ public class MarkParticipantAsEligibleTests
         var requestBody = new Participant
         {
             NhsNumber = "1234567890",
-            ParticipantId = "123"
+            ParticipantId = "123",
+            ScreeningId = "1"
         };
         var json = JsonSerializer.Serialize(requestBody);
         var mockRequest = MockHelpers.CreateMockHttpRequestData(json);
         var markParticipantAsEligible = new MarkParticipantAsEligible(_mockLogger.Object, _mockCreateResponse.Object, _mockParticipantManagementClient.Object, _handleException.Object);
 
-        var mockParticipantManagement = new ParticipantManagement { NHSNumber = 1234567890, EligibilityFlag = 0 };
+        var mockParticipantManagement = new ParticipantManagement { NHSNumber = 1234567890, EligibilityFlag = 0 , ScreeningId= 1 };
         _mockParticipantManagementClient.Setup(x => x.GetSingleByFilter(It.IsAny<Expression<Func<ParticipantManagement, bool>>>())).ReturnsAsync(mockParticipantManagement);
         _mockParticipantManagementClient.Setup(x => x.Update(It.IsAny<ParticipantManagement>())).ReturnsAsync(true);
 
@@ -49,16 +50,17 @@ public class MarkParticipantAsEligibleTests
     public async Task Run_MarkParticipantAsEligible_InvalidRequest_ReturnsBadRequest()
     {
         // Arrange
-        var requestBody = new Participant
+         var requestBody = new Participant
         {
             NhsNumber = "1234567890",
-            ParticipantId = "123"
+            ParticipantId = "123",
+            ScreeningId = "1"
         };
         var json = JsonSerializer.Serialize(requestBody);
         var mockRequest = MockHelpers.CreateMockHttpRequestData(json);
         var markParticipantAsEligible = new MarkParticipantAsEligible(_mockLogger.Object, _mockCreateResponse.Object, _mockParticipantManagementClient.Object, _handleException.Object);
 
-        var mockParticipantManagement = new ParticipantManagement { NHSNumber = 1234567890, EligibilityFlag = 0 };
+        var mockParticipantManagement = new ParticipantManagement { NHSNumber = 1234567890, EligibilityFlag = 0 , ScreeningId =1};
         _mockParticipantManagementClient.Setup(x => x.GetSingleByFilter(It.IsAny<Expression<Func<ParticipantManagement, bool>>>())).ReturnsAsync(mockParticipantManagement);
         _mockParticipantManagementClient.Setup(x => x.Update(It.IsAny<ParticipantManagement>())).ReturnsAsync(false);
 

--- a/tests/UnitTests/ScreeningDataServicesTests/MarkParticipantAsIneligibleTests/MarkParticipantAsIneligibleTests.cs
+++ b/tests/UnitTests/ScreeningDataServicesTests/MarkParticipantAsIneligibleTests/MarkParticipantAsIneligibleTests.cs
@@ -13,6 +13,7 @@ using Model;
 using Moq;
 using Google.Protobuf.Reflection;
 using DataServices.Client;
+using System.Linq.Expressions;
 
 [TestClass]
 public class MarkParticipantAsIneligibleTests
@@ -40,7 +41,8 @@ public class MarkParticipantAsIneligibleTests
             FileName = "test.csv",
             Participant = new Participant()
             {
-                NhsNumber = "1",
+                NhsNumber = "1234567890",
+                ScreeningId = "1",
                 ParticipantId = "123"
             }
         };
@@ -109,10 +111,9 @@ public class MarkParticipantAsIneligibleTests
                 CreatedException = false
             })));
 
-        var mockParticipantManagement = new ParticipantManagement { ParticipantId = 123, EligibilityFlag = 0 };
+       var mockParticipantManagement = new ParticipantManagement { NHSNumber = 1234567890, ScreeningId = 1, EligibilityFlag = 0 };
         _mockParticipantManagementClient.Setup(x => x.GetSingle(It.IsAny<string>())).ReturnsAsync(mockParticipantManagement);
-        _mockParticipantManagementClient.Setup(x => x.Update(It.IsAny<ParticipantManagement>())).ReturnsAsync(true);
-
+        _mockParticipantManagementClient.Setup(x => x.GetSingleByFilter(It.IsAny<Expression<Func<ParticipantManagement, bool>>>())).ReturnsAsync(mockParticipantManagement);
         // Act
         var result = await _function.RunAsync(_request.Object);
 


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Fix:- Use both NHS number and ScreenId to filter and update eligibility flag of participant.

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [x] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
