### PR TITLE
fix: to string issue

### DIFF
--- a/application/CohortManager/src/Functions/CaasIntegration/receiveCaasFile/ProcessFileClasses/ProcessCaasFile.cs
+++ b/application/CohortManager/src/Functions/CaasIntegration/receiveCaasFile/ProcessFileClasses/ProcessCaasFile.cs
@@ -173,7 +173,15 @@ public class ProcessCaasFile : IProcessCaasFile
                 basicParticipantCsvRecord.participant.ToParticipantDemographic()
             };
 
-            var participant = await _participantDemographic.GetSingleByFilter(x => x.NhsNumber.ToString() == basicParticipantCsvRecord.participant.NhsNumber);
+            long nhsNumber;
+
+            if(!long.TryParse(basicParticipantCsvRecord.participant.NhsNumber, out nhsNumber))
+            {
+                throw new FormatException("Unable to parse NHS Number");
+            }
+
+
+            var participant = await _participantDemographic.GetSingleByFilter(x => x.NhsNumber == nhsNumber);
 
             if (participant != null)
             {

--- a/application/CohortManager/src/Functions/Shared/Data/Database/ValidationExceptionData.cs
+++ b/application/CohortManager/src/Functions/Shared/Data/Database/ValidationExceptionData.cs
@@ -36,7 +36,7 @@ public class ValidationExceptionData : IValidationExceptionData
     public async Task<List<ValidationException>> GetAllExceptions(bool todayOnly)
     {
         IEnumerable<ExceptionManagement?> exceptions;
-        // we do  this check so that we only call the database when it is needed  
+        // we do  this check so that we only call the database when it is needed
         if (!todayOnly)
         {
             // get the exceptions from the list of all exceptions where the date created is today and no greater than today
@@ -55,7 +55,16 @@ public class ValidationExceptionData : IValidationExceptionData
     public async Task<ValidationException?> GetExceptionById(int exceptionId)
     {
         var exception = await _validationExceptionDataServiceClient.GetSingle(exceptionId.ToString());
-        var participantDemographic = await _demographicDataServiceClient.GetSingleByFilter(x => x.NhsNumber.ToString() == exception.NhsNumber);
+
+        long nhsNumber;
+
+        if(!long.TryParse(exception.NhsNumber, out nhsNumber))
+        {
+            throw new FormatException("Unable to parse NHS Number");
+        }
+
+
+        var participantDemographic = await _demographicDataServiceClient.GetSingleByFilter(x => x.NhsNumber == nhsNumber);
         var gpPracticeDetails = await _gpPracticeDataServiceClient.GetSingleByFilter(x => x.GPPracticeCode == participantDemographic.PrimaryCareProvider);
 
         return GetExceptionDetails(exception.ToValidationException(), participantDemographic, gpPracticeDetails);

--- a/application/CohortManager/src/Functions/Shared/Model/EFModels/ParticipantDemographic.cs
+++ b/application/CohortManager/src/Functions/Shared/Model/EFModels/ParticipantDemographic.cs
@@ -11,7 +11,7 @@ public class ParticipantDemographic
     public long ParticipantId { get; set; }
 
     [Column("NHS_NUMBER")]
-    public long? NhsNumber { get; set; }
+    public long NhsNumber { get; set; }
 
     [Column("SUPERSEDED_BY_NHS_NUMBER")]
     public long? SupersededByNhsNumber { get; set; }

--- a/application/CohortManager/src/Functions/Shared/Model/Participant.cs
+++ b/application/CohortManager/src/Functions/Shared/Model/Participant.cs
@@ -72,7 +72,7 @@ public class Participant
     {
         return new ParticipantDemographic
         {
-            NhsNumber = !string.IsNullOrEmpty(NhsNumber) ? long.Parse(NhsNumber) : null,
+            NhsNumber = !string.IsNullOrEmpty(NhsNumber) ? long.Parse(NhsNumber) : throw new FormatException("Cannot parse nhs number to Long"),
             SupersededByNhsNumber = !string.IsNullOrEmpty(SupersededByNhsNumber) ? long.Parse(SupersededByNhsNumber) : null,
             PrimaryCareProvider = PrimaryCareProvider,
             PrimaryCareProviderFromDate = PrimaryCareProviderEffectiveFromDate,

--- a/tests/UnitTests/ScreeningDataServicesTests/ValidationExceptionDataTests/ValidationExceptionDataTests/ValidationExceptionDataTests.cs
+++ b/tests/UnitTests/ScreeningDataServicesTests/ValidationExceptionDataTests/ValidationExceptionDataTests/ValidationExceptionDataTests.cs
@@ -46,7 +46,7 @@ public class ValidationExceptionDataTests
     [TestMethod]
     public async Task GetAllExceptions_NoExceptionId_ReturnsAllExceptions()
     {
-        //arrange 
+        //arrange
         _validationExceptionDataServiceClient.Setup(x => x.GetAll()).ReturnsAsync(_exceptionList);
 
         // Act
@@ -90,8 +90,8 @@ public class ValidationExceptionDataTests
     [TestMethod]
     public async Task GetExceptionById_ValidExceptionId_ReturnsExpectedException(int exceptionId)
     {
-        //arrange 
-        _validationExceptionDataServiceClient.Setup(x => x.GetSingle(It.IsAny<string>())).ReturnsAsync(new ExceptionManagement() { ExceptionId = exceptionId });
+        //arrange
+        _validationExceptionDataServiceClient.Setup(x => x.GetSingle(It.IsAny<string>())).ReturnsAsync(new ExceptionManagement() { ExceptionId = exceptionId, NhsNumber="123456789" });
         _demographicDataServiceClient.Setup(x => x.GetSingleByFilter(It.IsAny<Expression<Func<ParticipantDemographic, bool>>>())).ReturnsAsync(new ParticipantDemographic());
         _gpPracticeDataServiceClient.Setup(x => x.GetSingleByFilter(It.IsAny<Expression<Func<GPPractice, bool>>>())).ReturnsAsync(new GPPractice());
 
@@ -111,7 +111,7 @@ public class ValidationExceptionDataTests
     public async Task GetExceptionById_InvalidId_ReturnsNull(int exceptionId)
     {
         // Arrange
-        _validationExceptionDataServiceClient.Setup(x => x.GetSingle(It.IsAny<string>())).ReturnsAsync(new ExceptionManagement() { ExceptionId = exceptionId });
+        _validationExceptionDataServiceClient.Setup(x => x.GetSingle(It.IsAny<string>())).ReturnsAsync(new ExceptionManagement() { ExceptionId = exceptionId, NhsNumber="123456789" });
         _demographicDataServiceClient.Setup(x => x.GetSingleByFilter(It.IsAny<Expression<Func<ParticipantDemographic, bool>>>())).ReturnsAsync((ParticipantDemographic)null);
         _gpPracticeDataServiceClient.Setup(x => x.GetSingleByFilter(It.IsAny<Expression<Func<GPPractice, bool>>>())).ReturnsAsync((GPPractice)null);
 


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

- Ensures all uses of the filter function in the data service doesnt have a .ToString()
- Sorts issue with ParticipantDemographicDataService where we couldn't filter on NHSNumber as it was nullable

## Context

Bug Fixes

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
