### PR TITLE
feat: prevent running common lookup rules for del records

### DIFF
--- a/application/CohortManager/src/Functions/CaasIntegration/receiveCaasFile/ProcessFileClasses/ProcessCaasFile.cs
+++ b/application/CohortManager/src/Functions/CaasIntegration/receiveCaasFile/ProcessFileClasses/ProcessCaasFile.cs
@@ -175,7 +175,7 @@ public class ProcessCaasFile : IProcessCaasFile
 
             long nhsNumber;
 
-            if(!long.TryParse(basicParticipantCsvRecord.participant.NhsNumber, out nhsNumber))
+            if (!long.TryParse(basicParticipantCsvRecord.participant.NhsNumber, out nhsNumber))
             {
                 throw new FormatException("Unable to parse NHS Number");
             }
@@ -211,7 +211,9 @@ public class ProcessCaasFile : IProcessCaasFile
         {
             if (allowDeleteRecords)
             {
-                _logger.LogInformation("AllowDeleteRecords flag is true, delete record will be sent to removeParticipant function in a future PR.");
+                _logger.LogInformation("AllowDeleteRecords flag is true, delete record sent to updateParticipant function. A future PR will send the record to PMSRemoveParticipant once the new logic for it is implemented.");
+                var json = JsonSerializer.Serialize(basicParticipantCsvRecord);
+                await _callFunction.SendPost(Environment.GetEnvironmentVariable("PMSUpdateParticipant"), json);
             }
             else
             {

--- a/application/CohortManager/src/Functions/ScreeningValidationService/LookupValidation/LookupValidation.cs
+++ b/application/CohortManager/src/Functions/ScreeningValidationService/LookupValidation/LookupValidation.cs
@@ -80,7 +80,12 @@ public class LookupValidation
                 new RuleParameter("dbLookup", _dataLookup)
             };
 
-            var resultList = await re.ExecuteAllRulesAsync("Common", ruleParameters);
+            var resultList = new List<RuleResultTree>();
+
+            if (newParticipant.RecordType != Actions.Removed)
+            {
+                resultList = await re.ExecuteAllRulesAsync("Common", ruleParameters);
+            }
 
             if (re.GetAllRegisteredWorkflowNames().Contains(newParticipant.RecordType))
             {

--- a/tests/UnitTests/CaasIntegrationTests/processCaasFileTest/processCaasFileTests.cs
+++ b/tests/UnitTests/CaasIntegrationTests/processCaasFileTest/processCaasFileTests.cs
@@ -304,7 +304,7 @@ public class ProcessCaasFileTests
         // Assert
         _loggerMock.Verify(x => x.Log(It.Is<LogLevel>(l => l == LogLevel.Information),
                It.IsAny<EventId>(),
-               It.Is<It.IsAnyType>((v, t) => v.ToString().Contains("AllowDeleteRecords flag is true, delete record will be sent to removeParticipant function in a future PR.")),
+               It.Is<It.IsAnyType>((v, t) => v.ToString().Contains("AllowDeleteRecords flag is true")),
                It.IsAny<Exception>(),
                It.IsAny<Func<It.IsAnyType, Exception, string>>()),
            Times.Once);

--- a/tests/UnitTests/ScreeningValidationServiceTests/LookupValidation/LookupValidationTests.cs
+++ b/tests/UnitTests/ScreeningValidationServiceTests/LookupValidation/LookupValidationTests.cs
@@ -502,8 +502,6 @@ public class LookupValidationTests
     [TestMethod]
     [DataRow(Actions.Amended, "LDN")]
     [DataRow(Actions.Amended, "R/C")]
-    [DataRow(Actions.Removed, "LDN")]
-    [DataRow(Actions.Removed, "R/C")]
     public async Task Run_ValidateReasonForRemoval_CreatesException(string recordType, string reasonForRemoval)
     {
         // Arrange
@@ -648,8 +646,8 @@ public class LookupValidationTests
     [TestMethod]
     [DataRow("DMS", "ExcludedPCP", "ENGLAND", "DMS", "ExcludedPCP", "ENGLAND")] //DMS Invalid -> DMS Invalid
     [DataRow("DMS", "ExcludedPCP", "WALES", "DMS", "ExcludedPCP", "WALES")] //DMS + Wales Invalid -> DMS Wales Invalid
-    [DataRow("CYM","ValidPCP","WALES","CYM","ValidPCP","WALES")] //Wales Invalid -> Wales Invalid
-    [DataRow("CYM","ExcludedPCP","WALES","CYM","ExcludedPCP","WALES")] //Wales Invalid -> Wales Invalid
+    [DataRow("CYM", "ValidPCP", "WALES", "CYM", "ValidPCP", "WALES")] //Wales Invalid -> Wales Invalid
+    [DataRow("CYM", "ExcludedPCP", "WALES", "CYM", "ExcludedPCP", "WALES")] //Wales Invalid -> Wales Invalid
     [DataRow("DMS", "ExcludedPCP", "ENGLAND", "ABC", "ValidPCP", "WALES")] //DMS Invalid -> Wales Invalid
     public async Task Run_ParticipantLocationRemainingOutsideOfCohort_ShouldThrowException(string existingCurrentPosting, string existingPrimaryCareProvider, string existingPostingCategory, string newCurrentPosting, string newPrimaryCareProvider, string newPostingCategory)
     {


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description
- Adds new logic into LookupValidation function that will prevent all the common lookup rules being run for DEL records.
- DEL records should only ever run the DEL workflow.
- This functionality is only active when the "AllowDeleteRecords" is set true, so will not affect current behaviour.
- I have tested this by calling `updateParticipant` from `ProcessCaasFile`. This was just so I could easily trigger lookup validation.
- A future PR will implement further logic in the RemoveParticipant function, and replace the call to `updateParticipant`.
<!-- Describe your changes in detail. -->

## Context
[DTOSS-6335](https://nhsd-jira.digital.nhs.uk/browse/DTOSS-6335)
<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
