### PR TITLE
fix: demographic data function error handling

### DIFF
--- a/application/CohortManager/src/Functions/DemographicServices/DemographicDataManagementFunction/DemographicDataFunction.cs
+++ b/application/CohortManager/src/Functions/DemographicServices/DemographicDataManagementFunction/DemographicDataFunction.cs
@@ -48,7 +48,12 @@ public class DemographicDataFunction
     {
         try
         {
-            string NHSNumber = req.Query["Id"];
+
+            if(req.Query["Id"] == null)
+            {
+                return _createResponse.CreateHttpResponse(HttpStatusCode.BadRequest,req,"No NHS Number Provided");
+            }
+            string NHSNumber = req.Query["Id"]!;
 
             var demographicData = await GetDemographicData(NHSNumber);
             var data = JsonSerializer.Serialize(demographicData);
@@ -70,12 +75,12 @@ public class DemographicDataFunction
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "There has been an error saving demographic data: {Message}", ex.Message);
+            _logger.LogError(ex, "There has been an error getting demographic data: {Message}", ex.Message);
             return _createResponse.CreateHttpResponse(HttpStatusCode.InternalServerError, req);
         }
     }
 
-    private async Task<Demographic> GetDemographicData(string nhsNumber)
+    private async Task<Demographic?> GetDemographicData(string nhsNumber)
     {
         long nhsNumberLong;
         if (!long.TryParse(nhsNumber, out nhsNumberLong))
@@ -83,6 +88,11 @@ public class DemographicDataFunction
             throw new FormatException("Could not parse NhsNumber");
         }
         var result = await _participantDemographic.GetSingleByFilter(x => x.NhsNumber == nhsNumberLong);
+
+        if(result == null)
+        {
+            return null;
+        }
         return result.ToDemographic();
     }
 }


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

- 

## Context

Where no participant was found this wasn't throwing an exception that wasn't properly handled.
If no Id was provided this wasn't handled and would throw an exception that would return the incorrect http code

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
