### PR TITLE
feat: update invalid flag transform rule to trigger for del records

### DIFF
--- a/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/transformRules.json
+++ b/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/transformRules.json
@@ -274,7 +274,7 @@
       },
       {
         "RuleName": "00.Other.InvalidFlag.TrueAndNoPrimaryCareProvider",
-        "Expression": "!string.IsNullOrEmpty(participant.PrimaryCareProvider) && participant.InvalidFlag  == \"1\"",
+        "Expression": "(!string.IsNullOrEmpty(participant.PrimaryCareProvider) && participant.InvalidFlag  == \"1\") OR participant.RecordType == Actions.Removed",
         "Actions": {
           "OnSuccess": {
             "Name": "TransformAction",

--- a/tests/UnitTests/TransformDataServiceTests/TransformDataServiceTests/TransformDataServiceTests.cs
+++ b/tests/UnitTests/TransformDataServiceTests/TransformDataServiceTests/TransformDataServiceTests.cs
@@ -419,11 +419,16 @@ public class TransformDataServiceTests
     }
 
     [TestMethod]
-    public async Task Run_InvalidParticipantHasPrimaryCareProvider_TransformFields()
+    [DataRow("G82650", "1", Actions.New)]
+    [DataRow("G82650", "1", Actions.Amended)]
+    [DataRow("", "0", Actions.Removed)]
+    public async Task Run_InvalidParticipantHasPrimaryCareProvider_TransformFields(string primaryCareProvider, string invalidFlag, string recordType)
     {
         // Arrange
-        _requestBody.Participant.PrimaryCareProvider = "G82650";
+        _requestBody.Participant.PrimaryCareProvider = primaryCareProvider;
         _requestBody.Participant.ReasonForRemovalEffectiveFromDate = DateTime.Today.ToString();
+        _requestBody.Participant.InvalidFlag = invalidFlag;
+        _requestBody.Participant.RecordType = recordType;
 
         var json = JsonSerializer.Serialize(_requestBody);
         SetUpRequestBody(json);


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description
- Updates the invalid flag transform rule to also trigger when a del record is processed.

<!-- Describe your changes in detail. -->

## Context
- When a del record is allowed to be processed, the same data transformation as the invalid flag rule is required to be made.

[DTOSS-6335](https://nhsd-jira.digital.nhs.uk/browse/DTOSS-6335)

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [x] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
