### PR TITLE
fix: rules engine startup bug

### DIFF
--- a/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/TransformDataService.cs
+++ b/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/TransformDataService.cs
@@ -117,7 +117,8 @@ public class TransformDataService
         var reSettings = new ReSettings
         {
             CustomActions = actions,
-            CustomTypes = [typeof(Actions)]
+            CustomTypes = [typeof(Actions)],
+            UseFastExpressionCompiler = false
         };
 
         var re = new RulesEngine.RulesEngine(rules, reSettings);
@@ -140,8 +141,8 @@ public class TransformDataService
         // Set up rules engine
         string json = await File.ReadAllTextAsync("namePrefixRules.json");
         var rules = JsonSerializer.Deserialize<Workflow[]>(json);
-
-        var re = new RulesEngine.RulesEngine(rules);
+        var reSettings = new ReSettings {UseFastExpressionCompiler = false};
+        var re = new RulesEngine.RulesEngine(rules, reSettings);
 
         namePrefix = namePrefix.ToUpper();
 

--- a/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/TransformString.cs
+++ b/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/TransformString.cs
@@ -14,7 +14,8 @@ public class TransformString
     {
         string json = File.ReadAllText("characterRules.json");
         var rules = JsonSerializer.Deserialize<Workflow[]>(json);
-        _ruleEngine = new RulesEngine.RulesEngine(rules);
+        var reSettings = new ReSettings {UseFastExpressionCompiler = false};
+        _ruleEngine = new RulesEngine.RulesEngine(rules, reSettings);
     }
 
     public async Task<CohortDistributionParticipant> TransformStringFields(CohortDistributionParticipant participant)

--- a/application/CohortManager/src/Functions/ScreeningValidationService/LookupValidation/Breast_Screening_cohortRules.json
+++ b/application/CohortManager/src/Functions/ScreeningValidationService/LookupValidation/Breast_Screening_cohortRules.json
@@ -4,7 +4,7 @@
     "Rules": [
       {
         "RuleName": "35.TooManyDemographicsFieldsChanged.NonFatal",
-        "Expression": "existingParticipant.ParticipantId == null || ((newParticipant.FamilyName == existingParticipant.FamilyName AND newParticipant.Gender == existingParticipant.Gender) OR (newParticipant.FamilyName == existingParticipant.FamilyName AND newParticipant.DateOfBirth == existingParticipant.DateOfBirth) OR (newParticipant.Gender== existingParticipant.Gender AND newParticipant.DateOfBirth == existingParticipant.DateOfBirth))"
+        "Expression": "existingParticipant.ParticipantId == null || ((newParticipant.FamilyName == existingParticipant.FamilyName AND newParticipant.Gender == existingParticipant.Gender) OR (newParticipant.FamilyName == existingParticipant.FamilyName AND newParticipant.DateOfBirth == existingParticipant.DateOfBirth) OR (newParticipant.Gender == existingParticipant.Gender AND newParticipant.DateOfBirth == existingParticipant.DateOfBirth))"
       },
       {
         "RuleName": "54.ValidateBsoCode.NonFatal",

--- a/application/CohortManager/src/Functions/ScreeningValidationService/LookupValidation/LookupValidation.cs
+++ b/application/CohortManager/src/Functions/ScreeningValidationService/LookupValidation/LookupValidation.cs
@@ -68,7 +68,8 @@ public class LookupValidation
 
             var reSettings = new ReSettings
             {
-                CustomTypes = [typeof(Actions)]
+                CustomTypes = [typeof(Actions)],
+                UseFastExpressionCompiler = false
             };
             var re = new RulesEngine.RulesEngine(rules, reSettings);
 

--- a/application/CohortManager/src/Functions/ScreeningValidationService/StaticValidation/StaticValidation.cs
+++ b/application/CohortManager/src/Functions/ScreeningValidationService/StaticValidation/StaticValidation.cs
@@ -51,7 +51,8 @@ public class StaticValidation
 
             var reSettings = new ReSettings
             {
-                CustomTypes = [typeof(Regex), typeof(RegexOptions), typeof(ValidationHelper), typeof(Status), typeof(Actions)]
+                CustomTypes = [typeof(Regex), typeof(RegexOptions), typeof(ValidationHelper), typeof(Status), typeof(Actions)],
+                UseFastExpressionCompiler = false
             };
 
             var re = new RulesEngine.RulesEngine(rules, reSettings);


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description
- Turned off fast compiler for the rules

<!-- Describe your changes in detail. -->

## Context
There was a bug in the rules engine where it would fail to parse some rules when evaluating the first participant after startup
[DTOSS-7561](https://nhsd-jira.digital.nhs.uk/browse/DTOSS-7561)

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
