### PR TITLE
fix: bump rules engine version

### DIFF
--- a/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/TransformDataService.csproj
+++ b/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/TransformDataService.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.19.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.0.13" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.15.1" />
-    <PackageReference Include="RulesEngine" Version="5.0.3" />
+    <PackageReference Include="RulesEngine" Version="5.0.5" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
   </ItemGroup>
   <ItemGroup>

--- a/application/CohortManager/src/Functions/ScreeningValidationService/LookupValidation/LookupValidation.csproj
+++ b/application/CohortManager/src/Functions/ScreeningValidationService/LookupValidation/LookupValidation.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.19.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.0.13" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.15.1" />
-    <PackageReference Include="RulesEngine" Version="5.0.3" />
+    <PackageReference Include="RulesEngine" Version="5.0.5" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/application/CohortManager/src/Functions/ScreeningValidationService/StaticValidation/StaticValidation.csproj
+++ b/application/CohortManager/src/Functions/ScreeningValidationService/StaticValidation/StaticValidation.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.19.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.0.13" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.15.1" />
-    <PackageReference Include="RulesEngine" Version="5.0.3" />
+    <PackageReference Include="RulesEngine" Version="5.0.5" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

<!-- Describe your changes in detail. -->

## Context
The rules engine package was out of date and this seemed to be causing an issue when parsing the rules due to the LINQ and rules engine versions not being compatible

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
