### PR TITLE
refactor: move create participant to use ToParticipantManagment

### DIFF
--- a/application/CohortManager/src/Functions/Shared/Data/Database/DatabaseHelper.cs
+++ b/application/CohortManager/src/Functions/Shared/Data/Database/DatabaseHelper.cs
@@ -90,8 +90,4 @@ public class DatabaseHelper : IDatabaseHelper
             _ => throw new NotImplementedException()
         };
     }
-    public int ParseExceptionFlag(object exception)
-    {
-        return exception != DBNull.Value && exception.ToString() == "Y" || exception == "1" ? 1 : 0;
-    }
 }

--- a/application/CohortManager/src/Functions/Shared/Data/Database/IDatabaseHelper.cs
+++ b/application/CohortManager/src/Functions/Shared/Data/Database/IDatabaseHelper.cs
@@ -4,5 +4,4 @@ public interface IDatabaseHelper
 {
     object ConvertNullToDbNull(string value);
     bool CheckIfNumberNull(string property);
-    int ParseExceptionFlag(object exception);
 }

--- a/application/CohortManager/src/Functions/Shared/Model/Participant.cs
+++ b/application/CohortManager/src/Functions/Shared/Model/Participant.cs
@@ -116,29 +116,22 @@ public class Participant
     {
         var participantManagement = new ParticipantManagement
         {
-            ParticipantId = long.Parse(ParticipantId),
             ScreeningId = long.Parse(ScreeningId),
             NHSNumber = long.Parse(NhsNumber),
             RecordType = RecordType,
-            EligibilityFlag = short.Parse(EligibilityFlag ?? "1"),
+            EligibilityFlag = MappingUtilities.ParseStringFlag(EligibilityFlag ?? "1"),
             ReasonForRemoval = ReasonForRemoval,
             ReasonForRemovalDate = MappingUtilities.ParseDates(ReasonForRemovalEffectiveFromDate),
             BusinessRuleVersion = BusinessRuleVersion,
-            ExceptionFlag = ParseExceptionFlag(ExceptionFlag ?? "0"),
+            ExceptionFlag = MappingUtilities.ParseStringFlag(ExceptionFlag ?? "0"),
             RecordInsertDateTime = MappingUtilities.ParseDates(RecordInsertDateTime),
             RecordUpdateDateTime = MappingUtilities.ParseDates(RecordUpdateDateTime),
         };
 
-        return participantManagement;
-    }
+        if (ParticipantId != null)
+            participantManagement.ParticipantId = long.Parse(ParticipantId);
 
-    private static short ParseExceptionFlag(string ExceptionFlag)
-    {
-        if (ExceptionFlag == "N" || ExceptionFlag == "n" || ExceptionFlag == "NO")
-        {
-            return 0;
-        }
-        return short.Parse(ExceptionFlag ?? "0");
+        return participantManagement;
     }
 
     private int GetInvalidFlag()

--- a/application/CohortManager/src/Functions/Shared/Utilities/MappingUtilities.cs
+++ b/application/CohortManager/src/Functions/Shared/Utilities/MappingUtilities.cs
@@ -14,6 +14,21 @@ public static class MappingUtilities
     }
 
     /// <summary>
+    /// Parses flags that can be Y, N, 0 or 1, such as the exception flag
+    /// </summary>
+    public static short ParseStringFlag(string flag)
+    {
+        return flag.ToUpper() switch
+        {
+            "0" => 0,
+            "1" => 1,
+            "Y" => 1,
+            "N" => 0,
+            _ => throw new ArgumentException("Invalid input")
+        };
+    }
+
+    /// <summary>
     /// Parses a date string to a nullable DateTime.
     /// Can handle partial dates.
     /// </summary>

--- a/application/CohortManager/src/Functions/screeningDataServices/createParticipant/createParticipant.cs
+++ b/application/CohortManager/src/Functions/screeningDataServices/createParticipant/createParticipant.cs
@@ -49,23 +49,15 @@ public class CreateParticipant
             }
 
             if (!long.TryParse(participantCsvRecord.Participant.ScreeningId, out screeningId))
-            {
                 throw new FormatException("Could not parse ScreeningId");
-            }
 
             if (!long.TryParse(participantCsvRecord.Participant.NhsNumber, out nhsNumber))
-            {
                 throw new FormatException("Could not parse NhsNumber");
-            }
 
             var existingParticipantResult = await _participantManagementClient.GetByFilter(i => i.NHSNumber == nhsNumber && i.ScreeningId == screeningId);
 
             if (existingParticipantResult != null && existingParticipantResult.Any())
-            {
                 existingParticipant = new Participant(existingParticipantResult.First());
-            }
-
-
 
             var response = await ValidateData(existingParticipant, participantCsvRecord.Participant, participantCsvRecord.FileName);
             if (response.IsFatal)
@@ -74,29 +66,11 @@ public class CreateParticipant
                 return _createResponse.CreateHttpResponse(HttpStatusCode.Created, req);
             }
 
-            if (response.CreatedException)
-            {
+            if (response.CreatedException) 
                 participantCsvRecord.Participant.ExceptionFlag = "Y";
-            }
 
-
-
-            var ParticipantManagementRecord = new ParticipantManagement
-            {
-                ScreeningId = long.Parse(participantCsvRecord.Participant.ScreeningId),
-                NHSNumber = long.Parse(participantCsvRecord.Participant.NhsNumber),
-                ReasonForRemoval = participantCsvRecord.Participant.ReasonForRemoval,
-                ReasonForRemovalDate = MappingUtilities.ParseDates(participantCsvRecord.Participant.ReasonForRemovalEffectiveFromDate),
-                BusinessRuleVersion = participantCsvRecord.Participant.BusinessRuleVersion,
-                ExceptionFlag = participantCsvRecord.Participant.ExceptionFlag == "Y" ? Int16.Parse("1") : Int16.Parse("0"),
-                RecordInsertDateTime = MappingUtilities.ParseNullableDateTime(participantCsvRecord.Participant.RecordInsertDateTime),
-                RecordUpdateDateTime = MappingUtilities.ParseNullableDateTime(participantCsvRecord.Participant.RecordUpdateDateTime),
-                RecordType = participantCsvRecord.Participant.RecordType
-
-            };
+            var ParticipantManagementRecord = participantCsvRecord.Participant.ToParticipantManagement();
             var participantCreated = await _participantManagementClient.Add(ParticipantManagementRecord);
-
-
 
             if (participantCreated)
             {


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description
- Refactored create participant to use the standard ToParticipantManagment method rather than using custom logic in the class
- Created a centralized ParseStringFlag method instead of relying on individual implementations
<!-- Describe your changes in detail. -->

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
