### PR TITLE
fix: existing family and given name transformation not applied

### DIFF
--- a/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/TransformAction.cs
+++ b/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/TransformAction.cs
@@ -24,6 +24,7 @@ class TransformAction : ActionBase
         {
             var transformFields = context.GetContext<List<TransformFields>>("transformFields");
             var participant = (CohortDistributionParticipant)ruleParameters.Where(rule => rule.Name == "participant").Select(result => result.Value).FirstOrDefault();
+            var databaseParticipant = (CohortDistribution)ruleParameters.Where(rule => rule.Name == "databaseParticipant").Select(result => result.Value).FirstOrDefault();
 
             foreach (var transformField in transformFields)
             {
@@ -31,7 +32,7 @@ class TransformAction : ActionBase
 
                 if (transformField.isExpression)
                 {
-                    EvaluateExpression(property!, transformField.value, participant);
+                    EvaluateExpression(property!, transformField.value, participant, databaseParticipant);
                 }
                 else
                 {
@@ -63,10 +64,10 @@ class TransformAction : ActionBase
         }
     }
 
-    private static void EvaluateExpression(PropertyInfo property, string expression, CohortDistributionParticipant participant)
+    private static void EvaluateExpression(PropertyInfo property, string expression, CohortDistributionParticipant participant, CohortDistribution databaseParticipant)
     {
         var reParser = new RuleExpressionParser(new ReSettings());
-        var ruleParameters = new RuleParameter[] { new RuleParameter("participant", participant) };
+        var ruleParameters = new RuleParameter[] { new RuleParameter("participant", participant), new RuleParameter("databaseParticipant", databaseParticipant) };
         var result = reParser.Evaluate<string>(expression, ruleParameters);
 
         property.SetValue(participant, result);

--- a/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/transformRules.json
+++ b/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/transformRules.json
@@ -507,9 +507,9 @@
             "Context": {
               "transformFields": [
                 {
-                "isExpression": true,
-                "field": "FamilyName",
-                "value": "databaseParticipant.FamilyName"
+                  "isExpression": true,
+                  "field": "FamilyName",
+                  "value": "databaseParticipant.FamilyName"
                 }
               ]
             }
@@ -525,7 +525,7 @@
             "Context": {
               "transformFields": [
                 {
-                  "isExpression": false,
+                  "isExpression": true,
                   "field": "FirstName",
                   "value": "databaseParticipant.GivenName"
                 }


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

<!-- Describe your changes in detail. -->
Fixes an issue where the transform function was unable to evaluate the `databaseParticipant` for both the `family_name` and the `given_name`.

## Context
[DTOSS-7634](https://nhsd-jira.digital.nhs.uk/browse/DTOSS-7634)
<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
