### PR TITLE
fix: improve regex for postcode validation

### DIFF
--- a/application/CohortManager/src/Functions/ScreeningValidationService/StaticValidation/Breast_Screening_staticRules.json
+++ b/application/CohortManager/src/Functions/ScreeningValidationService/StaticValidation/Breast_Screening_staticRules.json
@@ -52,7 +52,7 @@
       },
       {
         "RuleName": "30.Postcode.NonFatal",
-        "Expression": "string.IsNullOrEmpty(participant.Postcode) OR Regex.IsMatch(participant.Postcode, \"^([A-Z]{1,2}[0-9][A-Z0-9]? ?[0-9][A-Z]{2})$\", RegexOptions.IgnoreCase)",
+        "Expression": "string.IsNullOrEmpty(participant.Postcode) OR Regex.IsMatch(participant.Postcode, \"^([A-Za-z][A-Ha-hJ-Yj-y]?[0-9][A-Za-z0-9]? ?[0-9][A-Za-z]{2}|[Gg][Ii][Rr] ?0[Aa]{2})$\", RegexOptions.IgnoreCase)",
         "Actions": {
           "OnFailure": {
             "Name": "OutputExpression",

--- a/tests/UnitTests/ScreeningValidationServiceTests/StaticValidation/StaticValidationTests.cs
+++ b/tests/UnitTests/ScreeningValidationServiceTests/StaticValidation/StaticValidationTests.cs
@@ -303,9 +303,11 @@ public class StaticValidationTests
     [DataRow("B33 8TH")]
     [DataRow("CR2 6XH")]
     [DataRow("LS10 1LT")]
+    [DataRow("GIR 0AA")]
+    [DataRow("GIR0AA")]
     [DataRow("")]
     [DataRow(null)]
-    public async Task Run_Should_Not_Create_Exception_When_Postcode_Rule_Passes(string postcode)
+    public async Task Run_ValidPostcode_PostcodeRulePasses(string postcode)
     {
         // Arrange
         _participantCsvRecord.Participant.Postcode = postcode;
@@ -324,8 +326,11 @@ public class StaticValidationTests
 
     [TestMethod]
     [DataRow("ABC123")]
-    [DataRow("ABC 123")]
-    public async Task Run_Should_Return_Created_And_Create_Exception_When_Postcode_Rule_Fails(string postcode)
+    [DataRow("1234 AB")]
+    [DataRow("AA 12345")]
+    [DataRow("A1B 1CDE")]
+    [DataRow("A1A@1AA")]
+    public async Task Run_InvalidPostcode_PostcodeRuleFailsAndExceptionCreated(string postcode)
     {
         // Arrange
         _participantCsvRecord.Participant.Postcode = postcode;


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description
- improved the regex for the postcode check in static validation

<!-- Describe your changes in detail. -->

## Context
discovered the postcode regex does not cover all possible postcodes

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
