### PR TITLE
fix: date of birth comparison check in rule 35

### DIFF
--- a/application/CohortManager/src/Functions/ScreeningValidationService/LookupValidation/Breast_Screening_cohortRules.json
+++ b/application/CohortManager/src/Functions/ScreeningValidationService/LookupValidation/Breast_Screening_cohortRules.json
@@ -4,7 +4,17 @@
     "Rules": [
       {
         "RuleName": "35.TooManyDemographicsFieldsChanged.NonFatal",
-        "Expression": "existingParticipant.ParticipantId == null || ((newParticipant.FamilyName == existingParticipant.FamilyName AND newParticipant.Gender == existingParticipant.Gender) OR (newParticipant.FamilyName == existingParticipant.FamilyName AND newParticipant.DateOfBirth == existingParticipant.DateOfBirth) OR (newParticipant.Gender == existingParticipant.Gender AND newParticipant.DateOfBirth == existingParticipant.DateOfBirth))"
+        "LocalParams": [
+          {
+            "Name": "NewDateOfBirth",
+            "Expression": "string.IsNullOrEmpty(newParticipant.DateOfBirth) ? null : newParticipant.DateOfBirth.Replace(\"-\", string.Empty)"
+          },
+          {
+            "Name": "ExistingDateOfBirth",
+            "Expression": "string.IsNullOrEmpty(existingParticipant.DateOfBirth) ? null : existingParticipant.DateOfBirth.Replace(\"-\", string.Empty)"
+          }
+        ],
+        "Expression": "existingParticipant.ParticipantId == null || ((newParticipant.FamilyName == existingParticipant.FamilyName AND newParticipant.Gender == existingParticipant.Gender) OR (newParticipant.FamilyName == existingParticipant.FamilyName AND NewDateOfBirth == ExistingDateOfBirth) OR (newParticipant.Gender == existingParticipant.Gender AND NewDateOfBirth == ExistingDateOfBirth))"
       },
       {
         "RuleName": "54.ValidateBsoCode.NonFatal",

--- a/application/CohortManager/src/Functions/Shared/Utilities/MappingUtilities.cs
+++ b/application/CohortManager/src/Functions/Shared/Utilities/MappingUtilities.cs
@@ -52,7 +52,7 @@ public static class MappingUtilities
 
     public static string? FormatDateTime(DateTime? date)
     {
-        return date?.ToString("yyyy-MM-dd hh:mm:ss");
+        return date?.ToString("yyyy-MM-dd");
     }
 
     private static string HandlePartialDates(string dateString)

--- a/tests/UnitTests/ScreeningValidationServiceTests/LookupValidation/LookupValidationTests.cs
+++ b/tests/UnitTests/ScreeningValidationServiceTests/LookupValidation/LookupValidationTests.cs
@@ -15,7 +15,6 @@ using Model.Enums;
 using Moq;
 using NHS.CohortManager.ScreeningValidationService;
 using RulesEngine.Models;
-using Data.Database;
 using Microsoft.Extensions.Options;
 
 [TestClass]
@@ -284,8 +283,8 @@ public class LookupValidationTests
     [DataRow(Actions.Amended, "Smith", Gender.Female, "19700101", "Jones", Gender.Female, "19700101")]  // New Family Name Only
     [DataRow(Actions.Amended, "Smith", Gender.Female, "19700101", "Smith", Gender.Male, "19700101")]    // New Gender Only
     [DataRow(Actions.Amended, "Smith", Gender.Female, "19700101", "Smith", Gender.Female, "19700102")]  // New Date of Birth Only
+    [DataRow(Actions.Amended, "Smith", Gender.Female, "1970-01-01", "Smith", Gender.Male, "19700101")]  // New Gender Only, same Date of Birth, but formatted differently
     [DataRow(Actions.Amended, "Smith", Gender.Female, "19700101", "Smith", Gender.Female, "19700101")]  // No Change
-    [DataRow(Actions.New, "", new Gender(), "", "Smith", Gender.Female, "19700101")]                    // New Record Type
     public async Task Run_OneFieldChanged_DemographicsRulePasses(string recordType,
         string existingFamilyName, Gender existingGender, string existingDateOfBirth, string newFamilyName,
         Gender newGender, string newDateOfBirth)
@@ -308,7 +307,7 @@ public class LookupValidationTests
 
         // Assert
         _exceptionHandler.Verify(handleException => handleException.CreateValidationExceptionLog(
-            It.Is<IEnumerable<RuleResultTree>>(r => r.Any(x => x.Rule.RuleName == "35.TooManyDemographicsFieldsChanged")),
+            It.Is<IEnumerable<RuleResultTree>>(r => r.Any(x => x.Rule.RuleName == "35.TooManyDemographicsFieldsChanged.NonFatal")),
             It.IsAny<ParticipantCsvRecord>()),
             Times.Never());
     }


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description
The date of birth comparison check was always failing on rule 35 due to the date string formatting not matching. 

This was then causing rule 35 to trigger when only one field had changed, rather than when 2 fields have changed as expected.

This PR makes sure the date of birth fields are in the same format before checking if the dates match.
<!-- Describe your changes in detail. -->

## Context
[DTOSS-7635](https://nhsd-jira.digital.nhs.uk/browse/DTOSS-7635)
<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [x] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
