### PR TITLE
feat: enabling the new docker image building script in Cohort Manager

### DIFF
--- a/.github/workflows/cicd-1-pull-request.yaml
+++ b/.github/workflows/cicd-1-pull-request.yaml
@@ -102,10 +102,14 @@ jobs:
   build-image-stage: # Recommended maximum execution time is 3 minutes
     name: "Image build stage"
     needs: [metadata, commit-stage, test-stage]
-    uses: ./.github/workflows/stage-3-build-images.yaml
+    uses: NHSDigital/dtos-devops-templates/.github/workflows/stage-3-build-images.yaml@main
     if: needs.metadata.outputs.does_pull_request_exist == 'true' || (github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'reopened'))
     with:
-      environment_tag: "${{ needs.metadata.outputs.environment_tag }}"
+      docker_compose_file: application/CohortManager/compose.core.yaml,application/CohortManager/compose.cohort-distribution.yaml
+      excluded_containers_csv_list: azurite,azurite-setup,sql-edge,db-setup
+      environment_tag: ${{ needs.metadata.outputs.environment_tag }}
+      function_app_source_code_path: application/CohortManager/src
+      project_name: cohort-manager
     secrets: inherit
   acceptance-stage: # Recommended maximum execution time is 10 minutes
     name: "Acceptance stage"


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

A change that will switch Team Select CI process from using an internal version of `.github/workflows/stage-3-build-images.yaml` and `scripts/deployment/get-docker-names.sh` files to using the ones from [Template repository](https://github.com/NHSDigital/dtos-devops-templates/pull/116), with a support for curating a list of docker image to build based on multiple compose.yaml files.
 

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [X] Refactoring (non-breaking change)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [X] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [X] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
