### PR TITLE
fix: rule 51 null exception

### DIFF
--- a/application/CohortManager/src/Functions/ScreeningValidationService/LookupValidation/Breast_Screening_cohortRules.json
+++ b/application/CohortManager/src/Functions/ScreeningValidationService/LookupValidation/Breast_Screening_cohortRules.json
@@ -48,7 +48,7 @@
         "LocalParams": [
           {
             "Name": "ExistingParticipantInDMS",
-            "Expression": "(existingParticipant.CurrentPosting == \"DMS\" AND !string.IsNullOrEmpty(existingParticipant.PrimaryCareProvider) AND dbLookup.CheckIfPrimaryCareProviderInExcludedSmuList(existingParticipant.PrimaryCareProvider))"
+            "Expression": "(!string.IsNullOrEmpty(existingParticipant.CurrentPosting) AND  existingParticipant.CurrentPosting == \"DMS\" AND !string.IsNullOrEmpty(existingParticipant.PrimaryCareProvider) AND dbLookup.CheckIfPrimaryCareProviderInExcludedSmuList(existingParticipant.PrimaryCareProvider))"
           },
           {
             "Name": "existingParticipantPosting",
@@ -56,7 +56,7 @@
           },
           {
             "Name": "NewParticipantInDMS",
-            "Expression": "(newParticipant.CurrentPosting == \"DMS\" AND !string.IsNullOrEmpty(newParticipant.PrimaryCareProvider) AND dbLookup.CheckIfPrimaryCareProviderInExcludedSmuList(newParticipant.PrimaryCareProvider))"
+            "Expression": "(!string.IsNullOrEmpty(existingParticipant.CurrentPosting) AND  newParticipant.CurrentPosting == \"DMS\" AND !string.IsNullOrEmpty(newParticipant.PrimaryCareProvider) AND dbLookup.CheckIfPrimaryCareProviderInExcludedSmuList(newParticipant.PrimaryCareProvider))"
           },
           {
             "Name": "newParticipantPosting",

--- a/application/CohortManager/src/Functions/ScreeningValidationService/LookupValidation/DataLookupFacadeBreastScreening.cs
+++ b/application/CohortManager/src/Functions/ScreeningValidationService/LookupValidation/DataLookupFacadeBreastScreening.cs
@@ -114,10 +114,10 @@ public class DataLookupFacadeBreastScreening : IDataLookupFacadeBreastScreening
     }
     public string RetrievePostingCategory(string currentPosting)
     {
-        // if(string.IsNullOrEmpty(currentPosting))
-        // {
-        //     return null;
-        // }
+        if(string.IsNullOrEmpty(currentPosting))
+        {
+            return null;
+        }
         var result = _currentPostingClient.GetSingle(currentPosting).Result;
         return result.PostingCategory;
     }

--- a/application/CohortManager/src/Functions/ScreeningValidationService/LookupValidation/DataLookupFacadeBreastScreening.cs
+++ b/application/CohortManager/src/Functions/ScreeningValidationService/LookupValidation/DataLookupFacadeBreastScreening.cs
@@ -75,8 +75,9 @@ public class DataLookupFacadeBreastScreening : IDataLookupFacadeBreastScreening
     /// </summary>
     /// <param name="currentPosting">The participant's current posting (area code).</param>
     /// <returns>bool, whether or not the current posting is valid.<returns>
-    public bool CheckIfCurrentPostingExists(string currentPosting)
+    public bool CheckIfCurrentPostingExists(string? currentPosting)
     {
+
         var result = _currentPostingClient.GetByFilter(i => i.Posting == currentPosting && i.InUse == "Y").Result;
         if (result == null)
         {
@@ -113,6 +114,10 @@ public class DataLookupFacadeBreastScreening : IDataLookupFacadeBreastScreening
     }
     public string RetrievePostingCategory(string currentPosting)
     {
+        // if(string.IsNullOrEmpty(currentPosting))
+        // {
+        //     return null;
+        // }
         var result = _currentPostingClient.GetSingle(currentPosting).Result;
         return result.PostingCategory;
     }

--- a/tests/UnitTests/ScreeningValidationServiceTests/LookupValidation/DataLookupFacadeBreastScreeningTests.cs
+++ b/tests/UnitTests/ScreeningValidationServiceTests/LookupValidation/DataLookupFacadeBreastScreeningTests.cs
@@ -1,11 +1,42 @@
+using DataServices.Client;
+using Microsoft.Extensions.Logging;
+using Model;
+using Moq;
+using NHS.CohortManager.ScreeningValidationService;
+
 namespace NHS.CohortManager.Tests.UnitTests.ScreeningValidationServiceTests;
 
 [TestClass]
 public class DataLookupFacadeBreastScreeningTests
 {
+
+    private readonly Mock<ILogger<DataLookupFacadeBreastScreening>> _logger = new();
+    private readonly Mock<IDataServiceClient<BsSelectGpPractice>> _gpPracticeServiceClient = new();
+    private readonly Mock<IDataServiceClient<BsSelectOutCode>> _outcodeClient = new();
+    private readonly Mock<IDataServiceClient<LanguageCode>> _languageCodeClient = new();
+    private readonly Mock<IDataServiceClient<CurrentPosting>> _currentPostingClient = new();
+    private readonly Mock<IDataServiceClient<ExcludedSMULookup>> _excludedSMUClient = new();
+
+    private IDataLookupFacadeBreastScreening _dataLookupFacade;
+
     public DataLookupFacadeBreastScreeningTests()
     {
+        _dataLookupFacade = new DataLookupFacadeBreastScreening(_logger.Object,_gpPracticeServiceClient.Object,_outcodeClient.Object,_languageCodeClient.Object,_currentPostingClient.Object,_excludedSMUClient.Object);
+    }
 
+
+    [TestMethod]
+    [DataRow("CYM","WALES")]
+    [DataRow(null,null)]
+    public void RetrievePostingCategory_validRequest_ReturnsPostingCategory(string currentPosting, string expectedPostingCategory)
+    {
+        //arrange
+        _currentPostingClient.Setup(x => x.GetSingle(currentPosting)).ReturnsAsync(new CurrentPosting{PostingCategory = expectedPostingCategory});
+        //act
+        var result = _dataLookupFacade.RetrievePostingCategory(currentPosting);
+
+        //assert
+        Assert.AreEqual(expectedPostingCategory,result);
     }
 
 

--- a/tests/UnitTests/ScreeningValidationServiceTests/LookupValidation/DataLookupFacadeBreastScreeningTests.cs
+++ b/tests/UnitTests/ScreeningValidationServiceTests/LookupValidation/DataLookupFacadeBreastScreeningTests.cs
@@ -1,0 +1,12 @@
+namespace NHS.CohortManager.Tests.UnitTests.ScreeningValidationServiceTests;
+
+[TestClass]
+public class DataLookupFacadeBreastScreeningTests
+{
+    public DataLookupFacadeBreastScreeningTests()
+    {
+
+    }
+
+
+}

--- a/tests/UnitTests/ScreeningValidationServiceTests/LookupValidation/LookupValidationTests.cs
+++ b/tests/UnitTests/ScreeningValidationServiceTests/LookupValidation/LookupValidationTests.cs
@@ -613,6 +613,9 @@ public class LookupValidationTests
 
     [DataRow("DMS", "ValidPCP", "", "ABC", "ExcludedPCP", "WALES")] // Valid -> Wales Invalid
     [DataRow("CYM", "ValidPCP", "WALES", "ABC", "ExcludedPCP", "ENGLAND")] // Wales Invalid -> Valid
+
+    [DataRow("DMS", "ValidPCP", "", null, "ExcludedPCP", "WALES")] // Valid -> Wales Invalid (Null current posting)
+    [DataRow(null, "ValidPCP", "WALES", "ABC", "ExcludedPCP", "ENGLAND")] // Wales Invalid -> Valid (Null current posting)
     public async Task Run_ParticipantLocationRemainingOutsideOfCohort_ShouldNotThrowException(string existingCurrentPosting, string existingPrimaryCareProvider, string existingPostingCategory, string newCurrentPosting, string newPrimaryCareProvider, string newPostingCategory)
     {
         // Arrange
@@ -640,6 +643,7 @@ public class LookupValidationTests
             It.Is<IEnumerable<RuleResultTree>>(r => r.Any(x => x.Rule.RuleName == "51.ParticipantLocationRemainingOutsideOfCohort.NonFatal")),
             It.IsAny<ParticipantCsvRecord>()),
             Times.Never());
+        _exceptionHandler.VerifyNoOtherCalls();
     }
 
     [TestMethod]

--- a/tests/UnitTests/TransformDataServiceTests/TransformDataServiceTests/TransformDataLookupFacadeTests.cs
+++ b/tests/UnitTests/TransformDataServiceTests/TransformDataServiceTests/TransformDataLookupFacadeTests.cs
@@ -65,4 +65,5 @@ public class TransformDataLookupFacadeTests
         // Act & Assert
         Assert.ThrowsException<TransformationException>(() => _sut.ValidateOutcode(postcode));
     }
+
 }

--- a/tests/UnitTests/TransformDataServiceTests/TransformDataServiceTests/TransformDataLookupFacadeTests.cs
+++ b/tests/UnitTests/TransformDataServiceTests/TransformDataServiceTests/TransformDataLookupFacadeTests.cs
@@ -65,5 +65,4 @@ public class TransformDataLookupFacadeTests
         // Act & Assert
         Assert.ThrowsException<TransformationException>(() => _sut.ValidateOutcode(postcode));
     }
-
 }


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Rule 51 fails to execute when the current posting is null on either existing or new participant.

## Context

https://nhsd-jira.digital.nhs.uk/browse/DTOSS-7841

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
