### PR TITLE
fix: outcode postcode spliting

### DIFF
--- a/application/CohortManager/src/Functions/ScreeningValidationService/LookupValidation/DataLookupFacadeBreastScreening.cs
+++ b/application/CohortManager/src/Functions/ScreeningValidationService/LookupValidation/DataLookupFacadeBreastScreening.cs
@@ -1,5 +1,6 @@
 namespace NHS.CohortManager.ScreeningValidationService;
 
+using System.Text.RegularExpressions;
 using DataServices.Client;
 using Microsoft.Extensions.Logging;
 using Model;
@@ -52,7 +53,7 @@ public class DataLookupFacadeBreastScreening : IDataLookupFacadeBreastScreening
     /// <returns>bool, whether or not the outcode code exists in the DB.<returns>
     public bool ValidateOutcode(string postcode)
     {
-        var outcode = postcode.Substring(0, postcode.IndexOf(" "));
+        var outcode = ParseOutcode(postcode);
         _logger.LogInformation("Validating Outcode: {Outcode}", outcode);
         var result = _outcodeClient.GetSingle(outcode);
 
@@ -120,5 +121,20 @@ public class DataLookupFacadeBreastScreening : IDataLookupFacadeBreastScreening
         }
         var result = _currentPostingClient.GetSingle(currentPosting).Result;
         return result.PostingCategory;
+    }
+    //TODO: needs moving to shared temp fix for parallel run.
+    private static string ParseOutcode(string postcode)
+    {
+        string pattern = @"^([A-Za-z][A-Ha-hJ-Yj-y]?[0-9][A-Za-z0-9]?) ?[0-9][A-Za-z]{2}$";
+
+        Match match = Regex.Match(postcode, pattern, RegexOptions.IgnoreCase, TimeSpan.FromSeconds(2));
+        if (!match.Success)
+        {
+            return null;
+        }
+
+        string outcode = match.Groups[1].Value;
+
+        return outcode;
     }
 }


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Missing Postcode fix for outcode lookup in lookup rules

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
