### PR TITLE
test: add unit test coverage for ScreeningLkpDataService

### DIFF
--- a/tests/UnitTests/DataServiceTests/DataServiceTests.csproj
+++ b/tests/UnitTests/DataServiceTests/DataServiceTests.csproj
@@ -23,6 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="../../../application/CohortManager/src/Functions/screeningDataServices/ScreeningLkpDataService/ScreeningLkpDataService.csproj" />
     <ProjectReference Include="..\..\..\application\CohortManager\src\Functions\screeningDataServices\BsSelectOutCode\BsSelectOutCode.csproj" />
     <ProjectReference Include="..\..\..\application\CohortManager\src\Functions\screeningDataServices\BsSelectGpPractice\BsSelectGpPractice.csproj" />
     <ProjectReference Include="..\..\..\application\CohortManager\src\Functions\screeningDataServices\CurrentPostingDataService\CurrentPosting.csproj" />

--- a/tests/UnitTests/DataServiceTests/ScreeningLkpDataServiceTests.cs
+++ b/tests/UnitTests/DataServiceTests/ScreeningLkpDataServiceTests.cs
@@ -1,0 +1,72 @@
+namespace DataServiceTests;
+
+using ScreeningLkpDataService;
+using Common;
+using DataServices.Core;
+using Microsoft.Extensions.Logging;
+using Model;
+using Moq;
+using NHS.CohortManager.Tests.TestUtils;
+using System.Net;
+using Microsoft.Azure.Functions.Worker;
+using FluentAssertions;
+
+[TestClass]
+public class ScreeningLkpDataServiceTests
+{
+    private readonly Mock<ILogger<ScreeningLkpDataService>> _mockFunctionLogger = new();
+    private readonly Mock<ILogger<RequestHandler<ScreeningLkp>>> _mockRequestHandlerLogger = new();
+    private readonly CreateResponse _createResponse = new();
+    private readonly Mock<FunctionContext> _context = new();
+    private readonly MockDataServiceAccessor<ScreeningLkp> _dataServiceAccessor;
+    private readonly List<ScreeningLkp> _mockData;
+    private readonly AuthenticationConfiguration _authenticationConfiguration;
+
+    public ScreeningLkpDataServiceTests()
+    {
+        _mockData = new List<ScreeningLkp>{
+            new ScreeningLkp{
+                ScreeningId = 1,
+                ScreeningName = "Test screening name 1",
+                ScreeningWorkflowId = "1"
+            }
+       };
+        _dataServiceAccessor = new MockDataServiceAccessor<ScreeningLkp>(_mockData);
+        _authenticationConfiguration = DataServiceTestHelper.AllowAllAccessConfig;
+    }
+
+    [TestMethod]
+    public async Task RunAsync_GetItemById_ReturnsOKStatusAndCorrectItem()
+    {
+        // Arrange
+        var _requestHandler = new RequestHandler<ScreeningLkp>(_dataServiceAccessor, _mockRequestHandlerLogger.Object, _authenticationConfiguration);
+        ScreeningLkpDataService function = new ScreeningLkpDataService(_mockFunctionLogger.Object, _requestHandler, _createResponse);
+        var req = new MockHttpRequestData(_context.Object, "", "GET");
+
+        // Act
+        var result = await function.Run(req, "1");
+
+        // Assert
+        var expectedScreening = _mockData.Single(i => i.ScreeningWorkflowId == "1");
+        var resultObject = await MockHelpers.GetResponseBodyAsObject<ScreeningLkp>(result);
+
+        Assert.AreEqual(HttpStatusCode.OK, result.StatusCode);
+        resultObject.Should().BeEquivalentTo(expectedScreening);
+    }
+
+    [TestMethod]
+    public async Task RunAsync_GetItemByIdWithInvalidMethod_ReturnsInternalServerError()
+    {
+        // Arrange
+        var invalidMethod = string.Empty;
+        var _requestHandler = new RequestHandler<ScreeningLkp>(_dataServiceAccessor, _mockRequestHandlerLogger.Object, _authenticationConfiguration);
+        ScreeningLkpDataService function = new ScreeningLkpDataService(_mockFunctionLogger.Object, _requestHandler, _createResponse);
+        var req = new MockHttpRequestData(_context.Object, "", invalidMethod);
+
+        // Act
+        var result = await function.Run(req, "1");
+
+        // Assert
+        Assert.AreEqual(HttpStatusCode.InternalServerError, result.StatusCode);
+    }
+}


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description
Adds 100% unit test coverage for ScreeningLkpDataService.
<!-- Describe your changes in detail. -->

## Context
[DTOSS-7857](https://nhsd-jira.digital.nhs.uk/browse/DTOSS-7857)
<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [x] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
