### PR TITLE
fix: change rule to use IsNullOrEmpty

### DIFF
--- a/application/CohortManager/compose.core.yaml
+++ b/application/CohortManager/compose.core.yaml
@@ -13,9 +13,9 @@ services:
       - caasfolder_STORAGE=UseDevelopmentStorage=true
       - MeshApiBaseUrl=https://localhost:8700/messageexchange
       - BSSMailBox="X26ABC1"
-      - MeshPassword = ${MESHPASSWORD}
-      - MeshSharedKey = ${MESHSHAREDKEY}
-      - MeshKeyPassphrase = ${MESHKEYPASSPHRASE}
+      - MeshPassword=${MESHPASSWORD}
+      - MeshSharedKey=${MESHSHAREDKEY}
+      - MeshKeyPassphrase=${MESHKEYPASSPHRASE}
       - ASPNETCORE_URLS=http://*:7059
 
   receive-caas-file:

--- a/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/transformRules.json
+++ b/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/transformRules.json
@@ -482,7 +482,7 @@
       },
       {
         "RuleName": "03.Other.DateOfDeath.NotDea",
-        "Expression": "participant.DateOfDeath != null && participant.ReasonForRemoval != \"DEA\"",
+        "Expression": "!string.IsNullOrEmpty(participant.DateOfDeath) && participant.ReasonForRemoval != \"DEA\"",
         "Actions": {
           "OnSuccess": {
             "Name": "TransformAction",


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description
Changed transform rule 3 date of death not null with RFR != DEA to use `string.IsNullOrEmpty()`

<!-- Describe your changes in detail. -->

## Context
The transformation rule was triggering for every participant because the rule used != null instead of !string.IsNullOrEmpty
[DTOSS-7811](https://nhsd-jira.digital.nhs.uk/browse/DTOSS-7811)

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
