### PR TITLE
fix: DTOSS-7928 fix the trigger to run the image building process workflow

### DIFF
--- a/.github/workflows/cicd-1-pull-request.yaml
+++ b/.github/workflows/cicd-1-pull-request.yaml
@@ -103,7 +103,7 @@ jobs:
     name: "Image build stage"
     needs: [metadata, commit-stage, test-stage]
     uses: NHSDigital/dtos-devops-templates/.github/workflows/stage-3-build-images.yaml@main
-    if: needs.metadata.outputs.does_pull_request_exist == 'true' || (github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'reopened'))
+    if: needs.metadata.outputs.does_pull_request_exist == 'true' || github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'reopened'))
     with:
       docker_compose_file: application/CohortManager/compose.core.yaml,application/CohortManager/compose.cohort-distribution.yaml
       excluded_containers_csv_list: azurite,azurite-setup,sql-edge,db-setup

--- a/.github/workflows/cicd-2-publish.yaml
+++ b/.github/workflows/cicd-2-publish.yaml
@@ -51,15 +51,15 @@ jobs:
           export VERSION="${{ steps.variables.outputs.version }}"
           make list-variables
 
-  publish:
-    name: "Build and publish image stage"
-    # runs-on: ubuntu-latest
-    needs: [metadata]
-    uses: ./.github/workflows/stage-3-build-images.yaml
-    if: github.event.pull_request.merged == true
-    with:
-      environment_tag: "${{ needs.metadata.outputs.environment_tag }}"
-    secrets: inherit
+  # publish:
+  #   name: "Build and publish image stage"
+  #   # runs-on: ubuntu-latest
+  #   needs: [metadata]
+  #   uses: ./.github/workflows/stage-3-build-images.yaml
+  #   if: github.event.pull_request.merged == true
+  #   with:
+  #     environment_tag: "${{ needs.metadata.outputs.environment_tag }}"
+  #   secrets: inherit
     # timeout-minutes: 3
     # steps:
     #   - name: "Checkout code"

--- a/application/CohortManager/src/Functions/Shared/rebuild.all
+++ b/application/CohortManager/src/Functions/Shared/rebuild.all
@@ -1,0 +1,1 @@
+rebuild_all_images


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

A fix to be able to run the image building process straight from the `cicd-1-pull-request.yaml` workflow instead of using the `cicd-2-publish.yaml` one, which was still referencing the old `.github/workflows/stage-3-build.yam`l file.

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [X] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [X] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [X] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
