### PR TITLE
fix: dummy postcode validation

### DIFF
--- a/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/TransformDataLookupFacade.cs
+++ b/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/TransformDataLookupFacade.cs
@@ -1,9 +1,8 @@
 namespace NHS.CohortManager.CohortDistribution;
 
 using DataServices.Client;
-using Microsoft.Extensions.Logging;
-using System.Text.RegularExpressions;
 using Model;
+using Common;
 
 public class TransformDataLookupFacade : ITransformDataLookupFacade
 {
@@ -18,7 +17,8 @@ public class TransformDataLookupFacade : ITransformDataLookupFacade
 
     public bool ValidateOutcode(string postcode)
     {
-        string outcode = ParseOutcode(postcode);
+        string outcode = ValidationHelper.ParseOutcode(postcode)
+            ?? throw new TransformationException("Postcode format invalid");
 
         var result = _outcodeClient.GetSingle(outcode).Result;
 
@@ -26,7 +26,8 @@ public class TransformDataLookupFacade : ITransformDataLookupFacade
     }
 
     public string GetBsoCode(string postcode){
-        string outcode = ParseOutcode(postcode);
+        string outcode = ValidationHelper.ParseOutcode(postcode)
+            ?? throw new TransformationException("Postcode format invalid");
 
         var result = _outcodeClient.GetSingle(outcode).Result;
 
@@ -47,21 +48,5 @@ public class TransformDataLookupFacade : ITransformDataLookupFacade
         if (gpPractice == null) return string.Empty;
 
         return gpPractice.BsoCode;
-    }
-
-    /// <summary>
-    /// Gets the outcode (first half of the postcode) from a postcode.
-    /// Can handle postcodes in any format (including without spaces)
-    /// </summary>
-    private static string ParseOutcode(string postcode)
-    {
-        string pattern = @"^([A-Za-z][A-Ha-hJ-Yj-y]?[0-9][A-Za-z0-9]?) ?[0-9][A-Za-z]{2}$";
-
-        Match match = Regex.Match(postcode, pattern, RegexOptions.IgnoreCase, TimeSpan.FromSeconds(2));
-        if (!match.Success) throw new TransformationException("Postcode format invalid");
-
-        string outcode = match.Groups[1].Value;
-
-        return outcode;
     }
 }

--- a/application/CohortManager/src/Functions/ScreeningValidationService/LookupValidation/DataLookupFacadeBreastScreening.cs
+++ b/application/CohortManager/src/Functions/ScreeningValidationService/LookupValidation/DataLookupFacadeBreastScreening.cs
@@ -1,9 +1,10 @@
 namespace NHS.CohortManager.ScreeningValidationService;
 
-using System.Text.RegularExpressions;
 using DataServices.Client;
 using Microsoft.Extensions.Logging;
 using Model;
+using Common;
+
 public class DataLookupFacadeBreastScreening : IDataLookupFacadeBreastScreening
 {
     private readonly ILogger<DataLookupFacadeBreastScreening> _logger;
@@ -53,7 +54,7 @@ public class DataLookupFacadeBreastScreening : IDataLookupFacadeBreastScreening
     /// <returns>bool, whether or not the outcode code exists in the DB.<returns>
     public bool ValidateOutcode(string postcode)
     {
-        var outcode = ParseOutcode(postcode);
+        var outcode = ValidationHelper.ParseOutcode(postcode);
         _logger.LogInformation("Validating Outcode: {Outcode}", outcode);
         var result = _outcodeClient.GetSingle(outcode);
 
@@ -121,30 +122,5 @@ public class DataLookupFacadeBreastScreening : IDataLookupFacadeBreastScreening
         }
         var result = _currentPostingClient.GetSingle(currentPosting).Result;
         return result.PostingCategory;
-    }
-
-    //TODO: needs moving to shared temp fix for parallel run.
-
-    /// <summary>
-    /// Gets the outcode (1st part of postcode) from the postcode.
-    /// </summary>
-    /// <param name="postcode">a non-null string representing the postcode</param>
-    /// <remarks>
-    /// Works for valid UK postcodes and dummy postcodes.
-    /// Works with or without a space separator between outcode and incode.
-    /// </remarks>
-    private static string ParseOutcode(string postcode)
-    {
-        string pattern = @"^([A-Za-z][A-Za-z]?[0-9][A-Za-z0-9]?) ?[0-9][A-Za-z]{2}$";
-
-        Match match = Regex.Match(postcode, pattern, RegexOptions.IgnoreCase, TimeSpan.FromSeconds(2));
-        if (!match.Success)
-        {
-            return null;
-        }
-
-        string outcode = match.Groups[1].Value;
-
-        return outcode;
     }
 }

--- a/application/CohortManager/src/Functions/ScreeningValidationService/LookupValidation/DataLookupFacadeBreastScreening.cs
+++ b/application/CohortManager/src/Functions/ScreeningValidationService/LookupValidation/DataLookupFacadeBreastScreening.cs
@@ -122,10 +122,20 @@ public class DataLookupFacadeBreastScreening : IDataLookupFacadeBreastScreening
         var result = _currentPostingClient.GetSingle(currentPosting).Result;
         return result.PostingCategory;
     }
+
     //TODO: needs moving to shared temp fix for parallel run.
+
+    /// <summary>
+    /// Gets the outcode (1st part of postcode) from the postcode.
+    /// </summary>
+    /// <param name="postcode">a non-null string representing the postcode</param>
+    /// <remarks>
+    /// Works for valid UK postcodes and dummy postcodes.
+    /// Works with or without a space separator between outcode and incode.
+    /// </remarks>
     private static string ParseOutcode(string postcode)
     {
-        string pattern = @"^([A-Za-z][A-Ha-hJ-Yj-y]?[0-9][A-Za-z0-9]?) ?[0-9][A-Za-z]{2}$";
+        string pattern = @"^([A-Za-z][A-Za-z]?[0-9][A-Za-z0-9]?) ?[0-9][A-Za-z]{2}$";
 
         Match match = Regex.Match(postcode, pattern, RegexOptions.IgnoreCase, TimeSpan.FromSeconds(2));
         if (!match.Success)

--- a/application/CohortManager/src/Functions/ScreeningValidationService/StaticValidation/Breast_Screening_staticRules.json
+++ b/application/CohortManager/src/Functions/ScreeningValidationService/StaticValidation/Breast_Screening_staticRules.json
@@ -52,7 +52,7 @@
       },
       {
         "RuleName": "30.Postcode.NonFatal",
-        "Expression": "string.IsNullOrEmpty(participant.Postcode) OR Regex.IsMatch(participant.Postcode, \"^([A-Za-z][A-Ha-hJ-Yj-y]?[0-9][A-Za-z0-9]? ?[0-9][A-Za-z]{2}|[Gg][Ii][Rr] ?0[Aa]{2})$\", RegexOptions.IgnoreCase)",
+        "Expression": "string.IsNullOrEmpty(participant.Postcode) OR ValidationHelper.ValidatePostcode(participant.Postcode)",
         "Actions": {
           "OnFailure": {
             "Name": "OutputExpression",

--- a/application/CohortManager/src/Functions/Shared/Common/ValidationHelper.cs
+++ b/application/CohortManager/src/Functions/Shared/Common/ValidationHelper.cs
@@ -1,6 +1,7 @@
 namespace Common;
 
 using System.Globalization;
+using System.Text.RegularExpressions;
 
 public static class ValidationHelper
 {
@@ -60,6 +61,30 @@ public static class ValidationHelper
         }
         return false;
 
+    }
+
+    /// <summary>
+    /// Validates the postcode according to the offical rules for valid
+    /// UK postcodes, also accepts dummy postcodes as valid.
+    /// </summary>
+    /// <param name="postcode">Postcode string (not null)</param>
+    /// <returns>bool, whether or not the postcode is valid</returns>
+    /// <remarks> 
+    /// further information for postcode validation can be found in 
+    /// ADR-008 on confluence.
+    /// </remarks>
+    public static bool ValidatePostcode(string postcode)
+    {
+        string validPostcodePattern = "^([A-Za-z][A-Ha-hJ-Yj-y]?[0-9][A-Za-z0-9]? ?[0-9][A-Za-z]{2}|[Gg][Ii][Rr] ?0[Aa]{2})$";
+        string dummyPostcodePattern = "^ZZ99 ?[A-Z]{2}$";
+
+        Match validPostcodeMatch = Regex.Match(postcode, validPostcodePattern, RegexOptions.IgnoreCase);
+        Match dummyPostcodeMatch = Regex.Match(postcode, dummyPostcodePattern, RegexOptions.IgnoreCase);
+
+        if (validPostcodeMatch.Success || dummyPostcodeMatch.Success)
+            return true;
+
+        return false;
     }
 
     private static bool ParseInt32(char value, out int integerValue)

--- a/application/CohortManager/src/Functions/Shared/Common/ValidationHelper.cs
+++ b/application/CohortManager/src/Functions/Shared/Common/ValidationHelper.cs
@@ -76,7 +76,7 @@ public static class ValidationHelper
     public static bool ValidatePostcode(string postcode)
     {
         string validPostcodePattern = "^([A-Za-z][A-Ha-hJ-Yj-y]?[0-9][A-Za-z0-9]? ?[0-9][A-Za-z]{2}|[Gg][Ii][Rr] ?0[Aa]{2})$";
-        string dummyPostcodePattern = "^ZZ99 ?[A-Z]{2}$";
+        string dummyPostcodePattern = "^ZZ99 ?[0-9][A-Z]{2}$";
 
         Match validPostcodeMatch = Regex.Match(postcode, validPostcodePattern, RegexOptions.IgnoreCase);
         Match dummyPostcodeMatch = Regex.Match(postcode, dummyPostcodePattern, RegexOptions.IgnoreCase);
@@ -85,6 +85,29 @@ public static class ValidationHelper
             return true;
 
         return false;
+    }
+
+    /// <summary>
+    /// Gets the outcode (1st part of postcode) from the postcode.
+    /// </summary>
+    /// <param name="postcode">a non-null string representing the postcode</param>
+    /// <remarks>
+    /// Works for valid UK postcodes and dummy postcodes.
+    /// Works with or without a space separator between outcode and incode.
+    /// </remarks>
+    public static string? ParseOutcode(string postcode)
+    {
+        string pattern = @"^([A-Za-z][A-Za-z]?[0-9][A-Za-z0-9]?) ?[0-9][A-Za-z]{2}$";
+
+        Match match = Regex.Match(postcode, pattern, RegexOptions.IgnoreCase, TimeSpan.FromSeconds(2));
+        if (!match.Success)
+        {
+            return null;
+        }
+
+        string outcode = match.Groups[1].Value;
+
+        return outcode;
     }
 
     private static bool ParseInt32(char value, out int integerValue)

--- a/tests/UnitTests/ScreeningValidationServiceTests/StaticValidation/StaticValidationTests.cs
+++ b/tests/UnitTests/ScreeningValidationServiceTests/StaticValidation/StaticValidationTests.cs
@@ -324,6 +324,10 @@ public class StaticValidationTests
     [DataRow("GIR0AA")]
     [DataRow("")]
     [DataRow(null)]
+    // Dummy Postcodes
+    [DataRow("ZZ99 9FZ")]
+    [DataRow("ZZ999FZ")]
+    [DataRow("ZZ99 3WZ")]
     public async Task Run_ValidPostcode_PostcodeRulePasses(string postcode)
     {
         // Arrange
@@ -347,6 +351,9 @@ public class StaticValidationTests
     [DataRow("AA 12345")]
     [DataRow("A1B 1CDE")]
     [DataRow("A1A@1AA")]
+    [DataRow("ZZ9 4LZ")]
+    [DataRow("Z99 4LZ")]
+    [DataRow("ZzZ99 LZ")]
     public async Task Run_InvalidPostcode_PostcodeRuleFailsAndExceptionCreated(string postcode)
     {
         // Arrange


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description
- Postcode validation and outcode parser now able to handle dummy postcodes
- moved outcode parsing to shared

<!-- Describe your changes in detail. -->

## Context
[DTOSS-8080](https://nhsd-jira.digital.nhs.uk/browse/DTOSS-8080)

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
