### PR TITLE
fix: create exception returning the wrong HTTP code

### DIFF
--- a/application/CohortManager/src/Functions/ExceptionHandling/CreateException/CreateException.cs
+++ b/application/CohortManager/src/Functions/ExceptionHandling/CreateException/CreateException.cs
@@ -49,7 +49,7 @@ public class CreateException
         if (await _validationData.Create(exception))
         {
             _logger.LogInformation("The exception record has been created successfully");
-            return _createResponse.CreateHttpResponse(HttpStatusCode.Created, req);
+            return _createResponse.CreateHttpResponse(HttpStatusCode.OK, req);
         }
 
         _logger.LogError("The exception record was not inserted into the database: {Exception}", exception);

--- a/tests/UnitTests/ExceptionHandlingTests/CreateExceptionTests/CreateExceptionTests.cs
+++ b/tests/UnitTests/ExceptionHandlingTests/CreateExceptionTests/CreateExceptionTests.cs
@@ -68,7 +68,7 @@ public class CreateExceptionTests
     }
 
     [TestMethod]
-    public async Task Run_ExceptionRecordCreated_ReturnsCreated()
+    public async Task Run_ExceptionRecordCreated_ReturnsOk()
     {
         // Arrange
         _validationExceptionData.Setup(s => s.Create(It.IsAny<ValidationException>())).ReturnsAsync(true);
@@ -79,7 +79,7 @@ public class CreateExceptionTests
         // Assert
         Assert.IsNotNull(result);
         _validationExceptionData.Verify(v => v.Create(It.IsAny<ValidationException>()), Times.Once);
-        Assert.AreEqual(HttpStatusCode.Created, result.StatusCode);
+        Assert.AreEqual(HttpStatusCode.OK, result.StatusCode);
     }
 
     [TestMethod]


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description
- changed create exception to return OK instead of CREATED

<!-- Describe your changes in detail. -->

## Context
In a previous PR, create exception was changed to return CREATED to fix a sonarqube issue, but the exception handler client expects an OK response, so this was causing the create exception request to be logged as a failure

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
