### PR TITLE
feat: DTOSS-8096 GetParticipantReferenceData test coverage

### DIFF
--- a/application/CohortManager/src/Functions/Functions.sln
+++ b/application/CohortManager/src/Functions/Functions.sln
@@ -226,6 +226,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AddCohortDistributionDataTe
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GetValidationExceptionsTests", "..\..\..\..\tests\UnitTests\ScreeningDataServicesTests\ValidationExceptionDataTests\GetValidationExceptionTests\GetValidationExceptionsTests.csproj", "{8E769A0D-F808-48F7-9E36-6F8BDC204C80}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GetParticipantReferenceDataTests", "..\..\..\..\tests\UnitTests\ParticipantManagementServicesTests\GetParticipantReferenceDataTests\GetParticipantReferenceDataTests.csproj", "{BF97136A-59AA-4468-9F10-B1F91140EE62}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -628,6 +630,10 @@ Global
 		{8E769A0D-F808-48F7-9E36-6F8BDC204C80}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8E769A0D-F808-48F7-9E36-6F8BDC204C80}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8E769A0D-F808-48F7-9E36-6F8BDC204C80}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BF97136A-59AA-4468-9F10-B1F91140EE62}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BF97136A-59AA-4468-9F10-B1F91140EE62}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BF97136A-59AA-4468-9F10-B1F91140EE62}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BF97136A-59AA-4468-9F10-B1F91140EE62}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/tests/UnitTests/ParticipantManagementServicesTests/GetParticipantReferenceDataTests/GetParticipantReferenceDataTests.cs
+++ b/tests/UnitTests/ParticipantManagementServicesTests/GetParticipantReferenceDataTests/GetParticipantReferenceDataTests.cs
@@ -124,6 +124,7 @@ public class GetParticipantReferenceDataTests
         // Act
         var result = await _function.Run(req);
 
+
         // Assert
         Assert.AreEqual(_mockHttpResponseData, result);
         _mockLogger.Verify(

--- a/tests/UnitTests/ParticipantManagementServicesTests/GetParticipantReferenceDataTests/GetParticipantReferenceDataTests.cs
+++ b/tests/UnitTests/ParticipantManagementServicesTests/GetParticipantReferenceDataTests/GetParticipantReferenceDataTests.cs
@@ -2,7 +2,6 @@ namespace NHS.CohortManager.Tests.UnitTests.ParticipantManagementServiceTests;
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Net;
 using System.Text.Json;
 using System.Threading.Tasks;
@@ -24,7 +23,6 @@ public class GetParticipantReferenceDataTests
     private Mock<IDataServiceClient<GeneCodeLkp>> _mockGeneCodeClient;
     private Mock<IDataServiceClient<HigherRiskReferralReasonLkp>> _mockRiskReasonClient;
     private readonly Mock<FunctionContext> _context = new();
-    private Mock<HttpRequestData> _mockRequest;
     private readonly HttpResponseData _mockHttpResponseData;
 
     private GetParticipantReferenceData _function;
@@ -36,7 +34,6 @@ public class GetParticipantReferenceDataTests
         _mockCreateResponse = new Mock<ICreateResponse>();
         _mockGeneCodeClient = new Mock<IDataServiceClient<GeneCodeLkp>>();
         _mockRiskReasonClient = new Mock<IDataServiceClient<HigherRiskReferralReasonLkp>>();
-        _mockRequest = new Mock<HttpRequestData>();
 
         _function = new GetParticipantReferenceData(
             _mockLogger.Object,

--- a/tests/UnitTests/ParticipantManagementServicesTests/GetParticipantReferenceDataTests/GetParticipantReferenceDataTests.cs
+++ b/tests/UnitTests/ParticipantManagementServicesTests/GetParticipantReferenceDataTests/GetParticipantReferenceDataTests.cs
@@ -1,0 +1,141 @@
+namespace NHS.CohortManager.Tests.UnitTests.ParticipantManagementServiceTests;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using NHS.CohortManager.ParticipantManagementService;
+using Common;
+using Model;
+using DataServices.Client;
+using Microsoft.Azure.Functions.Worker;
+
+[TestClass]
+public class GetParticipantReferenceDataTests
+{
+    private Mock<ILogger<GetParticipantReferenceData>> _mockLogger;
+    private Mock<ICreateResponse> _mockCreateResponse;
+    private Mock<IDataServiceClient<GeneCodeLkp>> _mockGeneCodeClient;
+    private Mock<IDataServiceClient<HigherRiskReferralReasonLkp>> _mockRiskReasonClient;
+    private readonly Mock<FunctionContext> _context = new();
+    private Mock<HttpRequestData> _mockRequest;
+    private readonly HttpResponseData _mockHttpResponseData;
+
+    private GetParticipantReferenceData _function;
+
+    [TestInitialize]
+    public void TestInitialize()
+    {
+        _mockLogger = new Mock<ILogger<GetParticipantReferenceData>>();
+        _mockCreateResponse = new Mock<ICreateResponse>();
+        _mockGeneCodeClient = new Mock<IDataServiceClient<GeneCodeLkp>>();
+        _mockRiskReasonClient = new Mock<IDataServiceClient<HigherRiskReferralReasonLkp>>();
+        _mockRequest = new Mock<HttpRequestData>();
+
+        _function = new GetParticipantReferenceData(
+            _mockLogger.Object,
+            _mockCreateResponse.Object,
+            _mockGeneCodeClient.Object,
+            _mockRiskReasonClient.Object
+        );
+    }
+
+    [TestMethod]
+    public async Task Run_ReturnsOk_WithData()
+    {
+        // Arrange
+
+        var geneCodeList = new List<GeneCodeLkp>
+        {
+            new GeneCodeLkp { GeneCode = "A1", GeneCodeDescription = "Gene A1" }
+        };
+
+        var riskReasonList = new List<HigherRiskReferralReasonLkp>
+        {
+            new HigherRiskReferralReasonLkp { HigherRiskReferralReasonCode = "HR1", HigherRiskReferralReasonCodeDescription = "Reason HR1" }
+        };
+
+        _mockGeneCodeClient.Setup(x => x.GetAll()).ReturnsAsync(geneCodeList);
+        _mockRiskReasonClient.Setup(x => x.GetAll()).ReturnsAsync(riskReasonList);
+
+        var expectedData = new ParticipantReferenceData(
+            new Dictionary<string, string> { { "A1", "Gene A1" } },
+            new Dictionary<string, string> { { "HR1", "Reason HR1" } }
+        );
+
+        var req = new MockHttpRequestData(_context.Object, "", "GET");
+        _mockCreateResponse
+            .Setup(x => x.CreateHttpResponse(HttpStatusCode.OK, req, It.IsAny<string>()))
+            .Returns(_mockHttpResponseData);
+
+        // Act
+        var result = await _function.Run(req);
+        var serializedData = JsonSerializer.Serialize(expectedData);
+
+
+
+        // Assert
+        Assert.AreEqual(_mockHttpResponseData, result);
+        _mockCreateResponse.Verify(x =>
+            x.CreateHttpResponse(HttpStatusCode.OK, req, serializedData), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task Run_ReturnsOk_WithEmptyLists()
+    {
+        // Arrange
+        _mockGeneCodeClient.Setup(x => x.GetAll()).ReturnsAsync(new List<GeneCodeLkp>());
+        _mockRiskReasonClient.Setup(x => x.GetAll()).ReturnsAsync(new List<HigherRiskReferralReasonLkp>());
+
+        var expectedData = new ParticipantReferenceData(
+            new Dictionary<string, string>(),
+            new Dictionary<string, string>()
+        );
+
+        var req  = new MockHttpRequestData(_context.Object, "", "GET");
+        _mockCreateResponse
+            .Setup(x => x.CreateHttpResponse(HttpStatusCode.OK, req, It.IsAny<string>()))
+            .Returns(_mockHttpResponseData);
+
+        // Act
+        var result = await _function.Run(req);
+        var serializedData = JsonSerializer.Serialize(expectedData);
+
+        // Assert
+        Assert.AreEqual(_mockHttpResponseData, result);
+        _mockCreateResponse.Verify(x =>
+            x.CreateHttpResponse(HttpStatusCode.OK, req, serializedData), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task Run_ReturnsInternalServerError_OnException()
+    {
+        // Arrange
+        _mockGeneCodeClient.Setup(x => x.GetAll()).ThrowsAsync(new Exception("Simulated Failure"));
+        var req  = new MockHttpRequestData(_context.Object, "", "GET");
+
+        _mockCreateResponse
+            .Setup(x => x.CreateHttpResponse(HttpStatusCode.InternalServerError, req, null))
+            .Returns(_mockHttpResponseData);
+
+        // Act
+        var result = await _function.Run(req);
+
+        // Assert
+        Assert.AreEqual(_mockHttpResponseData, result);
+        _mockLogger.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => true),
+                It.IsAny<Exception>(),
+                It.Is<Func<It.IsAnyType, Exception, string>>((v, t) => true)),
+            Times.Once);
+    }
+}

--- a/tests/UnitTests/ParticipantManagementServicesTests/GetParticipantReferenceDataTests/GetParticipantReferenceDataTests.csproj
+++ b/tests/UnitTests/ParticipantManagementServicesTests/GetParticipantReferenceDataTests/GetParticipantReferenceDataTests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.8.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.8.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\application\CohortManager\src\Functions\ParticipantManagementServices\GetParticipantReferenceData\GetParticipantReferenceData.csproj" />
+    <ProjectReference Include="..\..\..\..\application\CohortManager\src\Functions\Shared\Common\Common.csproj" />
+    <ProjectReference Include="..\..\..\TestUtils\TestUtils.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Updated and improved automated tests to include Component tests (Happy and Unhappy paths) and unit tests for GetParticipantReferenceData.

Achieved 100% test coverage

![image](https://github.com/user-attachments/assets/1a548d1c-211f-427b-a54e-4a12e0949e42)

PFB jira link:
https://nhsd-jira.digital.nhs.uk/browse/DTOSS-8096

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
