### PR TITLE
feat: DTOSS-8151 add test coverage reporting to parallelised unit tests

### DIFF
--- a/.github/workflows/stage-2-test.yaml
+++ b/.github/workflows/stage-2-test.yaml
@@ -88,18 +88,21 @@ jobs:
           mkdir "TestResults"
           find "${UNIT_TEST_DIR}/${{ matrix.scope }}" -name '*.csproj' | while read -r file; do
             echo -e "\nRunning unit tests for:\n${file}"
-            dotnet test "${file}" --logger ${LOGGER_FORMAT} --results-directory "TestResults" --verbosity quiet
+            base=$(basename "$file" .csproj)
+            dotnet test "${file}" --results-directory "TestResults" --logger "${LOGGER_FORMAT};LogFileName=${base}.${LOGGER_FORMAT}" --collect:"XPlat Code Coverage" --verbosity quiet
           done
       - name: Upload test results as artifact
         uses: actions/upload-artifact@v4
         with:
           name: test-results-${{ matrix.scope }}
-          path: TestResults/**/*.${{ inputs.unit_test_logger_format }}
+          path: |
+            TestResults/**/*.${{ inputs.unit_test_logger_format }}
+            TestResults/**/coverage.cobertura.xml
 
   aggregate-test-results:
     name: Aggregate results and report
     runs-on: ubuntu-latest
-    needs: [test-unit,test-coverage]
+    needs: [test-unit]
     permissions:
       pull-requests: write
     steps:
@@ -111,19 +114,25 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: aggregated-results
-      - name: Upload aggregated results as a single artifact
+      - name: Install ReportGenerator
+        run: dotnet tool install --global dotnet-reportgenerator-globaltool
+      - name: Collate coverage reports
+        continue-on-error: true
+        run: reportgenerator -reports:aggregated-results/**/coverage.cobertura.xml -targetdir:coverage -reporttypes:Cobertura
+      - name: Upload test coverage report
         uses: actions/upload-artifact@v4
         with:
-          name: test-results-aggregated
-          path: aggregated-results/**/*.${{ inputs.unit_test_logger_format }}
+          name: test-coverage-report
+          path: coverage/Cobertura.xml
       - name: Report results
         uses: bibipkins/dotnet-test-reporter@v1.5.3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           comment-title: Unit Test Results
           results-path: aggregated-results/**/*.${{ inputs.unit_test_logger_format }}
-          # coverage-path: aggregated-results/coverage.xml
-          # coverage-threshold: 80
+          coverage-type: cobertura
+          coverage-path: coverage/Cobertura.xml
+          # coverage-threshold: 50
 
   test-lint:
     name: Linting
@@ -139,24 +148,8 @@ jobs:
         run: |
           echo "Nothing to save"
 
-  test-coverage:
-    name: Test coverage
-    needs: [test-unit]
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      - name: Run test coverage check
-        run: |
-          make test-coverage
-      - name: Save the coverage check result
-        run: |
-          echo "Nothing to save"
-
   perform-static-analysis:
     name: Perform static analysis
-    needs: [test-unit]
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/.github/workflows/stage-2-test.yaml
+++ b/.github/workflows/stage-2-test.yaml
@@ -110,20 +110,22 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
-      - name: Download all test result artifacts
+      - name: Download all test results
         uses: actions/download-artifact@v4
         with:
           path: aggregated-results
-      - name: Install ReportGenerator
-        run: dotnet tool install --global dotnet-reportgenerator-globaltool
       - name: Collate coverage reports
         continue-on-error: true
-        run: reportgenerator -reports:aggregated-results/**/coverage.cobertura.xml -targetdir:coverage -reporttypes:Cobertura
-      - name: Upload test coverage report
+        run: |
+          mkdir coverage
+          dotnet tool install --global dotnet-coverage
+          dotnet coverage merge *.cobertura.xml --recursive -o coverage/vscoverage.xml -f xml
+          dotnet coverage merge *.cobertura.xml --recursive -o coverage/cobertura.xml -f cobertura
+      - name: Upload coverage report
         uses: actions/upload-artifact@v4
         with:
           name: test-coverage-report
-          path: coverage/Cobertura.xml
+          path: coverage/*.xml
       - name: Report results
         uses: bibipkins/dotnet-test-reporter@v1.5.3
         with:
@@ -131,7 +133,7 @@ jobs:
           comment-title: Unit Test Results
           results-path: aggregated-results/**/*.${{ inputs.unit_test_logger_format }}
           coverage-type: cobertura
-          coverage-path: coverage/Cobertura.xml
+          coverage-path: coverage/cobertura.xml
           # coverage-threshold: 50
 
   test-lint:
@@ -150,6 +152,7 @@ jobs:
 
   perform-static-analysis:
     name: Perform static analysis
+    needs: [aggregate-test-results]
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -160,6 +163,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Full history is needed to improving relevancy of reporting
+      - name: Download coverage report
+        uses: actions/download-artifact@v4
+        with:
+          name: test-coverage-report
+          path: coverage
       - name: Perform static analysis
         uses: ./.github/actions/perform-static-analysis
         with:

--- a/scripts/config/sonar-scanner.properties
+++ b/scripts/config/sonar-scanner.properties
@@ -7,3 +7,6 @@ sonar.sources=.
 
 #sonar.python.coverage.reportPaths=.coverage/coverage.xml
 #sonar.[javascript|typescript].lcov.reportPaths=.coverage/lcov.info
+
+# Test Coverage for C# (Ensure Reports Are Generated Before Running SonarScanner)
+sonar.cs.vscoveragexml.reportsPaths=coverage/vscoverage.xml


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Adds coverage reporting with minor changes to the parallelised unit test workflow. The report can set a coverage threshold gate per individual test. This remains disabled for the time being, since some tests currently have low coverage. The combined coverage report is also rendered in VisualStudio XML format, for ingestion by SonarQube Cloud.

## Context
Worked examples tend to show either parallel unit tests **or** exporting coverage reports to SonarQube Cloud - but not, it seems, both. Most combined coverage reports sacrifice test parallelism.
 
This was very difficult to get working owing to SonarQube Cloud not supporting Cobertura format test-coverage reports, and by the scarcity of tools that can merge multiple reports after parallelised testing runs. Most tools fail to fit this use case because:
- they do not support OpenCover test-coverage reports
- they paywall OpenCover output (ReportGenerator)
- they can only merge at the time the test runs (Coverlet - no use for a matrix job)
- they imply running all tests again (negating the parallelism)

Many, many alternative approaches were tried by @patrickmoore-nc and @SamAinsworth-NHS to arrive at this working solution.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [x] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
