### PR TITLE
feat: add shared httpclient function

### DIFF
--- a/application/CohortManager/src/Functions/Functions.sln
+++ b/application/CohortManager/src/Functions/Functions.sln
@@ -228,6 +228,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GetValidationExceptionsTest
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GetParticipantReferenceDataTests", "..\..\..\..\tests\UnitTests\ParticipantManagementServicesTests\GetParticipantReferenceDataTests\GetParticipantReferenceDataTests.csproj", "{BF97136A-59AA-4468-9F10-B1F91140EE62}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HttpClientFunctionTests", "..\..\..\..\tests\UnitTests\SharedTests\HttpClientFunctionTests\HttpClientFunctionTests.csproj", "{D488875D-E001-4FAC-A877-E9E2E805F169}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -634,6 +636,10 @@ Global
 		{BF97136A-59AA-4468-9F10-B1F91140EE62}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BF97136A-59AA-4468-9F10-B1F91140EE62}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BF97136A-59AA-4468-9F10-B1F91140EE62}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D488875D-E001-4FAC-A877-E9E2E805F169}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D488875D-E001-4FAC-A877-E9E2E805F169}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D488875D-E001-4FAC-A877-E9E2E805F169}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D488875D-E001-4FAC-A877-E9E2E805F169}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/application/CohortManager/src/Functions/Shared/Common/HttpClientFunction.cs
+++ b/application/CohortManager/src/Functions/Shared/Common/HttpClientFunction.cs
@@ -1,0 +1,58 @@
+namespace Common;
+
+using Microsoft.Extensions.Logging;
+
+public class HttpClientFunction : IHttpClientFunction
+{
+    private readonly ILogger<HttpClientFunction> _logger;
+    private readonly IHttpClientFactory _factory;
+
+    public HttpClientFunction(ILogger<HttpClientFunction> logger, IHttpClientFactory factory)
+    {
+        _logger = logger;
+        _factory = factory;
+    }
+
+    public async Task<HttpResponseMessage> GetAsync(string url, Dictionary<string, string> headers)
+    {
+        using var client = _factory.CreateClient();
+
+        client.BaseAddress = new Uri(url);
+        client.Timeout = TimeSpan.FromMinutes(1000);
+
+        if (headers != null)
+        {
+            foreach (var header in headers)
+            {
+                client.DefaultRequestHeaders.Add(header.Key, header.Value);
+            }
+        }
+
+        try
+        {
+            HttpResponseMessage response = await client.GetAsync(url);
+            return response;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to execute request to {Url}, message: {Message}", RemoveURLQueryString(url), ex.Message);
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Removes the query string from the URL to prevent us logging sensitive information.
+    /// </summary>
+    /// <param name="url"></param>
+    /// <returns></returns>
+    private static string RemoveURLQueryString(string url)
+    {
+        if (string.IsNullOrEmpty(url))
+        {
+            return url;
+        }
+
+        int queryIndex = url.IndexOf('?');
+        return queryIndex >= 0 ? url.Substring(0, queryIndex) : url;
+    }
+}

--- a/application/CohortManager/src/Functions/Shared/Common/HttpClientFunction.cs
+++ b/application/CohortManager/src/Functions/Shared/Common/HttpClientFunction.cs
@@ -13,6 +13,12 @@ public class HttpClientFunction : IHttpClientFunction
         _factory = factory;
     }
 
+    /// <summary>
+    /// Performs a GET request using HttpClient.
+    /// </summary>
+    /// <param name="url">URL to be used in request.</param>
+    /// <param name="headers">Headers to be used in request.</param>
+    /// <returns>HttpResponseMessage<returns>
     public async Task<HttpResponseMessage> GetAsync(string url, Dictionary<string, string> headers)
     {
         using var client = _factory.CreateClient();
@@ -43,8 +49,6 @@ public class HttpClientFunction : IHttpClientFunction
     /// <summary>
     /// Removes the query string from the URL to prevent us logging sensitive information.
     /// </summary>
-    /// <param name="url"></param>
-    /// <returns></returns>
     private static string RemoveURLQueryString(string url)
     {
         if (string.IsNullOrEmpty(url))

--- a/application/CohortManager/src/Functions/Shared/Common/HttpClientFunction.cs
+++ b/application/CohortManager/src/Functions/Shared/Common/HttpClientFunction.cs
@@ -13,12 +13,6 @@ public class HttpClientFunction : IHttpClientFunction
         _factory = factory;
     }
 
-    /// <summary>
-    /// Performs a GET request using HttpClient.
-    /// </summary>
-    /// <param name="url">URL to be used in request.</param>
-    /// <param name="headers">Headers to be used in request.</param>
-    /// <returns>HttpResponseMessage<returns>
     public async Task<HttpResponseMessage> GetAsync(string url, Dictionary<string, string> headers)
     {
         using var client = _factory.CreateClient();

--- a/application/CohortManager/src/Functions/Shared/Common/Interfaces/ICallFunction.cs
+++ b/application/CohortManager/src/Functions/Shared/Common/Interfaces/ICallFunction.cs
@@ -2,6 +2,12 @@ namespace Common;
 
 using System.Net;
 
+/// <summary>
+/// The methods in this interface use the obsolete WebRequest.Create method.
+/// A new shared function called HttpClientFunction.cs has been created to implement these methods using the recommended HttpClient.
+/// This interface is still in use until all these methods have been implemented in HttpClientFunction.cs, when it will be replaced by HttpClientFunction.cs.
+/// Any new methods that are required should only be implemented in HttpClientFunction.cs.
+/// </summary>
 public interface ICallFunction
 {
     Task<HttpWebResponse> SendPost(string url, string postData);

--- a/application/CohortManager/src/Functions/Shared/Common/Interfaces/IHttpClientFunction.cs
+++ b/application/CohortManager/src/Functions/Shared/Common/Interfaces/IHttpClientFunction.cs
@@ -2,5 +2,11 @@ namespace Common;
 
 public interface IHttpClientFunction
 {
+    /// <summary>
+    /// Performs a GET request using HttpClient.
+    /// </summary>
+    /// <param name="url">URL to be used in request.</param>
+    /// <param name="headers">Headers to be used in request.</param>
+    /// <returns>HttpResponseMessage<returns>
     Task<HttpResponseMessage> GetAsync(string url, Dictionary<string, string> headers);
 }

--- a/application/CohortManager/src/Functions/Shared/Common/Interfaces/IHttpClientFunction.cs
+++ b/application/CohortManager/src/Functions/Shared/Common/Interfaces/IHttpClientFunction.cs
@@ -1,0 +1,6 @@
+namespace Common;
+
+public interface IHttpClientFunction
+{
+    Task<HttpResponseMessage> GetAsync(string url, Dictionary<string, string> headers);
+}

--- a/tests/UnitTests/SharedTests/HttpClientFunctionTests/HttpClientFunctionTests.cs
+++ b/tests/UnitTests/SharedTests/HttpClientFunctionTests/HttpClientFunctionTests.cs
@@ -1,0 +1,89 @@
+namespace NHS.CohortManager.Tests.UnitTests.HttpClientFunctionTests;
+
+using Moq;
+using Microsoft.Extensions.Logging;
+using Common;
+using System.Net;
+using Moq.Protected;
+
+[TestClass]
+public class HttpClientFunctionTests
+{
+    private readonly Mock<ILogger<HttpClientFunction>> _logger = new();
+    private readonly Mock<IHttpClientFactory> _factory = new();
+    private readonly Mock<HttpMessageHandler> _httpMessageHandler = new();
+    private HttpClientFunction? _function;
+    private readonly string _mockUrl = "http://test.com";
+    private readonly Dictionary<string, string> _mockHeaders = new Dictionary<string, string>()
+    {
+        {"Mock-Header", "mock-header" }
+    };
+
+    [TestMethod]
+    public async Task Run_GetAsyncIsSuccessful_ReturnsOkResponse()
+    {
+        // Arrange
+        _httpMessageHandler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(req => req.Method == HttpMethod.Get),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(
+                new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK
+                }
+            );
+
+        var httpClient = new HttpClient(_httpMessageHandler.Object);
+        _factory.Setup(_ => _.CreateClient(It.IsAny<string>())).Returns(httpClient);
+
+        _function = new HttpClientFunction(_logger.Object, _factory.Object);
+
+        // Act
+        var result = await _function.GetAsync(_mockUrl, _mockHeaders);
+
+        // Assert
+        Assert.IsNotNull(result);
+        Assert.AreEqual(HttpStatusCode.OK, result.StatusCode);
+    }
+
+    [TestMethod]
+    public async Task Run_GetAsyncFails_LogsErrorWithoutNhsNumberAndThrowsException()
+    {
+        // Arrange
+        var errorMessage = "There was an error";
+        var nhsNumber = "1234567890";
+        var mockUrl = $"{_mockUrl}?nhsNumber={nhsNumber}";
+
+        _httpMessageHandler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(req => req.Method == HttpMethod.Get),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .Throws(
+                new Exception(errorMessage)
+            );
+
+        var httpClient = new HttpClient(_httpMessageHandler.Object);
+        _factory.Setup(_ => _.CreateClient(It.IsAny<string>())).Returns(httpClient);
+
+        _function = new HttpClientFunction(_logger.Object, _factory.Object);
+
+        // Act & Assert
+        var result = await Assert.ThrowsExceptionAsync<Exception>(() => _function.GetAsync(mockUrl, _mockHeaders));
+        Assert.AreEqual(errorMessage, result.Message);
+
+        _logger.Verify(x => x.Log(
+            It.Is<LogLevel>(l => l == LogLevel.Error),
+            It.IsAny<EventId>(),
+            It.Is<It.IsAnyType>((v, t) => !v.ToString().Contains(nhsNumber)),
+            It.IsAny<Exception>(),
+            It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+        Times.Once);
+    }
+}

--- a/tests/UnitTests/SharedTests/HttpClientFunctionTests/HttpClientFunctionTests.cs
+++ b/tests/UnitTests/SharedTests/HttpClientFunctionTests/HttpClientFunctionTests.cs
@@ -81,7 +81,7 @@ public class HttpClientFunctionTests
         _logger.Verify(x => x.Log(
             It.Is<LogLevel>(l => l == LogLevel.Error),
             It.IsAny<EventId>(),
-            It.Is<It.IsAnyType>((v, t) => !v.ToString().Contains(nhsNumber)),
+            It.Is<It.IsAnyType>((v, t) => v.ToString().Contains(errorMessage) && !v.ToString().Contains(nhsNumber)),
             It.IsAny<Exception>(),
             It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
         Times.Once);

--- a/tests/UnitTests/SharedTests/HttpClientFunctionTests/HttpClientFunctionTests.csproj
+++ b/tests/UnitTests/SharedTests/HttpClientFunctionTests/HttpClientFunctionTests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../../../application/CohortManager/src/Functions/Shared/Common/Common.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description
As part of the PDS integration ticket, we need to be able to send a GET request to the PDS get patient endpoint. This request requires specific headers that we currently aren't able to set using any of the methods in CallFunction.cs. 

Rather than add a new method in CallFunction.cs to handle this new request, after some discussion Sam and I decided it would be better to create a new shared function that implements this new method using HttpClient, rather than the obsolete Webrequest.Create.

This function can then be used independently from CallFunction.cs when it comes to migrating all the requests to use HttpClient.

Currently the new HttpClientFunction.cs only implements a GET request, but future work can add all the other required requests from CallFunction.cs (using HttpClient), then can replace them in the application on a function by function basis.
<!-- Describe your changes in detail. -->

## Context
Parent ticket: [DTOSS-8133](https://nhsd-jira.digital.nhs.uk/browse/DTOSS-8133)
<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [x] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
