### PR TITLE
fix: now calculates the date before trying to send to datas services

### DIFF
--- a/application/CohortManager/src/Functions/Shared/Common/DateTimeHelper.cs
+++ b/application/CohortManager/src/Functions/Shared/Common/DateTimeHelper.cs
@@ -6,16 +6,16 @@ using Model;
 public static class DateTimeHelper
 {
 
-/// <summary>
-/// Validates if the input string is in ISO 8601 date format.
-/// </summary>
-/// <param name="value">The date string to validate.</param>
-/// <returns>
-/// A tuple where the first item is a boolean indicating validity,
-/// and the second item is the parsed DateTime or the
-/// default value if parsing fails.
-/// </returns>
-    public static (bool isValidDateFormat, DateTime? date) IsValidDateFormat (string value)
+    /// <summary>
+    /// Validates if the input string is in ISO 8601 date format.
+    /// </summary>
+    /// <param name="value">The date string to validate.</param>
+    /// <returns>
+    /// A tuple where the first item is a boolean indicating validity,
+    /// and the second item is the parsed DateTime or the
+    /// default value if parsing fails.
+    /// </returns>
+    public static (bool isValidDateFormat, DateTime? date) IsValidDateFormat(string value)
     {
         bool isValidDateFormat = DateTime.TryParseExact(value, DateFormats.Iso8601, CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime date);
 

--- a/application/CohortManager/src/Functions/Shared/Data/Database/CreateCohortDistributionData.cs
+++ b/application/CohortManager/src/Functions/Shared/Data/Database/CreateCohortDistributionData.cs
@@ -3,8 +3,6 @@ namespace Data.Database;
 using System.Data;
 using System.Linq.Expressions;
 using System.Net;
-using System.Runtime.CompilerServices;
-using System.Runtime.ExceptionServices;
 using System.Threading.Tasks;
 using Common.Interfaces;
 using DataServices.Client;
@@ -209,7 +207,8 @@ public class CreateCohortDistributionData : ICreateCohortDistributionData
 
         if (dateFrom.HasValue)
         {
-            Expression<Func<BsSelectRequestAudit, bool>> predicate = (x => x.CreatedDateTime == dateFrom);
+            double numberOfDays = GetDays(dateFrom.Value);
+            Expression<Func<BsSelectRequestAudit, bool>> predicate = (x => x.CreatedDateTime >= DateTime.Today.AddDays(-numberOfDays));
             conditions.Add(predicate);
         }
 
@@ -235,6 +234,15 @@ public class CreateCohortDistributionData : ICreateCohortDistributionData
             return finalPredicate;
         }
         return x => true;
+    }
+
+    private static double GetDays(DateTime GivenDate)
+    {
+        DateTime today = DateTime.Today;
+        TimeSpan difference = today.Subtract(GivenDate);
+        var days = difference.TotalDays;
+
+        return days;
     }
 
     private static Expression<Func<T, bool>> CombineWithAnd<T>(List<Expression<Func<T, bool>>> expressions)


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

there was a bug that meant we could not get the items in there database via the date from.  Now we calculate the date and send it in a format that the data service parser is happy.

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
