### PR TITLE
fix: Fix Incorrect order of next Batch

### DIFF
--- a/application/CohortManager/src/Functions/Shared/Data/Database/CreateCohortDistributionData.cs
+++ b/application/CohortManager/src/Functions/Shared/Data/Database/CreateCohortDistributionData.cs
@@ -186,7 +186,7 @@ public class CreateCohortDistributionData : ICreateCohortDistributionData
             && x.StatusCode != errorCode
         );
 
-        var recordToReturn = res.OrderByDescending(x => x.CreatedDateTime).FirstOrDefault();
+        var recordToReturn = res.OrderBy(x => x.CreatedDateTime).FirstOrDefault();
 
         return new CohortRequestAudit()
         {


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Requests were returning in the wrong order fix.

## Context

When requests were being sent to retrieve cohort distribution when the request Id was populated it was returning the newest batch not the oldest.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
