### PR TITLE
fix: Reinstate Category Numbers for Validation Exceptions

### DIFF
--- a/application/CohortManager/src/Functions/ScreeningValidationService/LookupValidation/Breast_Screening_cohortRules.json
+++ b/application/CohortManager/src/Functions/ScreeningValidationService/LookupValidation/Breast_Screening_cohortRules.json
@@ -3,7 +3,7 @@
     "WorkflowName": "Common",
     "Rules": [
       {
-        "RuleName": "35.TooManyDemographicsFieldsChanged.NonFatal",
+        "RuleName": "35.TooManyDemographicsFieldsChanged.CaaS.NonFatal",
         "LocalParams": [
           {
             "Name": "NewDateOfBirth",
@@ -17,7 +17,7 @@
         "Expression": "existingParticipant.ParticipantId == null || ((newParticipant.FamilyName == existingParticipant.FamilyName AND newParticipant.Gender == existingParticipant.Gender) OR (newParticipant.FamilyName == existingParticipant.FamilyName AND NewDateOfBirth == ExistingDateOfBirth) OR (newParticipant.Gender == existingParticipant.Gender AND NewDateOfBirth == ExistingDateOfBirth))"
       },
       {
-        "RuleName": "54.ValidateBsoCode.NonFatal",
+        "RuleName": "54.ValidateBsoCode.NBO.NonFatal",
         "LocalParams": [
           {
             "Name": "reasonForRemoval",
@@ -44,7 +44,7 @@
     "WorkflowName": "AMENDED",
     "Rules": [
       {
-        "RuleName": "51.ParticipantLocationRemainingOutsideOfCohort.NonFatal",
+        "RuleName": "51.ParticipantLocationRemainingOutsideOfCohort.Non.NonFatal",
         "LocalParams": [
           {
             "Name": "ExistingParticipantInDMS",

--- a/application/CohortManager/src/Functions/ScreeningValidationService/LookupValidation/Breast_Screening_lookupRules.json
+++ b/application/CohortManager/src/Functions/ScreeningValidationService/LookupValidation/Breast_Screening_lookupRules.json
@@ -9,7 +9,7 @@
     ],
     "Rules": [
       {
-        "RuleName": "36.ValidatePrimaryCareProvider.NonFatal",
+        "RuleName": "36.ValidatePrimaryCareProvider.BSSelect.NonFatal",
         "Expression": "string.IsNullOrEmpty(newParticipant.PrimaryCareProvider) || dbLookup.CheckIfPrimaryCareProviderExists(newParticipant.primaryCareProvider)",
         "Actions": {
           "OnFailure": {
@@ -21,7 +21,7 @@
         }
       },
       {
-        "RuleName": "3645.CurrentPostingAndPrimaryProvider.NonFatal",
+        "RuleName": "3645.CurrentPostingAndPrimaryProvider.BSSelect.NonFatal",
         "LocalParams": [
           {
             "Name": "ValidPostingCategory",
@@ -35,7 +35,7 @@
         "Expression": "!(ValidPostingCategory AND InvalidPrimaryCareProvider)"
       },
       {
-        "RuleName": "58.CurrentPosting.NonFatal",
+        "RuleName": "58.CurrentPosting.NBO.NonFatal",
         "Expression": "ValidCurrentPosting",
         "Actions": {
           "OnFailure": {
@@ -47,7 +47,7 @@
         }
       },
       {
-        "RuleName": "00.ValidateLanguageCode.NonFatal",
+        "RuleName": "00.ValidateLanguageCode.Non.NonFatal",
         "LocalParams": [
           {
             "Name": "languageCode",
@@ -65,7 +65,7 @@
         }
       },
       {
-        "RuleName": "11.ValidateReasonForRemoval.NonFatal",
+        "RuleName": "11.ValidateReasonForRemoval.NBO.NonFatal",
         "LocalParams": [
           {
             "Name": "newRecordType",
@@ -84,7 +84,7 @@
     "WorkflowName": "ADD",
     "Rules": [
       {
-        "RuleName": "47.ParticipantMustNotExist.Fatal",
+        "RuleName": "47.ParticipantMustNotExist.NBO.Fatal",
         "Expression": "string.IsNullOrWhiteSpace(existingParticipant.NhsNumber)"
       }
     ]
@@ -93,7 +93,7 @@
     "WorkflowName": "AMENDED",
     "Rules": [
       {
-        "RuleName": "22.ParticipantMustExist.Fatal",
+        "RuleName": "22.CaaS.Fatal",
         "Expression": "!string.IsNullOrWhiteSpace(existingParticipant.NhsNumber)"
       }
     ]
@@ -102,7 +102,7 @@
     "WorkflowName": "DEL",
     "Rules": [
       {
-        "RuleName": "22.ParticipantMustExist.Fatal",
+        "RuleName": "22.ParticipantMustExist.CaaS.Fatal",
         "Expression": "!string.IsNullOrWhiteSpace(existingParticipant.NhsNumber)"
       }
     ]

--- a/application/CohortManager/src/Functions/ScreeningValidationService/StaticValidation/Breast_Screening_staticRules.json
+++ b/application/CohortManager/src/Functions/ScreeningValidationService/StaticValidation/Breast_Screening_staticRules.json
@@ -3,7 +3,7 @@
     "WorkflowName": "Common",
     "Rules": [
       {
-        "RuleName": "9.NhsNumber.Fatal",
+        "RuleName": "9.NhsNumber.CaaS.Fatal",
         "Expression": "Regex.IsMatch(participant.NhsNumber, \"^\\\\d{10}$\")",
         "Actions": {
           "OnFailure": {
@@ -15,7 +15,7 @@
         }
       },
       {
-        "RuleName": "57.SupersededByNhsNumber.NonFatal",
+        "RuleName": "57.SupersededByNhsNumber.NBO.NonFatal",
         "Expression": "string.IsNullOrEmpty(participant.SupersededByNhsNumber) OR Regex.IsMatch(participant.SupersededByNhsNumber, \"^\\\\d{10}$\")",
         "Actions": {
           "OnFailure": {
@@ -27,7 +27,7 @@
         }
       },
       {
-        "RuleName": "8.RecordType.NonFatal",
+        "RuleName": "8.RecordType.Non.NonFatal",
         "Expression": "participant.RecordType == Actions.New OR participant.RecordType == Actions.Amended OR participant.RecordType == Actions.Removed",
         "Actions": {
           "OnFailure": {
@@ -39,7 +39,7 @@
         }
       },
       {
-        "RuleName": "14.ReasonForRemoval.NonFatal",
+        "RuleName": "14.ReasonForRemoval.NBO.NonFatal",
         "Expression": "string.IsNullOrEmpty(participant.ReasonForRemoval) OR new string[] {\"AFL\",\"AFN\",\"CGA\",\"DEA\",\"DIS\",\"EMB\",\"LDN\",\"NIT\",\"OPA\",\"ORR\",\"RDI\",\"RDR\",\"RFI\",\"RPR\",\"SCT\",\"SDL\",\"SDN\",\"TRA\"}.Contains(participant.ReasonForRemoval)",
         "Actions": {
           "OnFailure": {
@@ -51,7 +51,7 @@
         }
       },
       {
-        "RuleName": "30.Postcode.NonFatal",
+        "RuleName": "30.Postcode.NBO.NonFatal",
         "Expression": "string.IsNullOrEmpty(participant.Postcode) OR ValidationHelper.ValidatePostcode(participant.Postcode)",
         "Actions": {
           "OnFailure": {
@@ -63,7 +63,7 @@
         }
       },
       {
-        "RuleName": "3.PrimaryCareProviderAndReasonForRemoval.NonFatal",
+        "RuleName": "3.PrimaryCareProviderAndReasonForRemoval.NBO.NonFatal",
         "Expression": "(string.IsNullOrEmpty(participant.PrimaryCareProvider) AND !string.IsNullOrEmpty(participant.ReasonForRemoval)) OR (!string.IsNullOrEmpty(participant.PrimaryCareProvider) AND string.IsNullOrEmpty(participant.ReasonForRemoval))",
         "Actions": {
           "OnFailure": {
@@ -75,7 +75,7 @@
         }
       },
       {
-        "RuleName": "17.DateOfBirth.NonFatal",
+        "RuleName": "17.DateOfBirth.NBO.NonFatal",
         "Expression": "!(string.IsNullOrEmpty(participant.DateOfBirth) || !ValidationHelper.ValidatePastDate(participant.DateOfBirth))",
         "Actions": {
           "OnFailure": {
@@ -87,7 +87,7 @@
         }
       },
       {
-        "RuleName": "39.FamilyName.NonFatal",
+        "RuleName": "39.FamilyName.NBO.NonFatal",
         "Expression": "!(participant.RecordType != Actions.Amended && string.IsNullOrEmpty(participant.FamilyName))",
         "Actions": {
           "OnFailure": {
@@ -99,7 +99,7 @@
         }
       },
       {
-        "RuleName": "40.FirstName.NonFatal",
+        "RuleName": "40.FirstName.NBO.NonFatal",
         "Expression": "!(participant.RecordType != Actions.Amended && string.IsNullOrEmpty(participant.FirstName))",
         "Actions": {
           "OnFailure": {
@@ -111,7 +111,7 @@
         }
       },
       {
-        "RuleName": "42.GPPracticeCode.NonFatal",
+        "RuleName": "42.GPPracticeCode.Non.NonFatal",
         "Expression": "participant.RecordType != Actions.New OR !string.IsNullOrEmpty(participant.PrimaryCareProvider)",
         "Actions": {
           "OnFailure": {
@@ -123,7 +123,7 @@
         }
       },
       {
-        "RuleName": "19.ReasonForRemovalEffectiveFromDate.NonFatal",
+        "RuleName": "19.ReasonForRemovalEffectiveFromDate.NBO.NonFatal",
         "Expression": "string.IsNullOrEmpty(participant.ReasonForRemovalEffectiveFromDate) OR ValidationHelper.ValidatePastDate(participant.ReasonForRemovalEffectiveFromDate)",
         "Actions": {
           "OnFailure": {
@@ -135,31 +135,31 @@
         }
       },
       {
-        "RuleName": "100.PrimaryCareProviderEffectiveFromDate.NonFatal",
+        "RuleName": "100.PrimaryCareProviderEffectiveFromDate.Non.NonFatal",
         "Expression": "string.IsNullOrEmpty(participant.PrimaryCareProviderEffectiveFromDate) OR ValidationHelper.ValidatePastDate(participant.PrimaryCareProviderEffectiveFromDate)"
       },
       {
-        "RuleName": "101.CurrentPostingEffectiveFromDate.NonFatal",
+        "RuleName": "101.CurrentPostingEffectiveFromDate.Non.NonFatal",
         "Expression": "string.IsNullOrEmpty(participant.CurrentPostingEffectiveFromDate) OR ValidationHelper.ValidatePastDate(participant.CurrentPostingEffectiveFromDate)"
       },
       {
-        "RuleName": "102.UsualAddressEffectiveFromDate.NonFatal",
+        "RuleName": "102.UsualAddressEffectiveFromDate.Non.NonFatal",
         "Expression": "string.IsNullOrEmpty(participant.UsualAddressEffectiveFromDate) OR ValidationHelper.ValidatePastDate(participant.UsualAddressEffectiveFromDate)"
       },
       {
-        "RuleName": "103.TelephoneNumberEffectiveFromDate.NonFatal",
+        "RuleName": "103.TelephoneNumberEffectiveFromDate.Non.NonFatal",
         "Expression": "string.IsNullOrEmpty(participant.TelephoneNumberEffectiveFromDate) OR ValidationHelper.ValidatePastDate(participant.TelephoneNumberEffectiveFromDate)"
       },
       {
-        "RuleName": "104.MobileNumberEffectiveFromDate.NonFatal",
+        "RuleName": "104.MobileNumberEffectiveFromDate.Non.NonFatal",
         "Expression": "string.IsNullOrEmpty(participant.MobileNumberEffectiveFromDate) OR ValidationHelper.ValidatePastDate(participant.MobileNumberEffectiveFromDate)"
       },
       {
-        "RuleName": "105.EmailAddressEffectiveFromDate.NonFatal",
+        "RuleName": "105.EmailAddressEffectiveFromDate.Non.NonFatal",
         "Expression": "string.IsNullOrEmpty(participant.EmailAddressEffectiveFromDate) OR ValidationHelper.ValidatePastDate(participant.EmailAddressEffectiveFromDate)"
       },
       {
-        "RuleName": "18.DateOfDeath.NonFatal",
+        "RuleName": "18.DateOfDeath.NBO.NonFatal",
         "Expression": "string.IsNullOrEmpty(participant.DateOfDeath) OR ValidationHelper.ValidatePastDate(participant.DateOfDeath)",
         "Actions": {
           "OnFailure": {
@@ -171,7 +171,7 @@
         }
       },
       {
-        "RuleName": "47.NewParticipantWithRemovalOrDeath.NonFatal",
+        "RuleName": "47.NewParticipantWithRemovalOrDeath.NBO.NonFatal",
         "Expression": "participant.RecordType != Actions.New OR (string.IsNullOrEmpty(participant.ReasonForRemoval) AND string.IsNullOrEmpty(participant.ReasonForRemovalEffectiveFromDate) AND string.IsNullOrEmpty(participant.DateOfDeath))",
         "Actions": {
           "OnFailure": {
@@ -183,7 +183,7 @@
         }
       },
       {
-        "RuleName": "49.InterpreterCheck.NonFatal",
+        "RuleName": "49.InterpreterCheck.Non.NonFatal",
         "Expression": "int.Parse(participant.IsInterpreterRequired) != 0 OR int.Parse(participant.IsInterpreterRequired) != 1",
         "Actions": {
           "OnFailure": {
@@ -195,7 +195,7 @@
         }
       },
       {
-        "RuleName": "61.InvalidFlag.NonFatal",
+        "RuleName": "61.InvalidFlag.NBO.NonFatal",
         "Expression": "participant.InvalidFlag == \"1\" OR participant.InvalidFlag == \"0\"",
         "Actions": {
           "OnFailure": {
@@ -207,7 +207,7 @@
         }
       },
       {
-        "RuleName": "62.ValidateReasonForRemoval.NonFatal",
+        "RuleName": "62.ValidateReasonForRemoval.NBO.NonFatal",
         "Expression": "!(participant.ReasonForRemoval == \"LDN\" AND  string.IsNullOrEmpty(participant.SupersededByNhsNumber))",
         "Actions": {
           "OnFailure": {
@@ -219,7 +219,7 @@
         }
       },
       {
-        "RuleName": "53.CurrentPostingAndPrimaryCareProvider.NonFatal",
+        "RuleName": "53.CurrentPostingAndPrimaryCareProvider.Non.NonFatal",
         "LocalParams": [
           {
             "Name": "currentPosting",
@@ -241,7 +241,7 @@
         }
       },
       {
-        "RuleName": "94.EligibilityFlag.NonFatal",
+        "RuleName": "94.EligibilityFlag.Non.NonFatal",
         "LocalParams": [
           {
             "Name": "newRecordType",
@@ -284,7 +284,7 @@
   "WorkflowName": "ADD",
   "Rules": [
     {
-      "RuleName": "71.NewParticipantWithNoAddress.NonFatal",
+      "RuleName": "71.NewParticipantWithNoAddress.NBO.NonFatal",
       "Expression": "!(participant.RecordType == Actions.New AND string.IsNullOrEmpty(participant.AddressLine1) AND string.IsNullOrEmpty(participant.AddressLine2) AND string.IsNullOrEmpty(participant.AddressLine3) AND string.IsNullOrEmpty(participant.AddressLine4) AND string.IsNullOrEmpty(participant.AddressLine5))",
         "Actions": {
           "OnFailure": {
@@ -301,7 +301,7 @@
     "WorkflowName": "AMENDED",
     "Rules": [
       {
-        "RuleName": "66.DeathStatus.NonFatal",
+        "RuleName": "66.DeathStatus.NBO.NonFatal",
         "LocalParams": [
           {
             "Name": "IsUpdateRequest",

--- a/application/CohortManager/src/Functions/Shared/Common/ExceptionHandler.cs
+++ b/application/CohortManager/src/Functions/Shared/Common/ExceptionHandler.cs
@@ -162,9 +162,10 @@ public class ExceptionHandler : IExceptionHandler
         {
             var ruleDetails = error.Rule.RuleName.Split('.');
             var ruleId = int.Parse(ruleDetails[0]);
+            var Category = ruleDetails[2];
             var errorMessage = (string)error.ActionResult.Output;
 
-            var IsFatal = ParseFatalRuleType(ruleDetails[2]);
+            var IsFatal = ParseFatalRuleType(ruleDetails[3]);
             if (IsFatal == 1)
             {
                 foundFatalRule = true;
@@ -180,14 +181,14 @@ public class ExceptionHandler : IExceptionHandler
             var exception = new ValidationException
             {
                 RuleId = ruleId,
-                RuleDescription = errorMessage ?? ruleDetails[1],
+                RuleDescription = errorMessage ?? ruleDetails[2],
                 FileName = participantCsvRecord.FileName,
                 NhsNumber = participantCsvRecord.Participant.NhsNumber,
                 ErrorRecord = JsonSerializer.Serialize(participantCsvRecord.Participant),
                 DateCreated = DateTime.Now,
                 DateResolved = DateTime.MaxValue,
                 ExceptionDate = DateTime.Now,
-                Category = ruleId == 51 ? (int)ExceptionCategory.ParticipantLocationRemainingOutsideOfCohort : (int)ExceptionCategory.File,
+                Category = ruleId == 51 ? (int)ExceptionCategory.ParticipantLocationRemainingOutsideOfCohort : GetCategory(Category),
                 ScreeningName = participantCsvRecord.Participant.ScreeningName,
                 CohortName = DefaultCohortName,
                 Fatal = IsFatal
@@ -214,6 +215,12 @@ public class ExceptionHandler : IExceptionHandler
             CreatedException = true
         };
     }
+
+    private int GetCategory(string category)
+    {
+        return (int)Enum.Parse(typeof(ExceptionCategory), category, ignoreCase: true);
+    }
+
     public async Task<bool> CreateRecordValidationExceptionLog(string nhsNumber, string fileName, string errorDescription, string screeningName, string errorRecord)
     {
         var validationException = CreateDefaultValidationException(nhsNumber, fileName, errorDescription, screeningName, errorRecord);

--- a/application/CohortManager/src/Functions/Shared/Model/Enums/ExceptionCategory.cs
+++ b/application/CohortManager/src/Functions/Shared/Model/Enums/ExceptionCategory.cs
@@ -6,5 +6,11 @@ public enum ExceptionCategory
     DeleteRecord = 8,
     ParticipantLocationRemainingOutsideOfCohort = 9,
     Schema = 10,
-    TransformExecuted = 11
+    TransformExecuted = 11,
+
+    NBO = 3,
+    CaaS = 2,
+    BSSelect = 1,
+    Non = 0
+
 }


### PR DESCRIPTION
…es and parsing the category name to a number in the enum ExceptionCategory while preserving categorys numbers for other types of category ouside of NBO, CaaS and BSSelect

<!-- markdownlint-disable-next-line first-line-heading -->
## Description

https://nhsd-jira.digital.nhs.uk/browse/DTOSS-8419

adding the name of the place we are sending the error to the rules and parsing the category name to a number in the enum ExceptionCategory while preserving categories numbers for other types of category outside of NBO, CaaS and BSSelect

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
