### PR TITLE
fix: correct wrong screening name logged to exception table

### DIFF
--- a/application/CohortManager/src/Functions/CohortDistributionServices/CreateCohortDistribution/CreateCohortDistribution.cs
+++ b/application/CohortManager/src/Functions/CohortDistributionServices/CreateCohortDistribution/CreateCohortDistribution.cs
@@ -92,7 +92,7 @@ public class CreateCohortDistribution
             {
                 var errorMessage = $"Participant {participantData.ParticipantId} triggered a validation rule, so will not be added to cohort distribution";
                 _logger.LogInformation(errorMessage);
-                await _exceptionHandler.CreateRecordValidationExceptionLog(participantData.NhsNumber, basicParticipantCsvRecord.FileName, errorMessage, serviceProvider, JsonSerializer.Serialize(participantData));
+                await _exceptionHandler.CreateRecordValidationExceptionLog(participantData.NhsNumber, basicParticipantCsvRecord.FileName, errorMessage, basicParticipantCsvRecord.ScreeningService, JsonSerializer.Serialize(participantData));
 
                 var participantMangement = await _participantManagementClient.GetSingle(participantData.ParticipantId);
                 participantMangement.ExceptionFlag = 1;


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Service provider was being logged to the exception table instead of screening Name, This caused issues with resolving exceptions when an amend is received. 

## Context
https://nhsd-jira.digital.nhs.uk/browse/DTOSS-8518
Correct logging and removal of exceptions.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
