### PR TITLE
refactor: migrate CaasIntegration to use httpClientFunction

### DIFF
--- a/application/CohortManager/src/Functions/CaasIntegration/receiveCaasFile/ProcessFileClasses/CallDurableDemographicFunc.cs
+++ b/application/CohortManager/src/Functions/CaasIntegration/receiveCaasFile/ProcessFileClasses/CallDurableDemographicFunc.cs
@@ -1,10 +1,7 @@
 namespace NHS.Screening.ReceiveCaasFile;
 
-
-using System.Net.Http.Headers;
 using System.Text.Json;
 using Common;
-using Microsoft.Azure.Functions.Worker.Extensions.Abstractions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Model;
@@ -13,27 +10,24 @@ using Polly;
 
 public class CallDurableDemographicFunc : ICallDurableDemographicFunc
 {
-
-    private readonly ICallFunction _callFunction;
+    private readonly IHttpClientFunction _httpClientFunction;
     private readonly ILogger<CallDurableDemographicFunc> _logger;
-    private readonly HttpClient _httpClient;
     private readonly ICopyFailedBatchToBlob _copyFailedBatchToBlob;
     private readonly int _maxNumberOfChecks;
     private TimeSpan _delayBetweenChecks = TimeSpan.FromSeconds(3);
-
     private readonly ReceiveCaasFileConfig _config;
 
-
-    public CallDurableDemographicFunc(ICallFunction callFunction, ILogger<CallDurableDemographicFunc> logger, HttpClient httpClient, ICopyFailedBatchToBlob copyFailedBatchToBlob, IOptions<ReceiveCaasFileConfig> config)
+    public CallDurableDemographicFunc(
+        IHttpClientFunction httpClientFunction,
+        ILogger<CallDurableDemographicFunc> logger,
+        ICopyFailedBatchToBlob copyFailedBatchToBlob,
+        IOptions<ReceiveCaasFileConfig> config)
     {
         _config = config.Value;
-        _callFunction = callFunction;
+        _httpClientFunction = httpClientFunction;
         _logger = logger;
-        _httpClient = httpClient;
         _copyFailedBatchToBlob = copyFailedBatchToBlob;
         _maxNumberOfChecks = _config.maxNumberOfChecks;
-
-        _httpClient.Timeout = TimeSpan.FromSeconds(300);
     }
 
     /// <summary>
@@ -59,16 +53,9 @@ public class CallDurableDemographicFunc : ICallDurableDemographicFunc
 
         try
         {
-            using var memoryStream = new MemoryStream();
-            // this seems to be better for memory management
-            await JsonSerializer.SerializeAsync(memoryStream, participants);
-            memoryStream.Position = 0;
+            var response = await _httpClientFunction.SendPost(DemographicFunctionURI, JsonSerializer.Serialize(participants));
 
-            var content = new StreamContent(memoryStream);
-            content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
-            var response = await _httpClient.PostAsync(DemographicFunctionURI, content);
-
-            responseContent = response.Headers.Location.ToString();
+            responseContent = response.Headers.Location?.ToString();
 
             // this is not retrying the function if it fails but checking if it has done yet.
             var retryPolicy = Policy
@@ -86,12 +73,12 @@ public class CallDurableDemographicFunc : ICallDurableDemographicFunc
 
             if (finalStatus == WorkFlowStatus.Completed)
             {
-                _logger.LogWarning("Durable function completed {finalStatus}", finalStatus);
+                _logger.LogWarning("Durable function completed {FinalStatus}", finalStatus);
                 return true;
             }
             else
             {
-                _logger.LogError("Check limit reached or demographic function failed {finalStatus}", finalStatus);
+                _logger.LogError("Check limit reached or demographic function failed {FinalStatus}", finalStatus);
                 await _copyFailedBatchToBlob.writeBatchToBlob(
                     JsonSerializer.Serialize(participants),
                     new InvalidOperationException("there was an error while adding batch of participants to the demographic table")
@@ -122,16 +109,15 @@ public class CallDurableDemographicFunc : ICallDurableDemographicFunc
     {
         try
         {
-            using HttpResponseMessage response = await _httpClient.GetAsync(statusRequestGetUri);
-            var jsonResponse = await response.Content.ReadAsStringAsync();
+            var response = await _httpClientFunction.SendGet(statusRequestGetUri);
 
-            var data = JsonSerializer.Deserialize<WebhookResponse>(jsonResponse);
+            var data = JsonSerializer.Deserialize<WebhookResponse>(response);
 
             if (data != null)
             {
                 if (!Enum.TryParse(data.RuntimeStatus, out WorkFlowStatus workFlowStatus))
                 {
-                    _logger.LogError(jsonResponse);
+                    _logger.LogError(response);
                 }
                 return workFlowStatus;
             }
@@ -140,7 +126,7 @@ public class CallDurableDemographicFunc : ICallDurableDemographicFunc
         //sometimes the webhook can fail for very annoying reasons but the Orchestration data still exists so we can check for its status
         catch (Exception ex)
         {
-            var getOrchestrationStatusURL = Environment.GetEnvironmentVariable("GetOrchestrationStatusURL");
+            var getOrchestrationStatusURL = _config.GetOrchestrationStatusURL;
 
             if (string.IsNullOrWhiteSpace(getOrchestrationStatusURL))
             {
@@ -151,8 +137,8 @@ public class CallDurableDemographicFunc : ICallDurableDemographicFunc
             _logger.LogWarning(ex, "There has been error getting the status for instanceId {InstanceId}", instanceId);
 
             var json = JsonSerializer.Serialize(instanceId);
-            var response = await _callFunction.SendPost(getOrchestrationStatusURL, json);
-            var responseBody = await _callFunction.GetResponseText(response);
+            var response = await _httpClientFunction.SendPost(getOrchestrationStatusURL, json);
+            var responseBody = await _httpClientFunction.GetResponseText(response);
 
             if (Enum.TryParse<WorkFlowStatus>(responseBody, out var result))
             {

--- a/application/CohortManager/src/Functions/CaasIntegration/receiveCaasFile/ProcessFileClasses/ProcessCaasFile.cs
+++ b/application/CohortManager/src/Functions/CaasIntegration/receiveCaasFile/ProcessFileClasses/ProcessCaasFile.cs
@@ -3,7 +3,6 @@ namespace NHS.Screening.ReceiveCaasFile;
 using System.Text.Json;
 using Common;
 using Common.Interfaces;
-using Data.Database;
 using DataServices.Client;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -21,7 +20,7 @@ public class ProcessCaasFile : IProcessCaasFile
     private readonly IDataServiceClient<ParticipantDemographic> _participantDemographic;
     private readonly IRecordsProcessedTracker _recordsProcessTracker;
     private readonly IValidateDates _validateDates;
-    private readonly ICallFunction _callFunction;
+    private readonly IHttpClientFunction _httpClientFunction;
     private readonly ReceiveCaasFileConfig _config;
     private readonly string DemographicURI;
     private readonly string AddParticipantQueueName;
@@ -37,7 +36,7 @@ public class ProcessCaasFile : IProcessCaasFile
         IDataServiceClient<ParticipantDemographic> participantDemographic,
         IRecordsProcessedTracker recordsProcessedTracker,
         IValidateDates validateDates,
-        ICallFunction callFunction,
+        IHttpClientFunction httpClientFunction,
         ICallDurableDemographicFunc callDurableDemographicFunc,
         IOptions<ReceiveCaasFileConfig> receiveCaasFileConfig
     )
@@ -50,7 +49,7 @@ public class ProcessCaasFile : IProcessCaasFile
         _participantDemographic = participantDemographic;
         _recordsProcessTracker = recordsProcessedTracker;
         _validateDates = validateDates;
-        _callFunction = callFunction;
+        _httpClientFunction = httpClientFunction;
         _callDurableDemographicFunc = callDurableDemographicFunc;
         _config = receiveCaasFileConfig.Value;
 
@@ -211,7 +210,7 @@ public class ProcessCaasFile : IProcessCaasFile
             {
                 _logger.LogInformation("AllowDeleteRecords flag is true, delete record sent to RemoveParticipant function.");
                 var json = JsonSerializer.Serialize(basicParticipantCsvRecord);
-                await _callFunction.SendPost(_config.PMSRemoveParticipant, json);
+                await _httpClientFunction.SendPost(_config.PMSRemoveParticipant, json);
             }
             else
             {

--- a/application/CohortManager/src/Functions/CaasIntegration/receiveCaasFile/Program.cs
+++ b/application/CohortManager/src/Functions/CaasIntegration/receiveCaasFile/Program.cs
@@ -28,7 +28,6 @@ try
     {
         services.AddApplicationInsightsTelemetryWorkerService();
         services.ConfigureFunctionsApplicationInsights();
-        services.AddTransient<ICallFunction, CallFunction>();
         services.AddSingleton<IReceiveCaasFileHelper, ReceiveCaasFileHelper>();
         services.AddScoped<IProcessCaasFile, ProcessCaasFile>(); //Do not change the lifetime of this.
         services.AddSingleton<ICreateResponse, CreateResponse>();
@@ -40,11 +39,6 @@ try
         services.AddTransient<IExceptionHandler, ExceptionHandler>();
         services.AddTransient<IBlobStorageHelper, BlobStorageHelper>();
         services.AddTransient<ICopyFailedBatchToBlob, CopyFailedBatchToBlob>();
-
-        services.AddHttpClient<ICallDurableDemographicFunc, CallDurableDemographicFunc>(client =>
-        {
-            client.BaseAddress = new Uri(config.DemographicURI);
-        });
         services.AddScoped<IValidateDates, ValidateDates>();
         services.AddScoped<IQueueClientFactory, QueueClientFactory>();
         // Register health checks
@@ -53,6 +47,7 @@ try
     .AddAzureQueues()
     .AddExceptionHandler()
     .AddDatabaseConnection()
+    .AddHttpClient()
     .Build();
 
     await host.RunAsync();

--- a/application/CohortManager/src/Functions/Shared/Common/Extensions/HttpClientExtension.cs
+++ b/application/CohortManager/src/Functions/Shared/Common/Extensions/HttpClientExtension.cs
@@ -1,0 +1,15 @@
+namespace Common;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+public static class HttpClientExtension
+{
+    public static IHostBuilder AddHttpClient(this IHostBuilder hostBuilder)
+    {
+        return hostBuilder.ConfigureServices(_ =>
+        {
+            _.AddHttpClient();
+            _.AddTransient<IHttpClientFunction, HttpClientFunction>();
+        });
+    }
+}

--- a/tests/UnitTests/CaasIntegrationTests/processCaasFileTest/processCaasFileTests.cs
+++ b/tests/UnitTests/CaasIntegrationTests/processCaasFileTest/processCaasFileTests.cs
@@ -22,10 +22,8 @@ public class ProcessCaasFileTests
     private readonly Mock<RecordsProcessedTracker> _recordsProcessedTrackerMock = new();
     private readonly Mock<DataServices.Client.IDataServiceClient<ParticipantDemographic>> _databaseClientParticipantMock = new();
     private readonly Mock<IValidateDates> _validateDates = new();
-    private readonly Mock<ICallFunction> _callFunction = new();
-
+    private readonly Mock<IHttpClientFunction> _httpClientFunction = new();
     private readonly Mock<ICallDurableDemographicFunc> _callDurableFunc = new();
-    private readonly ProcessCaasFile _processCaasFile;
 
     private readonly Mock<IOptions<ReceiveCaasFileConfig>> _config = new();
 
@@ -42,7 +40,7 @@ public class ProcessCaasFileTests
             _databaseClientParticipantMock.Object,
             _recordsProcessedTrackerMock.Object,
             _validateDates.Object,
-            _callFunction.Object,
+            _httpClientFunction.Object,
             _callDurableFunc.Object,
             _config.Object
         );
@@ -311,7 +309,7 @@ public class ProcessCaasFileTests
         // Assert: expect CreateDeletedRecordException to be invoked
         _exceptionHandlerMock.Verify(m => m.CreateDeletedRecordException(
             It.IsAny<BasicParticipantCsvRecord>()), Times.Once);
-        _callFunction.Verify(x => x.SendPost(
+        _httpClientFunction.Verify(x => x.SendPost(
             It.Is<string>(s => s.Contains("PMSRemoveParticipant")), It.IsAny<string>()),
             Times.Never);
         _loggerMock.Verify(x => x.Log(
@@ -344,7 +342,7 @@ public class ProcessCaasFileTests
         await task;
 
         // Assert: expect call to SendPost to occur
-        _callFunction.Verify(x => x.SendPost(
+        _httpClientFunction.Verify(x => x.SendPost(
             It.Is<string>(s => s.Contains("PMSRemoveParticipant")), It.IsAny<string>()),
             Times.Once);
         _loggerMock.Verify(x => x.Log(

--- a/tests/UnitTests/CallDurableDemographicFuncTests/CallDurableDemograpghicFunc.cs
+++ b/tests/UnitTests/CallDurableDemographicFuncTests/CallDurableDemograpghicFunc.cs
@@ -1,14 +1,12 @@
 namespace NHS.CohortManager.Tests.UnitTests.CheckDemographicTests;
 
 using Common;
-using NHS.CohortManager.Tests.TestUtils;
 using System.Net;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Model;
 using System.Text.Json;
 using System.Threading.Tasks;
-using Moq.Protected;
 using NHS.Screening.ReceiveCaasFile;
 using Microsoft.Extensions.Options;
 
@@ -16,11 +14,9 @@ using Microsoft.Extensions.Options;
 public class CallDurableDemographicFuncTests
 {
     private readonly Mock<ILogger<CallDurableDemographicFunc>> _logger = new();
-    private readonly Mock<ICallFunction> _callFunction = new();
-    private readonly Mock<HttpClient> _httpClient = new();
+    private readonly Mock<IHttpClientFunction> _httpClientFunction = new();
     private readonly CallDurableDemographicFunc _callDurableDemographicFunc;
     private readonly Mock<ICopyFailedBatchToBlob> _copyFailedBatchToBlob = new();
-
     private readonly Mock<IOptions<ReceiveCaasFileConfig>> _config = new();
 
     public CallDurableDemographicFuncTests()
@@ -32,7 +28,7 @@ public class CallDurableDemographicFuncTests
         };
 
         _config.Setup(c => c.Value).Returns(testConfig);
-        _callDurableDemographicFunc = new CallDurableDemographicFunc(_callFunction.Object, _logger.Object, _httpClient.Object, _copyFailedBatchToBlob.Object, _config.Object);
+        _callDurableDemographicFunc = new CallDurableDemographicFunc(_httpClientFunction.Object, _logger.Object, _copyFailedBatchToBlob.Object, _config.Object);
     }
 
     [TestMethod]
@@ -48,7 +44,7 @@ public class CallDurableDemographicFuncTests
         // Assert
         Assert.IsTrue(result);
         _logger.Verify(x => x.Log(
-            It.Is<Microsoft.Extensions.Logging.LogLevel>(l => l == Microsoft.Extensions.Logging.LogLevel.Information),
+            It.Is<LogLevel>(l => l == LogLevel.Information),
             It.IsAny<EventId>(),
             It.Is<It.IsAnyType>((v, t) => v.ToString().Contains("There were no items to to send to the demographic durable function")),
             null,
@@ -60,15 +56,10 @@ public class CallDurableDemographicFuncTests
     public async Task PostDemographicDataAsync_ParticipantsExist_ReturnTrue()
     {
         // Arrange
-        var participants = new List<ParticipantDemographic>
-        {
-            new ParticipantDemographic { /* populate properties */ }
-        };
+        var participants = new List<ParticipantDemographic> { new ParticipantDemographic() };
         var uri = "test-uri.com/post";
 
-        var response = MockHelpers.CreateMockHttpResponseData(HttpStatusCode.OK, "[]");
-
-        _callFunction.Setup(x => x.SendGet(It.IsAny<string>()))
+        _httpClientFunction.Setup(x => x.SendGet(It.IsAny<string>()))
             .Returns(Task.FromResult("status"))
             .Verifiable();
 
@@ -84,22 +75,21 @@ public class CallDurableDemographicFuncTests
     {
         // Arrange
         var uri = "http://test-uri.com/get-status";
-        var participants = new List<ParticipantDemographic>
-        {
-            new ParticipantDemographic { /* populate properties if needed */ }
-        };
+        var participants = new List<ParticipantDemographic> { new ParticipantDemographic() };
 
-        // Create the HttpClient with the common helper
-        var httpClient = CreateMockHttpClient(HttpStatusCode.OK);
-        var checkDemographic = new CallDurableDemographicFunc(_callFunction.Object, _logger.Object, httpClient, _copyFailedBatchToBlob.Object, _config.Object);
+        _httpClientFunction.Setup(x => x.SendPost(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(new HttpResponseMessage { StatusCode = HttpStatusCode.OK });
+
+        _httpClientFunction.Setup(x => x.SendGet(It.IsAny<string>()))
+            .ReturnsAsync(JsonSerializer.Serialize(new WebhookResponse { RuntimeStatus = "Completed" }));
 
         // Act
-        var result = await checkDemographic.PostDemographicDataAsync(participants, uri);
+        var result = await _callDurableDemographicFunc.PostDemographicDataAsync(participants, uri);
 
         // Assert
         Assert.IsTrue(result);
         _logger.Verify(x => x.Log(
-                It.Is<Microsoft.Extensions.Logging.LogLevel>(l => l == Microsoft.Extensions.Logging.LogLevel.Warning),
+                It.Is<LogLevel>(l => l == LogLevel.Warning),
                 It.IsAny<EventId>(),
                 It.Is<It.IsAnyType>((v, t) => v.ToString().Contains("Durable function completed")),
                 null,
@@ -112,22 +102,21 @@ public class CallDurableDemographicFuncTests
     {
         // Arrange
         var uri = "http://test-uri.com/get-status";
-        var participants = new List<ParticipantDemographic>
-        {
-            new ParticipantDemographic { /* populate properties if needed */ }
-        };
+        var participants = new List<ParticipantDemographic> { new ParticipantDemographic() };
 
-        // Create the HttpClient with the common helper
-        var httpClient = CreateMockHttpClient(HttpStatusCode.BadRequest);
-        var checkDemographic = new CallDurableDemographicFunc(_callFunction.Object, _logger.Object, httpClient, _copyFailedBatchToBlob.Object, _config.Object);
+        _httpClientFunction.Setup(x => x.SendPost(It.IsAny<string>(), It.IsAny<string>()))
+            .ThrowsAsync(new Exception("Simulated exception"));
+
+        _httpClientFunction.Setup(x => x.SendGet(It.IsAny<string>()))
+            .ReturnsAsync(JsonSerializer.Serialize(new WebhookResponse { RuntimeStatus = "Completed" }));
 
         // Act
-        var result = await checkDemographic.PostDemographicDataAsync(participants, uri);
+        var result = await _callDurableDemographicFunc.PostDemographicDataAsync(participants, uri);
 
         // Assert
         Assert.IsTrue(result);
         _logger.Verify(x => x.Log(
-            It.Is<Microsoft.Extensions.Logging.LogLevel>(l => l == Microsoft.Extensions.Logging.LogLevel.Error),
+            It.Is<LogLevel>(l => l == LogLevel.Error),
             It.IsAny<EventId>(),
             It.Is<It.IsAnyType>((v, t) => v.ToString().Contains("still sending records to queue")
                 && v.ToString().Contains("Simulated exception")),
@@ -138,67 +127,6 @@ public class CallDurableDemographicFuncTests
     }
 
     // Missing test coverage for exception state - due to the retry logic and private const _maxNumberOfChecks it would add 150 seconds to test run
-    // Tried to use reflection to manually change value but can't as it's const. 
-    // Reccomend to refactor CheckDemographic.cs to make it more testable.
-
-    private HttpClient CreateMockHttpClient(HttpStatusCode responseStatusCode)
-    {
-        var mockHttpMessageHandler = new Mock<HttpMessageHandler>();
-
-        // Setup for the POST request
-        mockHttpMessageHandler
-            .Protected()
-            .Setup<Task<HttpResponseMessage>>(
-                "SendAsync",
-                ItExpr.Is<HttpRequestMessage>(req => req.Method == HttpMethod.Post),
-                ItExpr.IsAny<CancellationToken>())
-            .Callback<HttpRequestMessage, CancellationToken>((request, cancellationToken) =>
-            {
-                Console.WriteLine($"POST Request URL: {request.RequestUri}");
-            })
-            .Returns<HttpRequestMessage, CancellationToken>((request, cancellationToken) =>
-            {
-                // For error simulation, throw an exception if the responseStatusCode is BadRequest.
-                if (responseStatusCode == HttpStatusCode.BadRequest)
-                {
-                    throw new Exception("Simulated exception");
-                }
-                var response = new HttpResponseMessage(responseStatusCode)
-                {
-                    Content = new StringContent("ignored")
-                };
-                // Set a valid Location header for the GET call in GetStatus
-                response.Headers.Location = new Uri("http://test-uri.com/status");
-                return Task.FromResult(response);
-            });
-
-        // Setup for the GET request
-        mockHttpMessageHandler
-            .Protected()
-            .Setup<Task<HttpResponseMessage>>(
-                "SendAsync",
-                ItExpr.Is<HttpRequestMessage>(req => req.Method == HttpMethod.Get),
-                ItExpr.IsAny<CancellationToken>())
-            .Callback<HttpRequestMessage, CancellationToken>((request, cancellationToken) =>
-            {
-                Console.WriteLine($"GET Request URL: {request.RequestUri}");
-            })
-            .ReturnsAsync(() =>
-            {
-                var webhookResponse = new WebhookResponse { RuntimeStatus = "Completed" };
-                var content = JsonSerializer.Serialize(webhookResponse);
-                return new HttpResponseMessage(responseStatusCode)
-                {
-                    Content = new StringContent(content)
-                };
-            });
-
-        // Create and return an HttpClient configured with the mocked handler.
-        var httpClient = new HttpClient(mockHttpMessageHandler.Object)
-        {
-            BaseAddress = new Uri("http://test-uri.com")
-        };
-        return httpClient;
-    }
-
+    // Tried to use reflection to manually change value but can't as it's const.
+    // Recommend to refactor CheckDemographic.cs to make it more testable.
 }


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description
Migrates all CallFunction methods in the Functions/CaasIntegration folder to use HttpClientFunction methods instead.
<!-- Describe your changes in detail. -->

## Context
[DTOSS-8785](https://nhsd-jira.digital.nhs.uk/browse/DTOSS-8785)
<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [x] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
