### PR TITLE
feat: Add Private Endpoints for Storage Tables

### DIFF
--- a/infrastructure/tf-core/rbac.tf
+++ b/infrastructure/tf-core/rbac.tf
@@ -8,6 +8,7 @@ locals {
   rbac_roles_storage = [
     "Storage Account Contributor",
     "Storage Blob Data Owner",
+    "Storage Table Data Contributor",
     "Storage Queue Data Contributor"
   ]
 

--- a/infrastructure/tf-core/storage.tf
+++ b/infrastructure/tf-core/storage.tf
@@ -26,6 +26,7 @@ module "storage" {
   # Private Endpoint Configuration if enabled
   private_endpoint_properties = var.features.private_endpoints_enabled ? {
     private_dns_zone_ids_blob            = [data.terraform_remote_state.hub.outputs.private_dns_zones["${each.value.region_key}-storage_blob"].id]
+    private_dns_zone_ids_table           = [data.terraform_remote_state.hub.outputs.private_dns_zones["${each.value.region_key}-storage_table"].id]
     private_dns_zone_ids_queue           = [data.terraform_remote_state.hub.outputs.private_dns_zones["${each.value.region_key}-storage_queue"].id]
     private_endpoint_enabled             = var.features.private_endpoints_enabled
     private_endpoint_subnet_id           = module.subnets["${module.regions_config[each.value.region_key].names.subnet}-pep"].id


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

In order for dotnet durable functions to access their underlying storage accounts when public access to the storage account is disabled, a private endpoint for the storage account table service must be deployed, along with the Table Contributor RBAC role..


## Context

Allows increased security compliance.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
