### PR TITLE
feat: DTOSS-7817 - Adding dotnet test step in between sonar scan start and end to attempt to fix coverage reporting

### DIFF
--- a/.github/actions/perform-static-analysis/action.yaml
+++ b/.github/actions/perform-static-analysis/action.yaml
@@ -14,6 +14,10 @@ inputs:
     description: "Path to coverage reports"
     required: false
     default: "coverage"
+  unit_test_dir:
+    description: "Directory containing the unit tests"
+    required: false
+    default: "tests"
 runs:
   using: "composite"
   steps:
@@ -22,7 +26,6 @@ runs:
       with:
         java-version: 17
         distribution: "zulu"
-
     - name: Install .NET SDKs
       uses: actions/setup-dotnet@v4
       with:
@@ -30,7 +33,6 @@ runs:
           7.0.x
           8.0.x
           9.0.x
-
     - name: Cache SonarQube packages
       uses: actions/cache@v4
       with:
@@ -38,7 +40,6 @@ runs:
         key: ${{ runner.os }}-sonar-${{ hashFiles('**/*.csproj') }}
         restore-keys: |
           ${{ runner.os }}-sonar-
-
     - name: Cache NuGet packages
       uses: actions/cache@v4
       with:
@@ -46,11 +47,9 @@ runs:
         key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/*.sln') }}
         restore-keys: |
           ${{ runner.os }}-nuget-
-
     - name: Install SonarScanner
       shell: bash
       run: dotnet tool install --global dotnet-sonarscanner
-
     - name: SonarCloud analysis
       shell: bash
       env:
@@ -59,17 +58,19 @@ runs:
       run: |
         # Make the script executable
         chmod +x ${{ github.workspace }}/scripts/reports/sonar-analysis.sh
+        
         # Run the script with all necessary parameters
         ${{ github.workspace }}/scripts/reports/sonar-analysis.sh \
-          "${{ inputs.sonar_project_key }}" \
-          "${{ inputs.sonar_organisation_key }}" \
-          "${{ inputs.sonar_token }}" \
-          "${{ inputs.coverage_path }}" \
-          "${{ github.token }}" \
-          "${{ github.event_name }}" \
-          "${{ github.head_ref }}" \
-          "${{ github.base_ref }}" \
-          "${{ github.event.pull_request.number }}" \
-          "${{ github.repository }}" \
-          "${{ github.ref }}" \
-          "${{ github.sha }}"
+        "${{ inputs.sonar_project_key }}" \
+        "${{ inputs.sonar_organisation_key }}" \
+        "${{ inputs.sonar_token }}" \
+        "${{ inputs.coverage_path }}" \
+        "${{ github.token }}" \
+        "${{ github.event_name }}" \
+        "${{ github.head_ref }}" \
+        "${{ github.base_ref }}" \
+        "${{ github.event.pull_request.number }}" \
+        "${{ github.repository }}" \
+        "${{ github.ref }}" \
+        "${{ github.sha }}" \
+        "${{ inputs.unit_test_dir }}"

--- a/.github/actions/perform-static-analysis/action.yaml
+++ b/.github/actions/perform-static-analysis/action.yaml
@@ -17,7 +17,7 @@ inputs:
   unit_test_dir:
     description: "Directory containing the unit tests"
     required: false
-    default: "tests"
+    default: "tests/UnitTests"
 runs:
   using: "composite"
   steps:

--- a/.github/workflows/stage-2-analyse.yaml
+++ b/.github/workflows/stage-2-analyse.yaml
@@ -1,5 +1,4 @@
 name: Analysis stage
-
 on:
   workflow_call:
     inputs:
@@ -35,26 +34,9 @@ on:
         description: Version of the software
         required: true
         type: string
-
 jobs:
-  download-test-coverage:
-    name: Download test coverage
-    runs-on: ubuntu-latest
-    timeout-minutes: 2
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          submodules: true
-      - name: Download coverage report
-        uses: actions/download-artifact@v4
-        with:
-          name: test-coverage-report
-          path: coverage
-          
   perform-static-analysis:
     name: Perform static analysis
-    needs: [download-test-coverage]
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -66,12 +48,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
-          fetch-depth: 0 # Full history for more accurate reporting
-      - name: Download coverage report
-        uses: actions/download-artifact@v4
-        with:
-          name: test-coverage-report
-          path: coverage
+          fetch-depth: 0
       - name: Perform static analysis
         uses: ./.github/actions/perform-static-analysis
         with:
@@ -79,3 +56,4 @@ jobs:
           sonar_project_key: ${{ vars.SONAR_PROJECT_KEY }}
           sonar_token: ${{ secrets.SONAR_TOKEN }}
           coverage_path: "coverage"
+          unit_test_dir: ${{ inputs.unit_test_dir }} # Added unit_test_dir parameter

--- a/scripts/reports/sonar-analysis.sh
+++ b/scripts/reports/sonar-analysis.sh
@@ -14,6 +14,7 @@ GITHUB_EVENT_PULL_REQUEST_NUMBER="$9"
 GITHUB_REPOSITORY="${10}"
 GITHUB_REF="${11}"
 GITHUB_SHA="${12}"
+UNIT_TEST_DIR="${13:-tests}"
 
 # Debug information about environment
 echo "===== DEBUG INFORMATION ====="
@@ -21,20 +22,7 @@ echo "GitHub event: $GITHUB_EVENT_NAME"
 echo "GitHub ref: $GITHUB_REF"
 echo "GitHub SHA: $GITHUB_SHA"
 echo "Coverage path: $COVERAGE_PATH"
-
-# Check if coverage directory exists
-echo "Checking coverage directory..."
-if [ -d "$COVERAGE_PATH" ]; then
-  echo "Coverage directory exists."
-  echo "Coverage files found:"
-  find "$COVERAGE_PATH" -type f -name "*.xml" | sort
-  echo "Coverage file sizes:"
-  find "$COVERAGE_PATH" -type f -name "*.xml" -exec ls -lh {} \;
-else
-  echo "WARNING: Coverage directory does not exist!"
-  mkdir -p "$COVERAGE_PATH"
-  echo "Created empty coverage directory."
-fi
+echo "Unit test directory: $UNIT_TEST_DIR"
 
 # Get PR information for SonarCloud
 if [[ "$GITHUB_EVENT_NAME" == "pull_request" || "$GITHUB_EVENT_NAME" == "pull_request_target" ]]; then
@@ -49,10 +37,11 @@ else
   PR_ARGS="/d:sonar.branch.name=${BRANCH_NAME}"
 fi
 
-# Debug info
-echo "GitHub event: $GITHUB_EVENT_NAME"
 echo "PR arguments: ${PR_ARGS}"
 echo "=========================="
+
+# Ensure coverage directory exists
+mkdir -p "$COVERAGE_PATH"
 
 # Restore solution dependencies
 echo "Restoring .NET dependencies..."
@@ -66,7 +55,10 @@ dotnet sonarscanner begin \
 /d:sonar.token="${SONAR_TOKEN}" \
 /d:sonar.host.url="https://sonarcloud.io" \
 /d:sonar.cs.opencover.reportsPaths="${COVERAGE_PATH}/*.xml" \
-/d:sonar.cs.cobertura.reportsPaths="${COVERAGE_PATH}/cobertura.xml" \
+/d:sonar.cs.vscoveragexml.reportsPaths="${COVERAGE_PATH}/coverage.xml" \
+/d:sonar.cs.cobertura.reportsPaths="${COVERAGE_PATH}/coverage.cobertura.xml" \
+/d:sonar.python.version="3.8" \
+/d:sonar.typescript.lcov.reportPaths="${COVERAGE_PATH}/lcov.info" \
 /d:sonar.coverage.exclusions="**/*Tests.cs,**/Tests/**/*.cs,**/test/**/*.ts,**/tests/**/*.ts,**/*.spec.ts,**/*.test.ts" \
 /d:sonar.tests="tests" \
 /d:sonar.test.inclusions="**/*.spec.ts,**/*.test.ts,**/tests/**/*.ts" \
@@ -80,8 +72,16 @@ ${PR_ARGS}
 echo "Building solutions..."
 find . -name "*.sln" -exec dotnet build {} --no-restore \;
 
-# Debug coverage files after build/test
-echo "Checking coverage files after build/test..."
+# Run consolidated tests to generate coverage
+echo "Running consolidated tests to generate coverage..."
+dotnet test "${UNIT_TEST_DIR}/ConsolidatedTests.csproj" \
+  --results-directory "${COVERAGE_PATH}" \
+  --logger "trx;LogFileName=TestResults.trx" \
+  --collect:"XPlat Code Coverage" \
+  --verbosity normal
+
+# Debug coverage files after test run
+echo "Checking coverage files after test run..."
 find "${COVERAGE_PATH}" -type f -name "*.xml" | sort
 echo "Coverage file details:"
 find "${COVERAGE_PATH}" -type f -name "*.xml" -exec ls -lh {} \;

--- a/scripts/reports/sonar-analysis.sh
+++ b/scripts/reports/sonar-analysis.sh
@@ -53,9 +53,7 @@ dotnet sonarscanner begin \
 /o:"${SONAR_ORGANISATION_KEY}" \
 /d:sonar.token="${SONAR_TOKEN}" \
 /d:sonar.host.url="https://sonarcloud.io" \
-/d:sonar.cs.opencover.reportsPaths="${COVERAGE_PATH}/*.xml" \
-/d:sonar.cs.vscoveragexml.reportsPaths="${COVERAGE_PATH}/coverage.xml" \
-/d:sonar.cs.cobertura.reportsPaths="${COVERAGE_PATH}/coverage.cobertura.xml" \
+/d:sonar.cs.opencover.reportsPaths="${COVERAGE_PATH}/**/*.xml" \
 /d:sonar.python.version="3.8" \
 /d:sonar.typescript.lcov.reportPaths="${COVERAGE_PATH}/lcov.info" \
 /d:sonar.coverage.exclusions="**/*Tests.cs,**/Tests/**/*.cs,**/test/**/*.ts,**/tests/**/*.ts,**/*.spec.ts,**/*.test.ts" \
@@ -74,10 +72,10 @@ find . -name "*.sln" -exec dotnet build {} --no-restore \;
 # Run consolidated tests to generate coverage
 echo "Running consolidated tests to generate coverage..."
 dotnet test "${UNIT_TEST_DIR}/ConsolidatedTests.csproj" \
---results-directory "${COVERAGE_PATH}" \
---logger "trx;LogFileName=TestResults.trx" \
---collect:"XPlat Code Coverage" \
---verbosity normal
+  --results-directory "${COVERAGE_PATH}" \
+  --logger "trx;LogFileName=TestResults.trx" \
+  --collect:"XPlat Code Coverage;Format=opencover" \
+  --verbosity normal
 
 # Debug coverage files and directories after test run
 echo "===== COVERAGE PATH CONTENT ====="

--- a/scripts/reports/sonar-analysis.sh
+++ b/scripts/reports/sonar-analysis.sh
@@ -14,7 +14,7 @@ GITHUB_EVENT_PULL_REQUEST_NUMBER="$9"
 GITHUB_REPOSITORY="${10}"
 GITHUB_REF="${11}"
 GITHUB_SHA="${12}"
-UNIT_TEST_DIR="${13:-tests}"
+UNIT_TEST_DIR="${13:-tests/UnitTests}"
 
 # Debug information about environment
 echo "===== DEBUG INFORMATION ====="

--- a/scripts/reports/sonar-analysis.sh
+++ b/scripts/reports/sonar-analysis.sh
@@ -41,7 +41,7 @@ dotnet sonarscanner begin \
 /o:"${SONAR_ORGANISATION_KEY}" \
 /d:sonar.token="${SONAR_TOKEN}" \
 /d:sonar.host.url="https://sonarcloud.io" \
-/d:sonar.cs.opencover.reportsPaths="${COVERAGE_PATH}/coverage.opencover.xml" \
+/d:sonar.cs.opencover.reportsPaths="${COVERAGE_PATH}/**/*.xml" \
 /d:sonar.python.version="3.8" \
 /d:sonar.typescript.lcov.reportPaths="${COVERAGE_PATH}/lcov.info" \
 /d:sonar.coverage.exclusions="**/*Tests.cs,**/Tests/**/*.cs,**/test/**/*.ts,**/tests/**/*.ts,**/*.spec.ts,**/*.test.ts" \
@@ -63,16 +63,6 @@ dotnet test "${UNIT_TEST_DIR}/ConsolidatedTests.csproj" \
   --logger "trx;LogFileName=TestResults.trx" \
   --collect:"XPlat Code Coverage;Format=opencover" \
   --verbosity normal
-
-# Look for OpenCover XML files and copy to standard location
-OPENCOVER_FILE=$(find "${COVERAGE_PATH}" -name "coverage.opencover.xml" | head -n 1)
-if [ -n "$OPENCOVER_FILE" ]; then
-  echo "Found OpenCover file: ${OPENCOVER_FILE}"
-  cp "${OPENCOVER_FILE}" "${COVERAGE_PATH}/coverage.opencover.xml"
-  echo "Copied to ${COVERAGE_PATH}/coverage.opencover.xml"
-else
-  echo "No OpenCover file found in ${COVERAGE_PATH}"
-fi
 
 # End SonarScanner
 dotnet sonarscanner end /d:sonar.token="${SONAR_TOKEN}"

--- a/scripts/reports/sonar-analysis.sh
+++ b/scripts/reports/sonar-analysis.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 set -e
-
 # Get input parameters
 SONAR_PROJECT_KEY="$1"
 SONAR_ORGANISATION_KEY="$2"
@@ -47,6 +46,16 @@ mkdir -p "$COVERAGE_PATH"
 echo "Restoring .NET dependencies..."
 find . -name "*.sln" -exec dotnet restore {} \;
 
+# Show explicit SonarCloud coverage paths to verify configuration
+OPENCOVER_PATH="${COVERAGE_PATH}/*.xml"
+VSCOVERAGE_PATH="${COVERAGE_PATH}/coverage.xml"
+COBERTURA_PATH="${COVERAGE_PATH}/coverage.cobertura.xml"
+
+echo "SonarCloud will look for coverage at these paths:"
+echo "OpenCover: $OPENCOVER_PATH"
+echo "VSCoverage: $VSCOVERAGE_PATH"
+echo "Cobertura: $COBERTURA_PATH"
+
 # Begin SonarScanner with coverage configuration and PR information
 echo "Starting SonarScanner..."
 dotnet sonarscanner begin \
@@ -54,15 +63,16 @@ dotnet sonarscanner begin \
 /o:"${SONAR_ORGANISATION_KEY}" \
 /d:sonar.token="${SONAR_TOKEN}" \
 /d:sonar.host.url="https://sonarcloud.io" \
-/d:sonar.cs.opencover.reportsPaths="${COVERAGE_PATH}/*.xml" \
-/d:sonar.cs.vscoveragexml.reportsPaths="${COVERAGE_PATH}/coverage.xml" \
-/d:sonar.cs.cobertura.reportsPaths="${COVERAGE_PATH}/coverage.cobertura.xml" \
+/d:sonar.cs.opencover.reportsPaths="${OPENCOVER_PATH}" \
+/d:sonar.cs.vscoveragexml.reportsPaths="${VSCOVERAGE_PATH}" \
+/d:sonar.cs.cobertura.reportsPaths="${COBERTURA_PATH}" \
 /d:sonar.python.version="3.8" \
 /d:sonar.typescript.lcov.reportPaths="${COVERAGE_PATH}/lcov.info" \
 /d:sonar.coverage.exclusions="**/*Tests.cs,**/Tests/**/*.cs,**/test/**/*.ts,**/tests/**/*.ts,**/*.spec.ts,**/*.test.ts" \
 /d:sonar.tests="tests" \
 /d:sonar.test.inclusions="**/*.spec.ts,**/*.test.ts,**/tests/**/*.ts" \
 /d:sonar.verbose=true \
+/d:sonar.log.level=DEBUG \
 /d:sonar.scm.provider=git \
 /d:sonar.scm.revision=${GITHUB_SHA} \
 /d:sonar.scanner.scanAll=true \
@@ -75,19 +85,62 @@ find . -name "*.sln" -exec dotnet build {} --no-restore \;
 # Run consolidated tests to generate coverage
 echo "Running consolidated tests to generate coverage..."
 dotnet test "${UNIT_TEST_DIR}/ConsolidatedTests.csproj" \
-  --results-directory "${COVERAGE_PATH}" \
-  --logger "trx;LogFileName=TestResults.trx" \
-  --collect:"XPlat Code Coverage" \
-  --verbosity normal
+--results-directory "${COVERAGE_PATH}" \
+--logger "trx;LogFileName=TestResults.trx" \
+--collect:"XPlat Code Coverage" \
+--verbosity normal
 
 # Debug coverage files after test run
+echo "===== COVERAGE FILE VERIFICATION ====="
 echo "Checking coverage files after test run..."
 find "${COVERAGE_PATH}" -type f -name "*.xml" | sort
 echo "Coverage file details:"
 find "${COVERAGE_PATH}" -type f -name "*.xml" -exec ls -lh {} \;
 
+# Look for coverage XML files specifically
+echo "Looking for coverage report formats..."
+find "${COVERAGE_PATH}" -type f -name "*coverage*.xml" | sort
+
+# Check content of XML files to verify they contain coverage data
+echo "Verifying coverage file content (first 10 lines):"
+find "${COVERAGE_PATH}" -type f -name "*coverage*.xml" -exec sh -c "echo '=== {} ==='; head -n 10 {}" \;
+
+# Check if SonarCloud expected files exist
+echo "Checking if SonarCloud expected paths exist:"
+[ -f "${COVERAGE_PATH}/coverage.xml" ] && echo "VSCoverage file exists: ${COVERAGE_PATH}/coverage.xml" || echo "VSCoverage file MISSING: ${COVERAGE_PATH}/coverage.xml"
+[ -f "${COVERAGE_PATH}/coverage.cobertura.xml" ] && echo "Cobertura file exists: ${COVERAGE_PATH}/coverage.cobertura.xml" || echo "Cobertura file MISSING: ${COVERAGE_PATH}/coverage.cobertura.xml"
+echo "OpenCover files:"
+find "${COVERAGE_PATH}" -type f -name "*.xml" | grep -i opencover || echo "No OpenCover files found"
+echo "===============================
+
+# Rename coverage files to match SonarCloud expected paths if needed
+echo "Renaming coverage files to match expected paths..."
+for xml_file in $(find "${COVERAGE_PATH}" -name "*coverage*.xml"); do
+  if [ ! -f "${COVERAGE_PATH}/coverage.xml" ] && [[ "$xml_file" == *coverage*.xml ]]; then
+    echo "Copying $xml_file to ${COVERAGE_PATH}/coverage.xml for VSCoverage report"
+    cp "$xml_file" "${COVERAGE_PATH}/coverage.xml"
+  fi
+  if [ ! -f "${COVERAGE_PATH}/coverage.cobertura.xml" ] && [[ "$xml_file" == *cobertura*.xml ]]; then
+    echo "Copying $xml_file to ${COVERAGE_PATH}/coverage.cobertura.xml for Cobertura report"
+    cp "$xml_file" "${COVERAGE_PATH}/coverage.cobertura.xml"
+  fi
+done
+
+# Check coverage files again after renaming
+echo "Coverage files after renaming:"
+find "${COVERAGE_PATH}" -type f -name "*.xml" | sort
+
 # End SonarScanner
-echo "Ending SonarScanner analysis..."
-dotnet sonarscanner end /d:sonar.token="${SONAR_TOKEN}"
+echo "Ending SonarScanner analysis (with file verification)..."
+dotnet sonarscanner end /d:sonar.token="${SONAR_TOKEN}" | tee sonar_end_output.log
+
+# Check SonarScanner logs for coverage imports
+echo "===== CHECKING SONARSCANNER LOGS FOR COVERAGE ====="
+grep -i "coverage" sonar_end_output.log || echo "No coverage mentions in logs"
+grep -i "parse" sonar_end_output.log || echo "No parsing mentions in logs"
+grep -i "import" sonar_end_output.log || echo "No import mentions in logs"
+grep -i "error" sonar_end_output.log || echo "No errors found in logs"
+grep -i "warn" sonar_end_output.log || echo "No warnings found in logs"
+echo "===============================
 
 echo "Analysis complete."

--- a/scripts/reports/sonar-analysis.sh
+++ b/scripts/reports/sonar-analysis.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -e
+
 # Get input parameters
 SONAR_PROJECT_KEY="$1"
 SONAR_ORGANISATION_KEY="$2"
@@ -15,14 +16,6 @@ GITHUB_REF="${11}"
 GITHUB_SHA="${12}"
 UNIT_TEST_DIR="${13:-tests/UnitTests}"
 
-# Debug information about environment
-echo "===== DEBUG INFORMATION ====="
-echo "GitHub event: $GITHUB_EVENT_NAME"
-echo "GitHub ref: $GITHUB_REF"
-echo "GitHub SHA: $GITHUB_SHA"
-echo "Coverage path: $COVERAGE_PATH"
-echo "Unit test directory: $UNIT_TEST_DIR"
-
 # Get PR information for SonarCloud
 if [[ "$GITHUB_EVENT_NAME" == "pull_request" || "$GITHUB_EVENT_NAME" == "pull_request_target" ]]; then
   PR_BRANCH="$GITHUB_HEAD_REF"
@@ -36,24 +29,19 @@ else
   PR_ARGS="/d:sonar.branch.name=${BRANCH_NAME}"
 fi
 
-echo "PR arguments: ${PR_ARGS}"
-echo "=========================="
-
 # Ensure coverage directory exists
 mkdir -p "$COVERAGE_PATH"
 
 # Restore solution dependencies
-echo "Restoring .NET dependencies..."
 find . -name "*.sln" -exec dotnet restore {} \;
 
 # Begin SonarScanner with coverage configuration and PR information
-echo "Starting SonarScanner..."
 dotnet sonarscanner begin \
 /k:"${SONAR_PROJECT_KEY}" \
 /o:"${SONAR_ORGANISATION_KEY}" \
 /d:sonar.token="${SONAR_TOKEN}" \
 /d:sonar.host.url="https://sonarcloud.io" \
-/d:sonar.cs.opencover.reportsPaths="${COVERAGE_PATH}/coverage.xml" \
+/d:sonar.cs.opencover.reportsPaths="${COVERAGE_PATH}/coverage.opencover.xml" \
 /d:sonar.python.version="3.8" \
 /d:sonar.typescript.lcov.reportPaths="${COVERAGE_PATH}/lcov.info" \
 /d:sonar.coverage.exclusions="**/*Tests.cs,**/Tests/**/*.cs,**/test/**/*.ts,**/tests/**/*.ts,**/*.spec.ts,**/*.test.ts" \
@@ -66,88 +54,25 @@ dotnet sonarscanner begin \
 ${PR_ARGS}
 
 # Build all solutions
-echo "Building solutions..."
 find . -name "*.sln" -exec dotnet build {} --no-restore \;
 
 # Run consolidated tests to generate coverage
-echo "Running consolidated tests to generate coverage..."
+# This is critical - tests must run between SonarScanner begin and end commands
 dotnet test "${UNIT_TEST_DIR}/ConsolidatedTests.csproj" \
   --results-directory "${COVERAGE_PATH}" \
   --logger "trx;LogFileName=TestResults.trx" \
   --collect:"XPlat Code Coverage;Format=opencover" \
   --verbosity normal
 
-# Debug coverage files and directories after test run
-echo "===== COVERAGE PATH CONTENT ====="
-echo "Listing all directories in ${COVERAGE_PATH}:"
-find "${COVERAGE_PATH}" -type d | sort
-
-echo "Listing all files in ${COVERAGE_PATH} recursively:"
-find "${COVERAGE_PATH}" -type f | sort
-
-# Find and copy coverage files to expected locations
-echo "Finding and copying coverage files to SonarCloud expected locations..."
-
-# Find all XML files and show their file sizes
-echo "All XML files found:"
-find "${COVERAGE_PATH}" -name "*.xml" -type f -exec ls -lh {} \;
-
 # Look for OpenCover XML files and copy to standard location
 OPENCOVER_FILE=$(find "${COVERAGE_PATH}" -name "coverage.opencover.xml" | head -n 1)
 if [ -n "$OPENCOVER_FILE" ]; then
   echo "Found OpenCover file: ${OPENCOVER_FILE}"
-  cp "${OPENCOVER_FILE}" "${COVERAGE_PATH}/coverage.xml"
-  echo "Copied to ${COVERAGE_PATH}/coverage.xml"
+  cp "${OPENCOVER_FILE}" "${COVERAGE_PATH}/coverage.opencover.xml"
+  echo "Copied to ${COVERAGE_PATH}/coverage.opencover.xml"
 else
-  echo "No OpenCover file found, looking for any XML..."
-  
-  # Fallback to any XML file if no specific format found
-  ANY_XML=$(find "${COVERAGE_PATH}" -name "*.xml" -not -name "TestResults.xml" | head -n 1)
-  if [ -n "$ANY_XML" ]; then
-    echo "Found XML file: ${ANY_XML}"
-    cp "${ANY_XML}" "${COVERAGE_PATH}/coverage.xml"
-    echo "Copied to ${COVERAGE_PATH}/coverage.xml"
-  else
-    echo "No suitable XML coverage file found"
-  fi
+  echo "No OpenCover file found in ${COVERAGE_PATH}"
 fi
 
-# Check if the coverage files now exist
-echo "Checking if coverage file exists at expected path:"
-[ -f "${COVERAGE_PATH}/coverage.xml" ] && echo "Coverage file exists: ${COVERAGE_PATH}/coverage.xml" || echo "Coverage file MISSING: ${COVERAGE_PATH}/coverage.xml"
-
-# Fix any XML issues
-echo "Fixing potential XML issues..."
-if [ -f "${COVERAGE_PATH}/coverage.xml" ]; then
-  # Create a backup
-  cp "${COVERAGE_PATH}/coverage.xml" "${COVERAGE_PATH}/coverage.xml.bak"
-  
-  # Fix common XML issues - remove BOM and invalid characters
-  # This uses 'sed' to remove the BOM marker if present
-  sed -i '1s/^\xEF\xBB\xBF//' "${COVERAGE_PATH}/coverage.xml" || true
-  
-  # Only keep valid XML characters
-  tr -cd '\11\12\15\40-\176' < "${COVERAGE_PATH}/coverage.xml.bak" > "${COVERAGE_PATH}/coverage.xml.tmp" || true
-  mv "${COVERAGE_PATH}/coverage.xml.tmp" "${COVERAGE_PATH}/coverage.xml" || true
-  
-  # Verify if fixed
-  echo "Checking if XML is now valid:"
-  xmllint --noout "${COVERAGE_PATH}/coverage.xml" && echo "✅ XML is now valid" || echo "❌ XML still has issues - continuing anyway"
-fi
-
-# Log coverage file info
-echo "===== COVERAGE FILE DETAILS ====="
-echo "Coverage file details:"
-ls -lh "${COVERAGE_PATH}/coverage.xml" || echo "File not found"
-echo "First 20 lines of coverage file:"
-head -n 20 "${COVERAGE_PATH}/coverage.xml" || echo "Cannot display file content"
-
-# End SonarScanner - REMOVED the duplicate command and the verbose parameter
-echo "Ending SonarScanner analysis..."
-dotnet sonarscanner end /d:sonar.token="${SONAR_TOKEN}" | tee sonar_output.log
-
-# Check for coverage mentions in output
-echo "Checking for coverage mentions in SonarScanner output:"
-grep -i "coverage\|parsing\|report" sonar_output.log || echo "No coverage-related terms found in logs"
-
-echo "Analysis complete."
+# End SonarScanner
+dotnet sonarscanner end /d:sonar.token="${SONAR_TOKEN}"


### PR DESCRIPTION


<!-- markdownlint-disable-next-line first-line-heading -->
## Description

<!-- Describe your changes in detail. -->

I am adding a dotnet test step in between sonar scan start and end to attempt to fix coverage reporting. Can only test this fix in main.

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
