### PR TITLE
chore: changing stream over to memory stream in GenerateStreamFromString method in MockHelpers class

### DIFF
--- a/tests/TestUtils/MockHelpers.cs
+++ b/tests/TestUtils/MockHelpers.cs
@@ -41,7 +41,7 @@ public static class MockHelpers
     {
         Mock<HttpWebResponse> mockWebResponse = new();
         mockWebResponse.Setup(i => i.StatusCode).Returns(httpStatusCode);
-        var webException  = new WebException(ErrorMessage,null, WebExceptionStatus.UnknownError,mockWebResponse.Object);
+        var webException = new WebException(ErrorMessage, null, WebExceptionStatus.UnknownError, mockWebResponse.Object);
         return webException;
     }
 
@@ -50,7 +50,7 @@ public static class MockHelpers
         var context = new Mock<FunctionContext>();
         var requestData = new Mock<HttpRequestData>(context.Object);
 
-        if(!string.IsNullOrEmpty(body))
+        if (!string.IsNullOrEmpty(body))
         {
             var bodyForHttpRequest = GetBodyForHttpRequest(body);
             requestData.Setup(context => context.Body).Returns(bodyForHttpRequest);
@@ -65,7 +65,8 @@ public static class MockHelpers
 
     public static async Task<TEntity> GetResponseBodyAsObject<TEntity>(HttpResponseData httpResponseData)
     {
-        using (var reader = new StreamReader(httpResponseData.Body)){
+        using (var reader = new StreamReader(httpResponseData.Body))
+        {
             var result = await reader.ReadToEndAsync();
             return JsonSerializer.Deserialize<TEntity>(result);
         }
@@ -93,7 +94,7 @@ public static class MockHelpers
         return memoryStream;
     }
 
-    private static Stream GenerateStreamFromString(string s)
+    private static MemoryStream GenerateStreamFromString(string s)
     {
         var stream = new MemoryStream();
         var writer = new StreamWriter(stream);


### PR DESCRIPTION
…ing method in MockHelpers class

<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Chore: changing stream over to memory stream in GenerateStreamFromString method in MockHelpers class)

https://sonarcloud.io/project/issues?open=AZbYoO08J-J0UbUiw6Md&id=NHSDigital_dtos-cohort-manager

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
