### PR TITLE
feat: DTOSS-9401-ExceptionsManagement-to-include-RECORD_UPDATED_DATE

### DIFF
--- a/application/CohortManager/src/Functions/ExceptionHandling/UpdateException/UpdateException.cs
+++ b/application/CohortManager/src/Functions/ExceptionHandling/UpdateException/UpdateException.cs
@@ -99,6 +99,6 @@ public class UpdateException
     private static void UpdateExceptionRecord(ExceptionManagement exceptionData, UpdateExceptionRequest updateRequest)
     {
         exceptionData.ServiceNowId = updateRequest.ServiceNowNumber; // can be null
-        exceptionData.ServiceNowCreatedDate = DateTime.Now;
+        exceptionData.RecordUpdatedDate = DateTime.Now;
     }
 }

--- a/application/CohortManager/src/Functions/Shared/Data/Database/ValidationExceptionData.cs
+++ b/application/CohortManager/src/Functions/Shared/Data/Database/ValidationExceptionData.cs
@@ -85,7 +85,7 @@ public class ValidationExceptionData : IValidationExceptionData
         if (validationExceptionToUpdate != null)
         {
             validationExceptionToUpdate.DateResolved = DateTime.Today;
-
+            validationExceptionToUpdate.RecordUpdatedDate = DateTime.Today;
             return await _validationExceptionDataServiceClient.Update(validationExceptionToUpdate);
         }
         return false;

--- a/application/CohortManager/src/Functions/Shared/DataServices.Migrations/Migrations/DataServicesContextModelSnapshot.cs
+++ b/application/CohortManager/src/Functions/Shared/DataServices.Migrations/Migrations/DataServicesContextModelSnapshot.cs
@@ -577,6 +577,10 @@ namespace DataServices.Migrations.Migrations
                         .HasColumnType("nvarchar(50)")
                         .HasColumnName("NHS_NUMBER");
 
+                    b.Property<DateTime?>("RecordUpdatedDate")
+                        .HasColumnType("datetime")
+                        .HasColumnName("RECORD_UPDATED_DATE");
+
                     b.Property<string>("RuleDescription")
                         .HasColumnType("nvarchar(max)")
                         .HasColumnName("RULE_DESCRIPTION");

--- a/application/CohortManager/src/Functions/Shared/Model/EFModels/ExceptionManagement.cs
+++ b/application/CohortManager/src/Functions/Shared/Model/EFModels/ExceptionManagement.cs
@@ -57,6 +57,9 @@ public class ExceptionManagement
     [Column("SERVICENOW_CREATED_DATE", TypeName = "datetime")]
     public DateTime? ServiceNowCreatedDate { get; set; }
 
+    [Column("RECORD_UPDATED_DATE", TypeName = "datetime")]
+    public DateTime? RecordUpdatedDate { get; set; }
+
     public ValidationException ToValidationException()
     {
         return new ValidationException
@@ -74,7 +77,9 @@ public class ExceptionManagement
             ExceptionDate = ExceptionDate,
             CohortName = CohortName,
             Fatal = IsFatal,
-            ServiceNowId = ServiceNowId
+            ServiceNowId = ServiceNowId,
+            ServiceNowCreatedDate = ServiceNowCreatedDate,
+            RecordUpdatedDate = RecordUpdatedDate
         };
     }
 
@@ -96,7 +101,9 @@ public class ExceptionManagement
             ExceptionDate = validationException.ExceptionDate ?? DateTime.Now,
             CohortName = validationException.CohortName,
             IsFatal = short.TryParse(input, out short result) ? result : new short(),
-            ServiceNowId = ServiceNowId
+            ServiceNowId = ServiceNowId,
+            ServiceNowCreatedDate = validationException.ServiceNowCreatedDate ?? DateTime.MinValue,
+            RecordUpdatedDate = validationException.RecordUpdatedDate ?? DateTime.MaxValue
         };
     }
 }

--- a/application/CohortManager/src/Functions/Shared/Model/UpdateExceptionRequest.cs
+++ b/application/CohortManager/src/Functions/Shared/Model/UpdateExceptionRequest.cs
@@ -2,6 +2,7 @@ namespace Model;
 
 public class UpdateExceptionRequest
 {
-    public string ExceptionId { get; set; }
+    public required string ExceptionId { get; set; }
     public string? ServiceNowNumber { get; set; }
+    public DateTime? ServiceNowCreatedDate { get; set; }
 }

--- a/application/CohortManager/src/Functions/Shared/Model/ValidationException.cs
+++ b/application/CohortManager/src/Functions/Shared/Model/ValidationException.cs
@@ -17,4 +17,6 @@ public class ValidationException
     public int? Fatal { get; set; }
     public ExceptionDetails ExceptionDetails { get; set; }
     public string? ServiceNowId { get; set; }
+    public DateTime? ServiceNowCreatedDate { get; set; }
+    public DateTime? RecordUpdatedDate { get; set; }
 }


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description
We need to... Update the GetExceptions API. We need to add the SERVICENOW_CREATED_DATE and RECORD_UPDATED_DATE.
Add a new field to the EXCEPTION_MANAGEMENT table called RECORD_UPDATED
Make sure to update RECORD_UPDATED_DATE while updating EXCEPTION_MANAGEMENT table with 
SERVICENOW_ID.
## Context
[DTOSS-9401](https://nhsd-jira.digital.nhs.uk/browse/DTOSS-9401)
## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [x] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
