### PR TITLE
Revert "refactor: migrate CaasIntegration to use httpClientFunction"

### DIFF
--- a/application/CohortManager/src/Functions/CaasIntegration/receiveCaasFile/ProcessFileClasses/CallDurableDemographicFunc.cs
+++ b/application/CohortManager/src/Functions/CaasIntegration/receiveCaasFile/ProcessFileClasses/CallDurableDemographicFunc.cs
@@ -1,7 +1,10 @@
 namespace NHS.Screening.ReceiveCaasFile;
 
+
+using System.Net.Http.Headers;
 using System.Text.Json;
 using Common;
+using Microsoft.Azure.Functions.Worker.Extensions.Abstractions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Model;
@@ -10,24 +13,27 @@ using Polly;
 
 public class CallDurableDemographicFunc : ICallDurableDemographicFunc
 {
-    private readonly IHttpClientFunction _httpClientFunction;
+
+    private readonly ICallFunction _callFunction;
     private readonly ILogger<CallDurableDemographicFunc> _logger;
+    private readonly HttpClient _httpClient;
     private readonly ICopyFailedBatchToBlob _copyFailedBatchToBlob;
     private readonly int _maxNumberOfChecks;
     private TimeSpan _delayBetweenChecks = TimeSpan.FromSeconds(3);
+
     private readonly ReceiveCaasFileConfig _config;
 
-    public CallDurableDemographicFunc(
-        IHttpClientFunction httpClientFunction,
-        ILogger<CallDurableDemographicFunc> logger,
-        ICopyFailedBatchToBlob copyFailedBatchToBlob,
-        IOptions<ReceiveCaasFileConfig> config)
+
+    public CallDurableDemographicFunc(ICallFunction callFunction, ILogger<CallDurableDemographicFunc> logger, HttpClient httpClient, ICopyFailedBatchToBlob copyFailedBatchToBlob, IOptions<ReceiveCaasFileConfig> config)
     {
         _config = config.Value;
-        _httpClientFunction = httpClientFunction;
+        _callFunction = callFunction;
         _logger = logger;
+        _httpClient = httpClient;
         _copyFailedBatchToBlob = copyFailedBatchToBlob;
         _maxNumberOfChecks = _config.maxNumberOfChecks;
+
+        _httpClient.Timeout = TimeSpan.FromSeconds(300);
     }
 
     /// <summary>
@@ -53,9 +59,16 @@ public class CallDurableDemographicFunc : ICallDurableDemographicFunc
 
         try
         {
-            var response = await _httpClientFunction.SendPost(DemographicFunctionURI, JsonSerializer.Serialize(participants));
+            using var memoryStream = new MemoryStream();
+            // this seems to be better for memory management
+            await JsonSerializer.SerializeAsync(memoryStream, participants);
+            memoryStream.Position = 0;
 
-            responseContent = response.Headers.Location?.ToString() ?? string.Empty;
+            var content = new StreamContent(memoryStream);
+            content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+            var response = await _httpClient.PostAsync(DemographicFunctionURI, content);
+
+            responseContent = response.Headers.Location.ToString();
 
             // this is not retrying the function if it fails but checking if it has done yet.
             var retryPolicy = Policy
@@ -73,12 +86,12 @@ public class CallDurableDemographicFunc : ICallDurableDemographicFunc
 
             if (finalStatus == WorkFlowStatus.Completed)
             {
-                _logger.LogWarning("Durable function completed {FinalStatus}", finalStatus);
+                _logger.LogWarning("Durable function completed {finalStatus}", finalStatus);
                 return true;
             }
             else
             {
-                _logger.LogError("Check limit reached or demographic function failed {FinalStatus}", finalStatus);
+                _logger.LogError("Check limit reached or demographic function failed {finalStatus}", finalStatus);
                 await _copyFailedBatchToBlob.writeBatchToBlob(
                     JsonSerializer.Serialize(participants),
                     new InvalidOperationException("there was an error while adding batch of participants to the demographic table")
@@ -109,15 +122,16 @@ public class CallDurableDemographicFunc : ICallDurableDemographicFunc
     {
         try
         {
-            var response = await _httpClientFunction.SendGet(statusRequestGetUri);
+            using HttpResponseMessage response = await _httpClient.GetAsync(statusRequestGetUri);
+            var jsonResponse = await response.Content.ReadAsStringAsync();
 
-            var data = JsonSerializer.Deserialize<WebhookResponse>(response);
+            var data = JsonSerializer.Deserialize<WebhookResponse>(jsonResponse);
 
             if (data != null)
             {
                 if (!Enum.TryParse(data.RuntimeStatus, out WorkFlowStatus workFlowStatus))
                 {
-                    _logger.LogError("There was an error parsing the RuntimeStatus: {Response}", response);
+                    _logger.LogError(jsonResponse);
                 }
                 return workFlowStatus;
             }
@@ -126,7 +140,7 @@ public class CallDurableDemographicFunc : ICallDurableDemographicFunc
         //sometimes the webhook can fail for very annoying reasons but the Orchestration data still exists so we can check for its status
         catch (Exception ex)
         {
-            var getOrchestrationStatusURL = _config.GetOrchestrationStatusURL;
+            var getOrchestrationStatusURL = Environment.GetEnvironmentVariable("GetOrchestrationStatusURL");
 
             if (string.IsNullOrWhiteSpace(getOrchestrationStatusURL))
             {
@@ -137,8 +151,8 @@ public class CallDurableDemographicFunc : ICallDurableDemographicFunc
             _logger.LogWarning(ex, "There has been error getting the status for instanceId {InstanceId}", instanceId);
 
             var json = JsonSerializer.Serialize(instanceId);
-            var response = await _httpClientFunction.SendPost(getOrchestrationStatusURL, json);
-            var responseBody = await _httpClientFunction.GetResponseText(response);
+            var response = await _callFunction.SendPost(getOrchestrationStatusURL, json);
+            var responseBody = await _callFunction.GetResponseText(response);
 
             if (Enum.TryParse<WorkFlowStatus>(responseBody, out var result))
             {

--- a/application/CohortManager/src/Functions/CaasIntegration/receiveCaasFile/ProcessFileClasses/ProcessCaasFile.cs
+++ b/application/CohortManager/src/Functions/CaasIntegration/receiveCaasFile/ProcessFileClasses/ProcessCaasFile.cs
@@ -3,6 +3,7 @@ namespace NHS.Screening.ReceiveCaasFile;
 using System.Text.Json;
 using Common;
 using Common.Interfaces;
+using Data.Database;
 using DataServices.Client;
 using Hl7.Fhir.Rest;
 using Microsoft.Extensions.Logging;
@@ -22,7 +23,7 @@ public class ProcessCaasFile : IProcessCaasFile
     private readonly IDataServiceClient<ParticipantDemographic> _participantDemographic;
     private readonly IRecordsProcessedTracker _recordsProcessTracker;
     private readonly IValidateDates _validateDates;
-    private readonly IHttpClientFunction _httpClientFunction;
+    private readonly ICallFunction _callFunction;
     private readonly ReceiveCaasFileConfig _config;
     private readonly string DemographicURI;
     private readonly string AddParticipantQueueName;
@@ -38,7 +39,7 @@ public class ProcessCaasFile : IProcessCaasFile
         IDataServiceClient<ParticipantDemographic> participantDemographic,
         IRecordsProcessedTracker recordsProcessedTracker,
         IValidateDates validateDates,
-        IHttpClientFunction httpClientFunction,
+        ICallFunction callFunction,
         ICallDurableDemographicFunc callDurableDemographicFunc,
         IOptions<ReceiveCaasFileConfig> receiveCaasFileConfig
     )
@@ -51,7 +52,7 @@ public class ProcessCaasFile : IProcessCaasFile
         _participantDemographic = participantDemographic;
         _recordsProcessTracker = recordsProcessedTracker;
         _validateDates = validateDates;
-        _httpClientFunction = httpClientFunction;
+        _callFunction = callFunction;
         _callDurableDemographicFunc = callDurableDemographicFunc;
         _config = receiveCaasFileConfig.Value;
 
@@ -227,7 +228,7 @@ public class ProcessCaasFile : IProcessCaasFile
             {
                 _logger.LogInformation("AllowDeleteRecords flag is true, delete record sent to RemoveParticipant function.");
                 var json = JsonSerializer.Serialize(basicParticipantCsvRecord);
-                await _httpClientFunction.SendPost(_config.PMSRemoveParticipant, json);
+                await _callFunction.SendPost(_config.PMSRemoveParticipant, json);
             }
             else
             {

--- a/application/CohortManager/src/Functions/CaasIntegration/receiveCaasFile/Program.cs
+++ b/application/CohortManager/src/Functions/CaasIntegration/receiveCaasFile/Program.cs
@@ -28,6 +28,7 @@ try
     {
         services.AddApplicationInsightsTelemetryWorkerService();
         services.ConfigureFunctionsApplicationInsights();
+        services.AddTransient<ICallFunction, CallFunction>();
         services.AddSingleton<IReceiveCaasFileHelper, ReceiveCaasFileHelper>();
         services.AddScoped<IProcessCaasFile, ProcessCaasFile>(); //Do not change the lifetime of this.
         services.AddSingleton<ICreateResponse, CreateResponse>();
@@ -39,6 +40,11 @@ try
         services.AddTransient<IExceptionHandler, ExceptionHandler>();
         services.AddTransient<IBlobStorageHelper, BlobStorageHelper>();
         services.AddTransient<ICopyFailedBatchToBlob, CopyFailedBatchToBlob>();
+
+        services.AddHttpClient<ICallDurableDemographicFunc, CallDurableDemographicFunc>(client =>
+        {
+            client.BaseAddress = new Uri(config.DemographicURI);
+        });
         services.AddScoped<IValidateDates, ValidateDates>();
         services.AddScoped<IQueueClientFactory, QueueClientFactory>();
         // Register health checks
@@ -47,7 +53,6 @@ try
     .AddAzureQueues()
     .AddExceptionHandler()
     .AddDatabaseConnection()
-    .AddHttpClient()
     .Build();
 
     await host.RunAsync();

--- a/tests/UnitTests/CaasIntegrationTests/processCaasFileTest/processCaasFileTests.cs
+++ b/tests/UnitTests/CaasIntegrationTests/processCaasFileTest/processCaasFileTests.cs
@@ -22,8 +22,10 @@ public class ProcessCaasFileTests
     private readonly Mock<RecordsProcessedTracker> _recordsProcessedTrackerMock = new();
     private readonly Mock<DataServices.Client.IDataServiceClient<ParticipantDemographic>> _databaseClientParticipantMock = new();
     private readonly Mock<IValidateDates> _validateDates = new();
-    private readonly Mock<IHttpClientFunction> _httpClientFunction = new();
+    private readonly Mock<ICallFunction> _callFunction = new();
+
     private readonly Mock<ICallDurableDemographicFunc> _callDurableFunc = new();
+    private readonly ProcessCaasFile _processCaasFile;
 
     private readonly Mock<IOptions<ReceiveCaasFileConfig>> _config = new();
 
@@ -40,7 +42,7 @@ public class ProcessCaasFileTests
             _databaseClientParticipantMock.Object,
             _recordsProcessedTrackerMock.Object,
             _validateDates.Object,
-            _httpClientFunction.Object,
+            _callFunction.Object,
             _callDurableFunc.Object,
             _config.Object
         );
@@ -310,7 +312,7 @@ public class ProcessCaasFileTests
         // Assert: expect CreateDeletedRecordException to be invoked
         _exceptionHandlerMock.Verify(m => m.CreateDeletedRecordException(
             It.IsAny<BasicParticipantCsvRecord>()), Times.Once);
-        _httpClientFunction.Verify(x => x.SendPost(
+        _callFunction.Verify(x => x.SendPost(
             It.Is<string>(s => s.Contains("PMSRemoveParticipant")), It.IsAny<string>()),
             Times.Never);
         _loggerMock.Verify(x => x.Log(
@@ -343,7 +345,7 @@ public class ProcessCaasFileTests
         await task;
 
         // Assert: expect call to SendPost to occur
-        _httpClientFunction.Verify(x => x.SendPost(
+        _callFunction.Verify(x => x.SendPost(
             It.Is<string>(s => s.Contains("PMSRemoveParticipant")), It.IsAny<string>()),
             Times.Once);
         _loggerMock.Verify(x => x.Log(

--- a/tests/UnitTests/CallDurableDemographicFuncTests/CallDurableDemograpghicFunc.cs
+++ b/tests/UnitTests/CallDurableDemographicFuncTests/CallDurableDemograpghicFunc.cs
@@ -1,12 +1,14 @@
 namespace NHS.CohortManager.Tests.UnitTests.CheckDemographicTests;
 
 using Common;
+using NHS.CohortManager.Tests.TestUtils;
 using System.Net;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Model;
 using System.Text.Json;
 using System.Threading.Tasks;
+using Moq.Protected;
 using NHS.Screening.ReceiveCaasFile;
 using Microsoft.Extensions.Options;
 
@@ -14,9 +16,11 @@ using Microsoft.Extensions.Options;
 public class CallDurableDemographicFuncTests
 {
     private readonly Mock<ILogger<CallDurableDemographicFunc>> _logger = new();
-    private readonly Mock<IHttpClientFunction> _httpClientFunction = new();
+    private readonly Mock<ICallFunction> _callFunction = new();
+    private readonly Mock<HttpClient> _httpClient = new();
     private readonly CallDurableDemographicFunc _callDurableDemographicFunc;
     private readonly Mock<ICopyFailedBatchToBlob> _copyFailedBatchToBlob = new();
+
     private readonly Mock<IOptions<ReceiveCaasFileConfig>> _config = new();
 
     public CallDurableDemographicFuncTests()
@@ -28,7 +32,7 @@ public class CallDurableDemographicFuncTests
         };
 
         _config.Setup(c => c.Value).Returns(testConfig);
-        _callDurableDemographicFunc = new CallDurableDemographicFunc(_httpClientFunction.Object, _logger.Object, _copyFailedBatchToBlob.Object, _config.Object);
+        _callDurableDemographicFunc = new CallDurableDemographicFunc(_callFunction.Object, _logger.Object, _httpClient.Object, _copyFailedBatchToBlob.Object, _config.Object);
     }
 
     [TestMethod]
@@ -44,7 +48,7 @@ public class CallDurableDemographicFuncTests
         // Assert
         Assert.IsTrue(result);
         _logger.Verify(x => x.Log(
-            It.Is<LogLevel>(l => l == LogLevel.Information),
+            It.Is<Microsoft.Extensions.Logging.LogLevel>(l => l == Microsoft.Extensions.Logging.LogLevel.Information),
             It.IsAny<EventId>(),
             It.Is<It.IsAnyType>((v, t) => v.ToString().Contains("There were no items to to send to the demographic durable function")),
             null,
@@ -56,10 +60,15 @@ public class CallDurableDemographicFuncTests
     public async Task PostDemographicDataAsync_ParticipantsExist_ReturnTrue()
     {
         // Arrange
-        var participants = new List<ParticipantDemographic> { new ParticipantDemographic() };
+        var participants = new List<ParticipantDemographic>
+        {
+            new ParticipantDemographic { /* populate properties */ }
+        };
         var uri = "test-uri.com/post";
 
-        _httpClientFunction.Setup(x => x.SendGet(It.IsAny<string>()))
+        var response = MockHelpers.CreateMockHttpResponseData(HttpStatusCode.OK, "[]");
+
+        _callFunction.Setup(x => x.SendGet(It.IsAny<string>()))
             .Returns(Task.FromResult("status"))
             .Verifiable();
 
@@ -75,21 +84,22 @@ public class CallDurableDemographicFuncTests
     {
         // Arrange
         var uri = "http://test-uri.com/get-status";
-        var participants = new List<ParticipantDemographic> { new ParticipantDemographic() };
+        var participants = new List<ParticipantDemographic>
+        {
+            new ParticipantDemographic { /* populate properties if needed */ }
+        };
 
-        _httpClientFunction.Setup(x => x.SendPost(It.IsAny<string>(), It.IsAny<string>()))
-            .ReturnsAsync(new HttpResponseMessage { StatusCode = HttpStatusCode.OK });
-
-        _httpClientFunction.Setup(x => x.SendGet(It.IsAny<string>()))
-            .ReturnsAsync(JsonSerializer.Serialize(new WebhookResponse { RuntimeStatus = "Completed" }));
+        // Create the HttpClient with the common helper
+        var httpClient = CreateMockHttpClient(HttpStatusCode.OK);
+        var checkDemographic = new CallDurableDemographicFunc(_callFunction.Object, _logger.Object, httpClient, _copyFailedBatchToBlob.Object, _config.Object);
 
         // Act
-        var result = await _callDurableDemographicFunc.PostDemographicDataAsync(participants, uri);
+        var result = await checkDemographic.PostDemographicDataAsync(participants, uri);
 
         // Assert
         Assert.IsTrue(result);
         _logger.Verify(x => x.Log(
-                It.Is<LogLevel>(l => l == LogLevel.Warning),
+                It.Is<Microsoft.Extensions.Logging.LogLevel>(l => l == Microsoft.Extensions.Logging.LogLevel.Warning),
                 It.IsAny<EventId>(),
                 It.Is<It.IsAnyType>((v, t) => v.ToString().Contains("Durable function completed")),
                 null,
@@ -102,21 +112,22 @@ public class CallDurableDemographicFuncTests
     {
         // Arrange
         var uri = "http://test-uri.com/get-status";
-        var participants = new List<ParticipantDemographic> { new ParticipantDemographic() };
+        var participants = new List<ParticipantDemographic>
+        {
+            new ParticipantDemographic { /* populate properties if needed */ }
+        };
 
-        _httpClientFunction.Setup(x => x.SendPost(It.IsAny<string>(), It.IsAny<string>()))
-            .ThrowsAsync(new Exception("Simulated exception"));
-
-        _httpClientFunction.Setup(x => x.SendGet(It.IsAny<string>()))
-            .ReturnsAsync(JsonSerializer.Serialize(new WebhookResponse { RuntimeStatus = "Completed" }));
+        // Create the HttpClient with the common helper
+        var httpClient = CreateMockHttpClient(HttpStatusCode.BadRequest);
+        var checkDemographic = new CallDurableDemographicFunc(_callFunction.Object, _logger.Object, httpClient, _copyFailedBatchToBlob.Object, _config.Object);
 
         // Act
-        var result = await _callDurableDemographicFunc.PostDemographicDataAsync(participants, uri);
+        var result = await checkDemographic.PostDemographicDataAsync(participants, uri);
 
         // Assert
         Assert.IsTrue(result);
         _logger.Verify(x => x.Log(
-            It.Is<LogLevel>(l => l == LogLevel.Error),
+            It.Is<Microsoft.Extensions.Logging.LogLevel>(l => l == Microsoft.Extensions.Logging.LogLevel.Error),
             It.IsAny<EventId>(),
             It.Is<It.IsAnyType>((v, t) => v.ToString().Contains("still sending records to queue")
                 && v.ToString().Contains("Simulated exception")),
@@ -127,6 +138,67 @@ public class CallDurableDemographicFuncTests
     }
 
     // Missing test coverage for exception state - due to the retry logic and private const _maxNumberOfChecks it would add 150 seconds to test run
-    // Tried to use reflection to manually change value but can't as it's const.
-    // Recommend to refactor CheckDemographic.cs to make it more testable.
+    // Tried to use reflection to manually change value but can't as it's const. 
+    // Reccomend to refactor CheckDemographic.cs to make it more testable.
+
+    private HttpClient CreateMockHttpClient(HttpStatusCode responseStatusCode)
+    {
+        var mockHttpMessageHandler = new Mock<HttpMessageHandler>();
+
+        // Setup for the POST request
+        mockHttpMessageHandler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(req => req.Method == HttpMethod.Post),
+                ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>((request, cancellationToken) =>
+            {
+                Console.WriteLine($"POST Request URL: {request.RequestUri}");
+            })
+            .Returns<HttpRequestMessage, CancellationToken>((request, cancellationToken) =>
+            {
+                // For error simulation, throw an exception if the responseStatusCode is BadRequest.
+                if (responseStatusCode == HttpStatusCode.BadRequest)
+                {
+                    throw new Exception("Simulated exception");
+                }
+                var response = new HttpResponseMessage(responseStatusCode)
+                {
+                    Content = new StringContent("ignored")
+                };
+                // Set a valid Location header for the GET call in GetStatus
+                response.Headers.Location = new Uri("http://test-uri.com/status");
+                return Task.FromResult(response);
+            });
+
+        // Setup for the GET request
+        mockHttpMessageHandler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(req => req.Method == HttpMethod.Get),
+                ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>((request, cancellationToken) =>
+            {
+                Console.WriteLine($"GET Request URL: {request.RequestUri}");
+            })
+            .ReturnsAsync(() =>
+            {
+                var webhookResponse = new WebhookResponse { RuntimeStatus = "Completed" };
+                var content = JsonSerializer.Serialize(webhookResponse);
+                return new HttpResponseMessage(responseStatusCode)
+                {
+                    Content = new StringContent(content)
+                };
+            });
+
+        // Create and return an HttpClient configured with the mocked handler.
+        var httpClient = new HttpClient(mockHttpMessageHandler.Object)
+        {
+            BaseAddress = new Uri("http://test-uri.com")
+        };
+        return httpClient;
+    }
+
 }


### PR DESCRIPTION
…#953)"

This reverts commit b89931736411bfaa4d0bcb388b900a99d22e29c6.

we need to revert this change as when this function is using the new http factory it fails on the call to the web hook of the durable demographic function. I am working on a way to convert this function over to the new http factory but for now I want to revert these changes.

<!-- Describe your changes in detail. -->

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
