### PR TITLE
fix: exception management date overflow

### DIFF
--- a/application/CohortManager/src/Functions/Shared/Model/EFModels/ExceptionManagement.cs
+++ b/application/CohortManager/src/Functions/Shared/Model/EFModels/ExceptionManagement.cs
@@ -91,7 +91,7 @@ public class ExceptionManagement
             ExceptionId = validationException.ExceptionId ?? 0,
             FileName = validationException.FileName,
             NhsNumber = validationException.NhsNumber,
-            DateCreated = validationException.DateCreated ?? DateTime.MinValue,
+            DateCreated = validationException.DateCreated ?? DateTime.MaxValue,
             DateResolved = validationException.DateResolved ?? DateTime.MaxValue,
             RuleId = validationException.RuleId,
             RuleDescription = validationException.RuleDescription,
@@ -102,7 +102,7 @@ public class ExceptionManagement
             CohortName = validationException.CohortName,
             IsFatal = short.TryParse(input, out short result) ? result : new short(),
             ServiceNowId = ServiceNowId,
-            ServiceNowCreatedDate = validationException.ServiceNowCreatedDate ?? DateTime.MinValue,
+            ServiceNowCreatedDate = validationException.ServiceNowCreatedDate ?? DateTime.MaxValue,
             RecordUpdatedDate = validationException.RecordUpdatedDate ?? DateTime.MaxValue
         };
     }


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description
datetime.minvalue was being used which is out of range for the mssql datetime type, but datetime.maxvalue is not

<!-- Describe your changes in detail. -->

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
