### PR TITLE
fix: add null check

### DIFF
--- a/application/CohortManager/src/Functions/ScreeningValidationService/LookupValidation/Breast_Screening_cohortRules.json
+++ b/application/CohortManager/src/Functions/ScreeningValidationService/LookupValidation/Breast_Screening_cohortRules.json
@@ -34,7 +34,7 @@
           },
           {
             "Name": "primaryCareProvider",
-            "Expression": "(string.IsNullOrEmpty(existingParticipant.PrimaryCareProvider) || !dbLookup.CheckIfPrimaryCareProviderExists(existingParticipant.PrimaryCareProvider)) && !existingParticipant.PrimaryCareProvider.StartsWith(\"ZZZ\")"
+            "Expression": "(string.IsNullOrEmpty(existingParticipant.PrimaryCareProvider) || !dbLookup.CheckIfPrimaryCareProviderExists(existingParticipant.PrimaryCareProvider)) && (string.IsNullOrEmpty(existingParticipant.PrimaryCareProvider) && !existingParticipant.PrimaryCareProvider.StartsWith(\"ZZZ\"))"
           }
         ],
         "Expression": "!(reasonForRemoval AND postcode AND primaryCareProvider)"


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description
adds an extra null check for rule 54 before checking if the primary care provider is null

<!-- Describe your changes in detail. -->

## Context
Rule was previously erroring if there were two amends send in a row with a null PCP

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
