### PR TITLE
feat: Add a new endpoint for DeleteParticipant that allows user to view participants in the Cohort Distribution table before deletion

### DIFF
--- a/application/CohortManager/src/Functions/CohortDistributionServices/DeleteParticipant/DeleteParticipant.cs
+++ b/application/CohortManager/src/Functions/CohortDistributionServices/DeleteParticipant/DeleteParticipant.cs
@@ -30,6 +30,8 @@ public class DeleteParticipant
     [Function("DeleteParticipant")]
     public async Task<HttpResponseData> RunAsync([HttpTrigger(AuthorizationLevel.Anonymous, "get", "post")] HttpRequestData req)
     {
+        _logger.LogInformation("DeleteParticipant function called");
+
         long NhsNumber;
         string? FamilyName;
         DateTime? DateOfBirth;
@@ -92,6 +94,66 @@ public class DeleteParticipant
             _logger.LogError(ex, "Delete participant function failed.\nMessage: {Message}\nStack Trace: {StackTrace}", ex.Message, ex.StackTrace);
             await _exceptionHandler.CreateSystemExceptionLogFromNhsNumber(ex, requestBody.NhsNumber?.ToString() ?? "N/A", "", "", JsonSerializer.Serialize(requestBody) ?? "N/A");
             return _createResponse.CreateHttpResponse(HttpStatusCode.InternalServerError, req);
+        }
+    }
+
+    [Function("PreviewParticipant")]
+    public async Task<HttpResponseData> PreviewAsync([HttpTrigger(AuthorizationLevel.Anonymous, "get", "post")] HttpRequestData req)
+    {
+        _logger.LogInformation("Preview Participant Called");
+
+        string requestBodyJson;
+        DeleteParticipantRequestBody? requestBody;
+
+        try
+        {
+            using (var reader = new StreamReader(req.Body, Encoding.UTF8))
+            {
+                requestBodyJson = await reader.ReadToEndAsync();
+            }
+
+            requestBody = JsonSerializer.Deserialize<DeleteParticipantRequestBody>(requestBodyJson);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to deserialize request body.");
+            return _createResponse.CreateHttpResponse(HttpStatusCode.BadRequest, req, "Invalid request format.");
+        }
+
+        if (requestBody == null ||
+            string.IsNullOrWhiteSpace(requestBody.NhsNumber) ||
+            string.IsNullOrWhiteSpace(requestBody.FamilyName) ||
+            !requestBody.DateOfBirth.HasValue)
+        {
+            _logger.LogError("Missing one or more required parameters.");
+            return _createResponse.CreateHttpResponse(HttpStatusCode.BadRequest, req, "Invalid or missing parameters.");
+        }
+
+        try
+        {
+            var nhsNumber = long.Parse(requestBody.NhsNumber);
+            var familyName = requestBody.FamilyName;
+            var dateOfBirth = requestBody.DateOfBirth;
+
+            var participantData = await _cohortDistributionClient.GetByFilter(p =>
+                p.NHSNumber == nhsNumber &&
+                p.FamilyName == familyName
+            );
+
+            var matchingParticipants = participantData.Where(p => p.DateOfBirth == dateOfBirth);
+
+            if (!matchingParticipants.Any())
+            {
+                _logger.LogInformation("No matching participants found");
+                return _createResponse.CreateHttpResponse(HttpStatusCode.NotFound, req, "No matching records found.");
+            }
+
+            return _createResponse.CreateHttpResponse(HttpStatusCode.OK, req, JsonSerializer.Serialize(matchingParticipants));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Preview failed: {Message}", ex.Message);
+            return _createResponse.CreateHttpResponse(HttpStatusCode.InternalServerError, req, "An error occurred while retrieving preview data.");
         }
     }
 }


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Created a new function within DeleteParticipant that allows the user to preview participants before deletion. The new function uses the DataServices client method GetByFilter to fetch participant data. The parameters for getting said data are DOB, Family Name and NHS Number. I'm unable to use the DoB directly within GetByFilter as the the method doesn't support the data type associated with DoB in the Cohort Distribution Table. This is a similar issue I encountered with Delete Participant. 
After getting the data, the function displays an array to to the user

Created unit tests to support this change

## Context

This ensures the user can preview participants before deletion.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [x] I have added tests to cover my changes
- [x] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
