### PR TITLE
fix: Adding proper row count logic to retrieve cohort distribution

### DIFF
--- a/application/CohortManager/src/Functions/CohortDistributionServices/RetrieveCohortDistribution/RetrieveCohortDistributionConfig.cs
+++ b/application/CohortManager/src/Functions/CohortDistributionServices/RetrieveCohortDistribution/RetrieveCohortDistributionConfig.cs
@@ -11,5 +11,6 @@ public class RetrieveCohortDistributionConfig
     public string CohortDistributionDataServiceURL { get; set; }
     [Required]
     public string BsSelectRequestAuditDataService { get; set; }
+    public int MaxRowCount { get; set; } = 1_000;
 
 }

--- a/tests/UnitTests/CohortDistributionTests/RetrieveCohortDistributionTests/RetrieveCohortDistributionTests.cs
+++ b/tests/UnitTests/CohortDistributionTests/RetrieveCohortDistributionTests/RetrieveCohortDistributionTests.cs
@@ -9,6 +9,7 @@ using Data.Database;
 using DataServices.Client;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Model;
 using Moq;
 using NHS.CohortManager.CohortDistributionDataServices;
@@ -27,11 +28,14 @@ public class RetrieveCohortDistributionTests
     private readonly Mock<IDataServiceClient<BsSelectRequestAudit>> _requestAuditDistributionDataClient = new();
     private readonly Mock<ICreateResponse> _createResponse = new();
     private readonly Mock<IExceptionHandler> _exceptionHandler = new();
+    private readonly Mock<IOptions<RetrieveCohortDistributionConfig>> _config = new();
 
     public RetrieveCohortDistributionTests()
     {
+
+        _config.Setup(i => i.Value).Returns(new RetrieveCohortDistributionConfig());
         _createCohortDistribution = new CreateCohortDistributionData(_createCohortLogger.Object, _cohortDistributionDataClient.Object, _requestAuditDistributionDataClient.Object);
-        _sut = new RetrieveCohortDistributionData(_retrieveCohortLogger.Object, _createCohortDistribution, _createResponse.Object, _exceptionHandler.Object);
+        _sut = new RetrieveCohortDistributionData(_retrieveCohortLogger.Object, _createCohortDistribution, _createResponse.Object, _exceptionHandler.Object, _config.Object);
 
         _createResponse.Setup(x => x.CreateHttpResponse(It.IsAny<HttpStatusCode>(), It.IsAny<HttpRequestData>(), It.IsAny<string?>()))
             .Returns((HttpStatusCode statusCode, HttpRequestData req, string? ResponseBody) =>
@@ -118,17 +122,36 @@ public class RetrieveCohortDistributionTests
 
     }
     [TestMethod]
-    public async Task Run_GetBatchNoRowCountOrRequestId_ReturnsBadRequest()
+    public async Task Run_GetBatchNoRowCountOrRequestId_ReturnsOkData()
     {
         // arrange
         NameValueCollection urlQueryItems = new NameValueCollection();
         var req = _setupRequest.Setup(null, urlQueryItems);
 
+        var cohortDistributionParticipant = new CohortDistribution { NHSNumber = 123456789 };
+        var participantsList = new List<CohortDistribution>
+        {
+            cohortDistributionParticipant
+        };
+
+        _cohortDistributionDataClient
+            .Setup(x => x.GetByFilter(It.IsAny<Expression<Func<CohortDistribution, bool>>>()))
+            .ReturnsAsync(participantsList);
+
+        _cohortDistributionDataClient
+            .Setup(x => x.GetSingle(It.IsAny<string>()))
+            .ReturnsAsync(cohortDistributionParticipant);
+
+        _cohortDistributionDataClient
+            .Setup(x => x.Update(It.IsAny<CohortDistribution>()))
+            .ReturnsAsync(true);
+
+
         // act
         var result = await _sut.Run(req.Object);
 
         // assert
-        Assert.AreEqual(HttpStatusCode.BadRequest, result.StatusCode);
+        Assert.AreEqual(HttpStatusCode.OK, result.StatusCode);
 
     }
     [TestMethod]


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Row count logic had been removed in a previous PR this is re adding the logic 

## Context

Limits and sets a default of rows to be returned by the retrieve cohort Distribution API

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [x] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
