### PR TITLE
fix: Removed NHS Number from two log statements

### DIFF
--- a/application/CohortManager/src/Functions/ParticipantManagementServices/addParticipant/addParticipant.cs
+++ b/application/CohortManager/src/Functions/ParticipantManagementServices/addParticipant/addParticipant.cs
@@ -121,7 +121,7 @@ public class AddParticipantFunction
 
         if (string.IsNullOrWhiteSpace(participantCsvRecord.Participant.ScreeningName))
         {
-            var errorDescription = $"A record with Nhs Number: {participantCsvRecord.Participant.NhsNumber} has invalid screening name and therefore cannot be processed by the static validation function";
+            var errorDescription = "Record has an invalid screening name and therefore cannot be processed by the static validation function";
             await _handleException.CreateRecordValidationExceptionLog(participantCsvRecord.Participant.NhsNumber, participantCsvRecord.FileName, errorDescription, "", JsonSerializer.Serialize(participantCsvRecord.Participant));
 
             return new ValidationExceptionLog()
@@ -136,6 +136,5 @@ public class AddParticipantFunction
         var responseBody = JsonSerializer.Deserialize<ValidationExceptionLog>(responseBodyJson);
 
         return responseBody;
-
     }
 }

--- a/application/CohortManager/src/Functions/ParticipantManagementServices/updateParticipant/updateParticipant.cs
+++ b/application/CohortManager/src/Functions/ParticipantManagementServices/updateParticipant/updateParticipant.cs
@@ -125,7 +125,7 @@ public class UpdateParticipantFunction
         {
             if (string.IsNullOrWhiteSpace(participantCsvRecord.Participant.ScreeningName))
             {
-                var errorDescription = $"A record with Nhs Number: {participantCsvRecord.Participant.NhsNumber} has invalid screening name and therefore cannot be processed by the static validation function";
+                var errorDescription = "Record has an invalid screening name and therefore cannot be processed by the static validation function";
                 await _handleException.CreateRecordValidationExceptionLog(participantCsvRecord.Participant.NhsNumber, participantCsvRecord.FileName, errorDescription, "", JsonSerializer.Serialize(participantCsvRecord.Participant));
 
                 return new ValidationExceptionLog()
@@ -148,4 +148,3 @@ public class UpdateParticipantFunction
         }
     }
 }
-


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

- Removed NHS Number from two log statements

## Context

- Log statements should not include NHS Numbers

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
