### PR TITLE
feat: DTOS-9708 New ExceptionCategory for change rule 35

### DIFF
--- a/application/CohortManager/src/Functions/ScreeningValidationService/LookupValidation/Breast_Screening_cohortRules.json
+++ b/application/CohortManager/src/Functions/ScreeningValidationService/LookupValidation/Breast_Screening_cohortRules.json
@@ -3,7 +3,7 @@
     "WorkflowName": "Common",
     "Rules": [
       {
-        "RuleName": "35.TooManyDemographicsFieldsChanged.NBO.NonFatal",
+        "RuleName": "35.TooManyDemographicsFieldsChanged.Confusion.NonFatal",
         "LocalParams": [
           {
             "Name": "NewDateOfBirth",

--- a/application/CohortManager/src/Functions/Shared/Model/Enums/ExceptionCategory.cs
+++ b/application/CohortManager/src/Functions/Shared/Model/Enums/ExceptionCategory.cs
@@ -1,4 +1,5 @@
 namespace Model.Enums;
+
 public enum ExceptionCategory
 {
     Non = 0,
@@ -11,5 +12,5 @@ public enum ExceptionCategory
     ParticipantLocationRemainingOutsideOfCohort = 9,
     Schema = 10,
     TransformExecuted = 11,
-
+    Confusion = 12,
 }


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description
Given  a record meets the criteria for validation rule 35 when an exception is raised then  do not change the exception_flag in participant management to true and allow the record to be saved to cohort distribution table

## Context

[DTOSS-9708](https://nhsd-jira.digital.nhs.uk/browse/DTOSS-9708)

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
