### PR TITLE
chore: Replace datetime.now with datetime.utcnow

### DIFF
--- a/application/CohortManager/src/Functions/CaasIntegration/RetrieveMeshFile/RetrieveMeshFile.cs
+++ b/application/CohortManager/src/Functions/CaasIntegration/RetrieveMeshFile/RetrieveMeshFile.cs
@@ -42,7 +42,7 @@ public class RetrieveMeshFile
     [Function("RetrieveMeshFile")]
     public async Task RunAsync([TimerTrigger("0 */5 * * * *")] TimerInfo myTimer)
     {
-        _logger.LogInformation("C# Timer trigger function executed at: ,{datetime}", DateTime.Now);
+        _logger.LogInformation("C# Timer trigger function executed at: ,{datetime}", DateTime.UtcNow);
 
         static bool messageFilter(MessageMetaData i) => true; // No current filter defined there might be business rules here
 

--- a/application/CohortManager/src/Functions/CaasIntegration/receiveCaasFile/receiveCaasFile.cs
+++ b/application/CohortManager/src/Functions/CaasIntegration/receiveCaasFile/receiveCaasFile.cs
@@ -91,7 +91,7 @@ public class ReceiveCaasFile
                     values.ToList().Clear();
                 }
             }
-            _logger.LogInformation("All rows processed for file named {Name}. time {Time}", name, DateTime.Now);
+            _logger.LogInformation("All rows processed for file named {Name}. time {Time}", name, DateTime.UtcNow);
         }
         catch (Exception ex)
         {

--- a/application/CohortManager/src/Functions/ExceptionHandling/UpdateException/UpdateException.cs
+++ b/application/CohortManager/src/Functions/ExceptionHandling/UpdateException/UpdateException.cs
@@ -99,6 +99,6 @@ public class UpdateException
     private static void UpdateExceptionRecord(ExceptionManagement exceptionData, UpdateExceptionRequest updateRequest)
     {
         exceptionData.ServiceNowId = updateRequest.ServiceNowNumber; // can be null
-        exceptionData.RecordUpdatedDate = DateTime.Now;
+        exceptionData.RecordUpdatedDate = DateTime.UtcNow;
     }
 }

--- a/application/CohortManager/src/Functions/NemsSubscriptionService/NemsMeshRetrieval/NemsMeshRetrieval.cs
+++ b/application/CohortManager/src/Functions/NemsSubscriptionService/NemsMeshRetrieval/NemsMeshRetrieval.cs
@@ -42,7 +42,7 @@ public class NemsMeshRetrieval
     [Function("RetrieveMeshFile")]
     public async Task RunAsync([TimerTrigger("0 */5 * * * *")] TimerInfo myTimer)
     {
-        _logger.LogInformation("C# Timer trigger function executed at: ,{datetime}", DateTime.Now);
+        _logger.LogInformation("C# Timer trigger function executed at: ,{datetime}", DateTime.UtcNow);
 
         static bool messageFilter(MessageMetaData i) => true; // No current filter defined there might be business rules here
 

--- a/application/CohortManager/src/Functions/Shared/Common/ExceptionHandler.cs
+++ b/application/CohortManager/src/Functions/Shared/Common/ExceptionHandler.cs
@@ -72,9 +72,9 @@ public class ExceptionHandler : IExceptionHandler
             FileName = participantCsvRecord.FileName,
             NhsNumber = participantCsvRecord.BasicParticipantData.NhsNumber,
             ErrorRecord = JsonSerializer.Serialize(participantCsvRecord.BasicParticipantData),
-            DateCreated = DateTime.Now,
+            DateCreated = DateTime.UtcNow,
             DateResolved = DateTime.MaxValue,
-            ExceptionDate = DateTime.Now,
+            ExceptionDate = DateTime.UtcNow,
             Category = (int)ExceptionCategory.DeleteRecord,
             ScreeningName = participantCsvRecord.BasicParticipantData.ScreeningName,
             CohortName = DefaultCohortName,
@@ -98,9 +98,9 @@ public class ExceptionHandler : IExceptionHandler
             FileName = participantCsvRecord.FileName,
             NhsNumber = participantCsvRecord.BasicParticipantData.NhsNumber,
             ErrorRecord = JsonSerializer.Serialize(participantCsvRecord.BasicParticipantData),
-            DateCreated = DateTime.Now,
+            DateCreated = DateTime.UtcNow,
             DateResolved = DateTime.MaxValue,
-            ExceptionDate = DateTime.Now,
+            ExceptionDate = DateTime.UtcNow,
             Category = (int)ExceptionCategory.Schema,
             ScreeningName = participantCsvRecord.BasicParticipantData.ScreeningName,
             CohortName = DefaultCohortName,
@@ -130,9 +130,9 @@ public class ExceptionHandler : IExceptionHandler
                 FileName = DefaultFileName,
                 NhsNumber = participant.NhsNumber,
                 ErrorRecord = JsonSerializer.Serialize(participant),
-                DateCreated = DateTime.Now,
+                DateCreated = DateTime.UtcNow,
                 DateResolved = null,
-                ExceptionDate = DateTime.Now,
+                ExceptionDate = DateTime.UtcNow,
                 Category = (int)ExceptionCategory.File,
                 ScreeningName = participant.ScreeningName,
                 CohortName = DefaultCohortName,
@@ -179,9 +179,9 @@ public class ExceptionHandler : IExceptionHandler
                 FileName = participantCsvRecord.FileName,
                 NhsNumber = participantCsvRecord.Participant.NhsNumber,
                 ErrorRecord = JsonSerializer.Serialize(participantCsvRecord.Participant),
-                DateCreated = DateTime.Now,
+                DateCreated = DateTime.UtcNow,
                 DateResolved = DateTime.MaxValue,
-                ExceptionDate = DateTime.Now,
+                ExceptionDate = DateTime.UtcNow,
                 Category = GetCategory(Category),
                 ScreeningName = participantCsvRecord.Participant.ScreeningName,
                 CohortName = DefaultCohortName,
@@ -237,9 +237,9 @@ public class ExceptionHandler : IExceptionHandler
             FileName = DefaultFileName,
             NhsNumber = participant.NhsNumber,
             ErrorRecord = JsonSerializer.Serialize(participant),
-            DateCreated = DateTime.Now,
+            DateCreated = DateTime.UtcNow,
             DateResolved = DateTime.MaxValue,
-            ExceptionDate = DateTime.Now,
+            ExceptionDate = DateTime.UtcNow,
             Category = (int)ExceptionCategory.TransformExecuted,
             ScreeningName = participant.ScreeningName,
             CohortName = DefaultCohortName,
@@ -270,7 +270,7 @@ public class ExceptionHandler : IExceptionHandler
             RuleId = DefaultRuleId,
             CohortName = DefaultCohortName,
             NhsNumber = string.IsNullOrEmpty(nhsNumber) ? DefaultNhsNumber : nhsNumber,
-            DateCreated = DateTime.Now,
+            DateCreated = DateTime.UtcNow,
             FileName = string.IsNullOrEmpty(fileName) ? DefaultFileName : fileName,
             DateResolved = DateTime.MaxValue,
             RuleDescription = errorDescription,
@@ -278,7 +278,7 @@ public class ExceptionHandler : IExceptionHandler
             ScreeningName = string.IsNullOrEmpty(screeningName) ? DefaultScreeningName : screeningName,
             Fatal = 0,
             ErrorRecord = string.IsNullOrEmpty(errorRecord) ? DefaultErrorRecord : errorRecord,
-            ExceptionDate = DateTime.Now
+            ExceptionDate = DateTime.UtcNow
         };
     }
 
@@ -318,7 +318,7 @@ public class ExceptionHandler : IExceptionHandler
             RuleId = exception.HResult,
             CohortName = DefaultCohortName,
             NhsNumber = string.IsNullOrEmpty(nhsNumber) ? DefaultNhsNumber : nhsNumber,
-            DateCreated = DateTime.Now,
+            DateCreated = DateTime.UtcNow,
             FileName = string.IsNullOrEmpty(fileName) ? DefaultFileName : fileName,
             DateResolved = DateTime.MaxValue,
             RuleDescription = exception.Message,
@@ -326,7 +326,7 @@ public class ExceptionHandler : IExceptionHandler
             ScreeningName = string.IsNullOrEmpty(screeningName) ? DefaultScreeningName : screeningName,
             Fatal = 1,
             ErrorRecord = string.IsNullOrEmpty(errorRecord) ? DefaultErrorRecord : errorRecord,
-            ExceptionDate = DateTime.Now
+            ExceptionDate = DateTime.UtcNow
         };
     }
 

--- a/application/CohortManager/src/Functions/Shared/Data/Database/CreateCohortDistributionData.cs
+++ b/application/CohortManager/src/Functions/Shared/Data/Database/CreateCohortDistributionData.cs
@@ -127,7 +127,7 @@ public class CreateCohortDistributionData : ICreateCohortDistributionData
         {
             RequestId = requestId,
             StatusCode = statusCode.ToString(),
-            CreatedDateTime = DateTime.Now
+            CreatedDateTime = DateTime.UtcNow
         });
     }
 

--- a/application/CohortManager/src/Functions/Shared/Data/Database/ValidationExceptionData.cs
+++ b/application/CohortManager/src/Functions/Shared/Data/Database/ValidationExceptionData.cs
@@ -74,7 +74,7 @@ public class ValidationExceptionData : IValidationExceptionData
         if (validationExceptionToUpdate != null)
         {
             validationExceptionToUpdate.DateResolved = DateTime.Today;
-            validationExceptionToUpdate.RecordUpdatedDate = DateTime.Now;
+            validationExceptionToUpdate.RecordUpdatedDate = DateTime.UtcNow;
             return await _validationExceptionDataServiceClient.Update(validationExceptionToUpdate);
         }
         return false;

--- a/application/CohortManager/src/Functions/Shared/Model/EFModels/ExceptionManagement.cs
+++ b/application/CohortManager/src/Functions/Shared/Model/EFModels/ExceptionManagement.cs
@@ -98,7 +98,7 @@ public class ExceptionManagement
             ErrorRecord = validationException.ErrorRecord,
             Category = validationException.Category,
             ScreeningName = validationException.ScreeningName,
-            ExceptionDate = validationException.ExceptionDate ?? DateTime.Now,
+            ExceptionDate = validationException.ExceptionDate ?? DateTime.UtcNow,
             CohortName = validationException.CohortName,
             IsFatal = short.TryParse(input, out short result) ? result : new short(),
             ServiceNowId = ServiceNowId,

--- a/application/CohortManager/src/Functions/Shared/Model/Participant.cs
+++ b/application/CohortManager/src/Functions/Shared/Model/Participant.cs
@@ -152,7 +152,7 @@ public class Participant
             PreferredLanguage = PreferredLanguage,
             InterpreterRequired = !string.IsNullOrEmpty(IsInterpreterRequired) ? short.Parse(IsInterpreterRequired) : null,
             InvalidFlag = (short?)GetInvalidFlag(),
-            RecordInsertDateTime = DateTime.Now,
+            RecordInsertDateTime = DateTime.UtcNow,
             RecordUpdateDateTime = null,
         };
     }

--- a/application/CohortManager/src/Functions/screeningDataServices/updateParticipantDetails/updateParticipantDetails.cs
+++ b/application/CohortManager/src/Functions/screeningDataServices/updateParticipantDetails/updateParticipantDetails.cs
@@ -80,7 +80,7 @@ public class UpdateParticipantDetails
             }
 
             reqParticipant.ParticipantId = existingParticipantData.ParticipantId.ToString();
-            reqParticipant.RecordUpdateDateTime = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss");
+            reqParticipant.RecordUpdateDateTime = DateTime.UtcNow.ToString("yyyy-MM-dd HH:mm:ss");
             var ParticipantManagementRecord = reqParticipant.ToParticipantManagement();
 
             //Mark Participant as Eligible/Ineligible

--- a/tests/UnitTests/CohortDistributionTests/RetrieveCohortRequestAuditTests/RetrieveCohortRequestAuditTests.cs
+++ b/tests/UnitTests/CohortDistributionTests/RetrieveCohortRequestAuditTests/RetrieveCohortRequestAuditTests.cs
@@ -25,7 +25,7 @@ public class RetrieveCohortRequestAuditTests
         // Arrange
         Guid requestId = new Guid();
         string statusCode = "testStatusCode";
-        DateTime dateFrom = DateTime.Now.AddDays(-1);
+        DateTime dateFrom = DateTime.UtcNow.AddDays(-1);
 
         _bsSelectRequestAuditDataServiceClient.Setup(x => x.GetByFilter(It.IsAny<Expression<Func<BsSelectRequestAudit, bool>>>())).ReturnsAsync(new List<BsSelectRequestAudit>()
         {
@@ -83,7 +83,7 @@ public class RetrieveCohortRequestAuditTests
         // Arrange
         string requestId = "";
         string statusCode = "testStatusCode";
-        DateTime dateFrom = DateTime.Now.AddDays(-1);
+        DateTime dateFrom = DateTime.UtcNow.AddDays(-1);
 
         _bsSelectRequestAuditDataServiceClient.Setup(x => x.GetByFilter(It.IsAny<Expression<Func<BsSelectRequestAudit, bool>>>())).ReturnsAsync(new List<BsSelectRequestAudit>()
         {
@@ -113,7 +113,7 @@ public class RetrieveCohortRequestAuditTests
         // Arrange
         string requestId = new Guid().ToString();
         string statusCode = "";
-        DateTime dateFrom = DateTime.Now.AddDays(-1);
+        DateTime dateFrom = DateTime.UtcNow.AddDays(-1);
 
         _bsSelectRequestAuditDataServiceClient.Setup(x => x.GetByFilter(It.IsAny<Expression<Func<BsSelectRequestAudit, bool>>>())).ReturnsAsync(new List<BsSelectRequestAudit>()
         {
@@ -143,7 +143,7 @@ public class RetrieveCohortRequestAuditTests
         // Arrange
         string requestId = new Guid().ToString();
         string statusCode = "testStatusCode";
-        DateTime dateFrom = DateTime.Now.AddDays(1);
+        DateTime dateFrom = DateTime.UtcNow.AddDays(1);
 
         _bsSelectRequestAuditDataServiceClient.Setup(x => x.GetByFilter(It.IsAny<Expression<Func<BsSelectRequestAudit, bool>>>())).ReturnsAsync(new List<BsSelectRequestAudit>());
 
@@ -162,7 +162,7 @@ public class RetrieveCohortRequestAuditTests
         // Arrange
         string requestId = new Guid().ToString();
         string statusCode = "nonExistentStatusCode";
-        DateTime dateFrom = DateTime.Now.AddDays(-1);
+        DateTime dateFrom = DateTime.UtcNow.AddDays(-1);
 
         _bsSelectRequestAuditDataServiceClient.Setup(x => x.GetByFilter(It.IsAny<Expression<Func<BsSelectRequestAudit, bool>>>())).ReturnsAsync(new List<BsSelectRequestAudit>());
 

--- a/tests/UnitTests/ServiceNowCohortLookupTests/ServiceNowCohortLookupTests.cs
+++ b/tests/UnitTests/ServiceNowCohortLookupTests/ServiceNowCohortLookupTests.cs
@@ -36,9 +36,9 @@ namespace NHS.CohortManager.Tests.UnitTests.ServiceNowCohortLookupTests;
          {
              ScheduleStatus = new ScheduleStatus
              {
-                 Last = DateTime.Now.AddDays(-1),
-                 Next = DateTime.Now.AddDays(1),
-                 LastUpdated = DateTime.Now
+                 Last = DateTime.UtcNow.AddDays(-1),
+                 Next = DateTime.UtcNow.AddDays(1),
+                 LastUpdated = DateTime.UtcNow
              },
              IsPastDue = false
          };
@@ -53,7 +53,7 @@ namespace NHS.CohortManager.Tests.UnitTests.ServiceNowCohortLookupTests;
              ServicenowId = ServiceNowId,
              NhsNumber = 0, // Invalid NHS number
              Status = ServiceNowStatus.New,
-             RecordUpdateDatetime = DateTime.Now
+             RecordUpdateDatetime = DateTime.UtcNow
          };
 
          _serviceNowCasesClientMock.Setup(x =>
@@ -87,7 +87,7 @@ namespace NHS.CohortManager.Tests.UnitTests.ServiceNowCohortLookupTests;
              ServicenowId = ServiceNowId,
              NhsNumber = validNhsNumberLong,
              Status = ServiceNowStatus.New,
-             RecordUpdateDatetime = DateTime.Now
+             RecordUpdateDatetime = DateTime.UtcNow
          };
 
          _serviceNowCasesClientMock.Setup(x =>
@@ -121,7 +121,7 @@ namespace NHS.CohortManager.Tests.UnitTests.ServiceNowCohortLookupTests;
              ServicenowId = ServiceNowId,
              NhsNumber = validNhsNumberLong,
              Status = ServiceNowStatus.Complete, // Already processed
-             RecordUpdateDatetime = DateTime.Now
+             RecordUpdateDatetime = DateTime.UtcNow
          };
 
          _serviceNowCasesClientMock.Setup(x =>


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Mixture of datetime.now and datetime.utcnow was causing confusion on datetimes in the database and logs.

## Context

consistency within logs and auditing

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
