### PR TITLE
feat: DTOSS-9709 new exception category Superseded for superseded numbers transformations

### DIFF
--- a/application/CohortManager/src/Functions/Shared/Common/ExceptionHandler.cs
+++ b/application/CohortManager/src/Functions/Shared/Common/ExceptionHandler.cs
@@ -233,6 +233,7 @@ public class ExceptionHandler : IExceptionHandler
         var category = ruleId switch
         {
             35 => ExceptionCategory.Confusion,
+            60 => ExceptionCategory.Superseded,
             _ => ExceptionCategory.TransformExecuted
         };
 

--- a/application/CohortManager/src/Functions/Shared/Model/Enums/ExceptionCategory.cs
+++ b/application/CohortManager/src/Functions/Shared/Model/Enums/ExceptionCategory.cs
@@ -12,5 +12,6 @@ public enum ExceptionCategory
     ParticipantLocationRemainingOutsideOfCohort = 9,
     Schema = 10,
     TransformExecuted = 11,
-    Confusion = 12
+    Confusion = 12,
+    Superseded = 13
 }


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description
Continuing ticket: [DTOSS-9337](https://nhsd-jira.digital.nhs.uk/browse/DTOSS-9337) we need to create a new exception category named "Superseded" for superseded numbers transformations.
 
60.Other.SupersededNhsNumber
 
The category number will be used in the exception API to allow users to view superseded NHS numbers

## Context
[DTOSS-9709](https://nhsd-jira.digital.nhs.uk/browse/DTOSS-9709)

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
