### PR TITLE
fix: Remove Ceased Flag from Participant Management table

### DIFF
--- a/application/CohortManager/src/Functions/Shared/DataServices.Migrations/Migrations/20250707144132_remove-ceased-flag.Designer.cs
+++ b/application/CohortManager/src/Functions/Shared/DataServices.Migrations/Migrations/20250707144132_remove-ceased-flag.Designer.cs
@@ -4,6 +4,7 @@ using DataServices.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace DataServices.Migrations.Migrations
 {
     [DbContext(typeof(DataServicesContext))]
-    partial class DataServicesContextModelSnapshot : ModelSnapshot
+    [Migration("20250707144132_remove-ceased-flag")]
+    partial class removeceasedflag
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/application/CohortManager/src/Functions/Shared/DataServices.Migrations/Migrations/20250707144132_remove-ceased-flag.cs
+++ b/application/CohortManager/src/Functions/Shared/DataServices.Migrations/Migrations/20250707144132_remove-ceased-flag.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DataServices.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class removeceasedflag : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CEASED_FLAG",
+                schema: "dbo",
+                table: "PARTICIPANT_MANAGEMENT");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<short>(
+                name: "CEASED_FLAG",
+                schema: "dbo",
+                table: "PARTICIPANT_MANAGEMENT",
+                type: "smallint",
+                nullable: false,
+                defaultValue: (short)0);
+        }
+    }
+}

--- a/application/CohortManager/src/Functions/Shared/Model/EFModels/ParticipantManagement.cs
+++ b/application/CohortManager/src/Functions/Shared/Model/EFModels/ParticipantManagement.cs
@@ -35,8 +35,6 @@ public class ParticipantManagement
     public Int16 BlockedFlag { get; set; }
     [Column("REFERRAL_FLAG")]
     public Int16 ReferralFlag { get; set; }
-    [Column("CEASED_FLAG")]
-    public Int16 CeasedFlag { get; set; }
     [Column("RECORD_UPDATE_DATETIME", TypeName = "datetime")]
     public DateTime? RecordUpdateDateTime { get; set; }
     [Column("NEXT_TEST_DUE_DATE", TypeName = "datetime")]

--- a/application/CohortManager/src/Functions/Shared/Model/Participant.cs
+++ b/application/CohortManager/src/Functions/Shared/Model/Participant.cs
@@ -26,7 +26,6 @@ public class Participant
         ExceptionFlag = pm.ExceptionFlag.ToString();
         BlockedFlag = pm.BlockedFlag.ToString();
         ReferralFlag = pm.ReferralFlag.ToString();
-        CeasedFlag = pm.CeasedFlag.ToString();
         RecordInsertDateTime = pm.RecordInsertDateTime.ToString();
         RecordUpdateDateTime = pm.RecordUpdateDateTime.ToString();
 
@@ -172,7 +171,6 @@ public class Participant
             ExceptionFlag = MappingUtilities.ParseStringFlag(ExceptionFlag ?? "0"),
             BlockedFlag = MappingUtilities.ParseStringFlag(BlockedFlag ?? "0"),
             ReferralFlag = MappingUtilities.ParseStringFlag(ReferralFlag ?? "0"),
-            CeasedFlag = MappingUtilities.ParseStringFlag(CeasedFlag ?? "0"),
             RecordInsertDateTime = MappingUtilities.ParseDates(RecordInsertDateTime),
             RecordUpdateDateTime = MappingUtilities.ParseDates(RecordUpdateDateTime),
         };
@@ -236,7 +234,6 @@ public class Participant
     public string? ExceptionFlag { get; set; }
     public string? BlockedFlag { get; set; }
     public string? ReferralFlag { get; set; }
-    public string? CeasedFlag { get; set; }
     public string? RecordInsertDateTime { get; set; }
     public string? RecordUpdateDateTime { get; set; }
     public string? ScreeningAcronym { get; set; }


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

This PR removes the CEASED_FLAG column from the PARTICIPANT_MANAGEMENT table via a proper EF Core migration. The migration drops the column cleanly from the database schema.

I removed the column in the Participant model and the ParticipantManagement EF Model manually

After that, I ran the migration. 

## Context

The CEASED_FLAG column is no longer needed and should be removed from the table. Previously, this column was removed manually in a prior PR, but to maintain proper database version control and consistency, this PR implements the removal through a formal EF Core migration.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [x] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
