### PR TITLE
fix: create new service bus env var

### DIFF
--- a/application/CohortManager/compose.cohort-distribution.yaml
+++ b/application/CohortManager/compose.cohort-distribution.yaml
@@ -9,7 +9,7 @@ services:
       context: ./src/Functions/
       dockerfile: CohortDistributionServices/DistributeParticipant/Dockerfile
     environment:
-      - ServiceBusConnectionString=Endpoint=sb://service-bus;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;
+      - ServiceBusConnectionString_internal=Endpoint=sb://service-bus;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;
       - CohortDistributionTopic=cohort-distribution-topic
       - DistributeParticipantSubscription=distribute-participant-sub
       - AzureWebJobsStorage=${AZURITE_CONNECTION_STRING}

--- a/application/CohortManager/compose.core.yaml
+++ b/application/CohortManager/compose.core.yaml
@@ -101,6 +101,7 @@ services:
       dockerfile: ParticipantManagementServices/ManageParticipant/Dockerfile
     environment:
       - ServiceBusConnectionString_internal=Endpoint=sb://service-bus;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;
+      - ServiceBusConnectionString_client_internal=Endpoint=sb://service-bus;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;
       - CohortDistributionTopic=cohort-distribution-topic
       - ParticipantManagementTopic=participant-management-topic
       - ManageParticipantSubscription=manage-participant-sub

--- a/application/CohortManager/compose.core.yaml
+++ b/application/CohortManager/compose.core.yaml
@@ -86,7 +86,7 @@ services:
       - UpdateQueueName=update-participant-queue
       - ScreeningLkpDataServiceURL=http://screening-lkp-data-service:8996/api/ScreeningLkpDataService
       - inboundBlobName=inbound
-      - ServiceBusConnectionString=Endpoint=sb://service-bus;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;
+      - ServiceBusConnectionString_internal=Endpoint=sb://service-bus;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;
       - fileExceptions=file-exceptions
       - ParticipantManagementQueueName=participant-management-topic
       - UseNewFunctions=false
@@ -100,7 +100,7 @@ services:
       context: ./src/Functions/
       dockerfile: ParticipantManagementServices/ManageParticipant/Dockerfile
     environment:
-      - ServiceBusConnectionString=Endpoint=sb://service-bus;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;
+      - ServiceBusConnectionString_internal=Endpoint=sb://service-bus;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;
       - CohortDistributionTopic=cohort-distribution-topic
       - ParticipantManagementTopic=participant-management-topic
       - ManageParticipantSubscription=manage-participant-sub

--- a/application/CohortManager/src/Functions/CaasIntegration/receiveCaasFile/Program.cs
+++ b/application/CohortManager/src/Functions/CaasIntegration/receiveCaasFile/Program.cs
@@ -43,7 +43,7 @@ try
     })
     .AddTelemetry()
     .AddHttpClient()
-    .AddAzureQueues(config.UseNewFunctions, config.ServiceBusConnectionString)
+    .AddAzureQueues(config.UseNewFunctions, config.ServiceBusConnectionString_internal)
     .AddExceptionHandler()
     .AddDatabaseConnection()
     .Build();
@@ -52,5 +52,5 @@ try
 }
 catch (Exception ex)
 {
-    logger.LogCritical(ex, "failed to start up function receive caas file function function");
+    logger.LogCritical(ex, "failed to start up function receive caas file");
 }

--- a/application/CohortManager/src/Functions/CaasIntegration/receiveCaasFile/receiveCaasFileConfig.cs
+++ b/application/CohortManager/src/Functions/CaasIntegration/receiveCaasFile/receiveCaasFileConfig.cs
@@ -25,7 +25,7 @@ public class ReceiveCaasFileConfig
     public string caasfolder_STORAGE { get; set; }
     [Required]
     public string inboundBlobName { get; set; }
-    public string ServiceBusConnectionString { get; set; }
+    public string ServiceBusConnectionString_internal { get; set; }
     public string GetOrchestrationStatusURL { get; set; }
     public bool UseNewFunctions { get; set; } = false;
     public string ParticipantManagementQueueName { get; set; }

--- a/application/CohortManager/src/Functions/CohortDistributionServices/DistributeParticipant/DistributeParticipantConfig.cs
+++ b/application/CohortManager/src/Functions/CohortDistributionServices/DistributeParticipant/DistributeParticipantConfig.cs
@@ -5,8 +5,6 @@ using System.ComponentModel.DataAnnotations;
 public class DistributeParticipantConfig
 {
     [Required]
-    public string ServiceBusConnectionString_internal { get; set; }
-    [Required]
     public string CohortDistributionTopic { get; set; }
     [Required]
     public string DistributeParticipantSubscription { get; set; }

--- a/application/CohortManager/src/Functions/CohortDistributionServices/DistributeParticipant/Program.cs
+++ b/application/CohortManager/src/Functions/CohortDistributionServices/DistributeParticipant/Program.cs
@@ -19,7 +19,6 @@ var host = new HostBuilder()
         // Register health checks
         services.AddBasicHealthCheck("DistributeParticipant");
     })
-    .AddAzureQueues(true, config.ServiceBusConnectionString_internal)
     .AddExceptionHandler()
     .AddTelemetry()
     .Build();

--- a/application/CohortManager/src/Functions/ParticipantManagementServices/ManageParticipant/ManageParticipantConfig.cs
+++ b/application/CohortManager/src/Functions/ParticipantManagementServices/ManageParticipant/ManageParticipantConfig.cs
@@ -5,7 +5,7 @@ using System.ComponentModel.DataAnnotations;
 public class ManageParticipantConfig
 {
     [Required]
-    public string ServiceBusConnectionString_internal { get; set; }
+    public string ServiceBusConnectionString_client_internal { get; set; }
     [Required]
     public string CohortDistributionTopic { get; set; }
     [Required]

--- a/application/CohortManager/src/Functions/ParticipantManagementServices/ManageParticipant/Program.cs
+++ b/application/CohortManager/src/Functions/ParticipantManagementServices/ManageParticipant/Program.cs
@@ -17,7 +17,7 @@ var host = new HostBuilder()
         services.AddBasicHealthCheck("ManageParticipant");
     })
     .AddExceptionHandler()
-    .AddAzureQueues(true, config.ServiceBusConnectionString_internal)
+    .AddAzureQueues(true, config.ServiceBusConnectionString_client_internal)
     .AddTelemetry()
     .Build();
 

--- a/application/CohortManager/src/Functions/Shared/Common/Extensions/AzureQueueExtension.cs
+++ b/application/CohortManager/src/Functions/Shared/Common/Extensions/AzureQueueExtension.cs
@@ -22,8 +22,8 @@ public static class AzureQueueExtension
             {
                 _.AddAzureClients(builder =>
                 {
-                    builder.AddServiceBusClient(serviceBusConnectionString);
-                    builder.UseCredential(new DefaultAzureCredential());
+                    builder.AddServiceBusClient(serviceBusConnectionString)
+                        .WithCredential(new DefaultAzureCredential());
 
                 });
                 _.AddSingleton<IQueueClient, AzureServiceBusClient>();

--- a/application/CohortManager/src/Functions/Shared/Common/Extensions/AzureQueueExtension.cs
+++ b/application/CohortManager/src/Functions/Shared/Common/Extensions/AzureQueueExtension.cs
@@ -22,9 +22,15 @@ public static class AzureQueueExtension
             {
                 _.AddAzureClients(builder =>
                 {
-                    builder.AddServiceBusClient(serviceBusConnectionString)
-                        .WithCredential(new DefaultAzureCredential());
-
+                    if (serviceBusConnectionString.StartsWith("Endpoint="))
+                    {
+                        builder.AddServiceBusClient(serviceBusConnectionString);
+                    }
+                    else
+                    {
+                        builder.AddServiceBusClientWithNamespace(serviceBusConnectionString)
+                            .WithCredential(new DefaultAzureCredential());
+                    }
                 });
                 _.AddSingleton<IQueueClient, AzureServiceBusClient>();
             }
@@ -64,9 +70,15 @@ public static class AzureQueueExtension
                 {
                     _.AddAzureClients(builder =>
                     {
-                        builder.AddServiceBusClient(serviceBusConnectionString)
-                            .WithCredential(new DefaultAzureCredential());
-
+                        if (serviceBusConnectionString.StartsWith("Endpoint="))
+                        {
+                            builder.AddServiceBusClient(serviceBusConnectionString);
+                        }
+                        else
+                        {
+                            builder.AddServiceBusClientWithNamespace(serviceBusConnectionString)
+                                .WithCredential(new DefaultAzureCredential());
+                        }
                     });
                     _.AddKeyedSingleton<IQueueClient, AzureServiceBusClient>(keyName);
                 }


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description
Created a new environment variable for the service bus connection because in azure the env var name has to be suffixed with __fullyQualifiedNamespace for the trigger to work, but because the client needs the env var taken from the IOptions config, it fails because it cannot pick up the variable since it is not named what it is expecting, so two env vars are needed.

<!-- Describe your changes in detail. -->

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
