### PR TITLE
fix: SBS connection strings

### DIFF
--- a/infrastructure/tf-core/function_app.tf
+++ b/infrastructure/tf-core/function_app.tf
@@ -177,7 +177,7 @@ locals {
                 # Second for loop for ServiceBusConnectionString_
                 {
                   for connection in config.service_bus_connections :
-                  "ServiceBusConnectionString_${connection}__fullyQualfiedNamespace" => "${module.azure_service_bus["${connection}-${region}"].namespace_name}.servicebus.windows.net"
+                  "ServiceBusConnectionString_${connection}__fullyQualifiedNamespace" => "${module.azure_service_bus["${connection}-${region}"].namespace_name}.servicebus.windows.net"
                 }
               )
             ) : {}

--- a/infrastructure/tf-core/function_app.tf
+++ b/infrastructure/tf-core/function_app.tf
@@ -167,11 +167,20 @@ locals {
             } : {},
 
             # Service Bus connections are stored in the config as a list of strings, so we need to iterate over them
-            length(config.service_bus_connections) > 0 ? {
-              for connection in config.service_bus_connections :
-              "ServiceBusConnectionString_${connection}" => "${module.azure_service_bus["${connection}-${region}"].namespace_name}.servicebus.windows.net"
-            } : {}
-
+            length(config.service_bus_connections) > 0 ? (
+              merge(
+                # First for loop for ServiceBusConnectionString_client_
+                {
+                  for connection in config.service_bus_connections :
+                  "ServiceBusConnectionString_client_${connection}" => "${module.azure_service_bus["${connection}-${region}"].namespace_name}.servicebus.windows.net"
+                },
+                # Second for loop for ServiceBusConnectionString_
+                {
+                  for connection in config.service_bus_connections :
+                  "ServiceBusConnectionString_${connection}__fullyQualfiedNamespace" => "${module.azure_service_bus["${connection}-${region}"].namespace_name}.servicebus.windows.net"
+                }
+              )
+            ) : {}
           )
 
           # These RBAC assignments are for the Function Apps only


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Change the Service Bus connection string from:
ServiceBusConnectionString_internal

To:
ServiceBusConnectionString_internal__fullyQualfiedNamespace
and
ServiceBusConnectionString_client_internal

## Context

Required by dotnet code when using managed identities.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
