### PR TITLE
fix: flatten ManageNemsSubscription config and improve regex parsing

### DIFF
--- a/application/CohortManager/compose.core.yaml
+++ b/application/CohortManager/compose.core.yaml
@@ -335,17 +335,17 @@ services:
         - ExceptionFunctionURL=http://create-exception:7070/api/CreateException
         - ParticipantDemographicDataServiceURL=http://participant-demographic-data-service:7993/api/ParticipantDemographicDataService
         - RetrievePdsDemographicURL=http://retrieve-pds-demographic:8082/api/RetrievePDSDemographic
-        - ManageNemsSubscription__NemsFhirEndpoint=https://msg.intspineservices.nhs.uk/STU3
-        - ManageNemsSubscription__FromAsid=200000002527
-        - ManageNemsSubscription__ToAsid=200000002527
-        - ManageNemsSubscription__OdsCode=T8T9T
-        - ManageNemsSubscription__MeshMailboxId=${NEMS_MESH_MAILBOX_ID}
-        - ManageNemsSubscription__NemsLocalCertPath=./nhs_signed_client.pfx
-        - ManageNemsSubscription__NemsLocalCertPassword=${NEMS_CERT_PASSWORD}
-        - ManageNemsSubscription__SubscriptionProfile=https://fhir.nhs.uk/STU3/StructureDefinition/EMS-Subscription-1
-        - ManageNemsSubscription__SubscriptionCriteria=https://fhir.nhs.uk/Id/nhs-number
-        - ManageNemsSubscription__DefaultEventTypes__0=pds-record-change-1
-        - ManageNemsSubscription__BypassServerCertificateValidation=true
+        - NemsFhirEndpoint=https://msg.intspineservices.nhs.uk/STU3
+        - NemsFromAsid=200000002527
+        - NemsToAsid=200000002527
+        - NemsOdsCode=T8T9T
+        - NemsMeshMailboxId=${NEMS_MESH_MAILBOX_ID}
+        - NemsLocalCertPath=./nhs_signed_client.pfx
+        - NemsLocalCertPassword=${NEMS_CERT_PASSWORD}
+        - NemsSubscriptionProfile=https://fhir.nhs.uk/STU3/StructureDefinition/EMS-Subscription-1
+        - NemsSubscriptionCriteria=https://fhir.nhs.uk/Id/nhs-number
+        - NemsDefaultEventTypes0=pds-record-change-1
+        - NemsBypassServerCertificateValidation=true
         - DtOsDatabaseConnectionString=Server=db,1433;Database=${DB_NAME};User Id=SA;Password=${PASSWORD};TrustServerCertificate=True
       ports:
         - "9081:9081"

--- a/application/CohortManager/src/Functions/DemographicServices/ManageNemsSubscription/Extensions/CertificateExtensions.cs
+++ b/application/CohortManager/src/Functions/DemographicServices/ManageNemsSubscription/Extensions/CertificateExtensions.cs
@@ -14,7 +14,7 @@ public static class CertificateExtensions
     /// <param name="logger">Logger for diagnostic messages</param>
     /// <returns>The loaded X509Certificate2</returns>
     /// <exception cref="InvalidOperationException">Thrown when no certificate configuration is found</exception>
-    public static async Task<X509Certificate2> LoadNemsCertificateAsync(this ManageNemsSubscriptionSettings config, ILogger logger)
+    public static async Task<X509Certificate2> LoadNemsCertificateAsync(this ManageNemsSubscriptionConfig config, ILogger logger)
     {
         if (!string.IsNullOrEmpty(config.KeyVaultConnectionString))
         {

--- a/application/CohortManager/src/Functions/DemographicServices/ManageNemsSubscription/ManageNemsSubscriptionConfig.cs
+++ b/application/CohortManager/src/Functions/DemographicServices/ManageNemsSubscription/ManageNemsSubscriptionConfig.cs
@@ -8,23 +8,6 @@ using System.ComponentModel.DataAnnotations;
 public class ManageNemsSubscriptionConfig
 {
     /// <summary>
-    /// ManageNemsSubscription-specific configuration settings
-    /// These will be stored in Key Vault with the "ManageNemsSubscription--" prefix
-    /// </summary>
-    public ManageNemsSubscriptionSettings ManageNemsSubscription { get; set; } = new();
-
-    /// <summary>
-    /// Custom validation to ensure either KeyVault or local cert is configured
-    /// </summary>
-    public bool IsValid => !string.IsNullOrEmpty(ManageNemsSubscription.KeyVaultConnectionString) || !string.IsNullOrEmpty(ManageNemsSubscription.NemsLocalCertPath);
-}
-
-/// <summary>
-/// NEMS-specific configuration settings that will be grouped under ManageNemsSubscription-- in Key Vault
-/// </summary>
-public class ManageNemsSubscriptionSettings
-{
-    /// <summary>
     /// NEMS FHIR API base endpoint
     /// Integration: https://msg.intspineservices.nhs.uk/STU3
     /// Production: Contact NHS Digital for production URLs
@@ -36,29 +19,29 @@ public class ManageNemsSubscriptionSettings
     /// Your organization's ASID (Application Service Instance Identifier)
     /// Example: "200000002527"
     /// </summary>
-    [Required(ErrorMessage = "FromAsid is required")]
-    public string FromAsid { get; set; } = string.Empty;
+    [Required(ErrorMessage = "NemsFromAsid is required")]
+    public string NemsFromAsid { get; set; } = string.Empty;
 
     /// <summary>
     /// Target ASID (usually same as FromAsid for NEMS)
     /// Example: "200000002527"
     /// </summary>
-    [Required(ErrorMessage = "ToAsid is required")]
-    public string ToAsid { get; set; } = string.Empty;
+    [Required(ErrorMessage = "NemsToAsid is required")]
+    public string NemsToAsid { get; set; } = string.Empty;
 
     /// <summary>
     /// Your organization's ODS code
     /// Example: "T8T9T"
     /// </summary>
-    [Required(ErrorMessage = "OdsCode is required")]
-    public string OdsCode { get; set; } = string.Empty;
+    [Required(ErrorMessage = "NemsOdsCode is required")]
+    public string NemsOdsCode { get; set; } = string.Empty;
 
     /// <summary>
     /// Your MESH mailbox ID (CRITICAL: Use full mailbox ID, not just ODS code)
     /// Example: "T8T9TOT001" (NOT just "T8T9T")
     /// </summary>
-    [Required(ErrorMessage = "MeshMailboxId is required")]
-    public string MeshMailboxId { get; set; } = string.Empty;
+    [Required(ErrorMessage = "NemsMeshMailboxId is required")]
+    public string NemsMeshMailboxId { get; set; } = string.Empty;
 
     /// <summary>
     /// Azure Key Vault connection string for certificate storage
@@ -87,23 +70,23 @@ public class ManageNemsSubscriptionSettings
     /// <summary>
     /// FHIR profile for EMS subscriptions
     /// </summary>
-    public string SubscriptionProfile { get; set; } = "https://fhir.nhs.uk/STU3/StructureDefinition/EMS-Subscription-1";
+    public string NemsSubscriptionProfile { get; set; } = "https://fhir.nhs.uk/STU3/StructureDefinition/EMS-Subscription-1";
 
     /// <summary>
     /// Base criteria for NHS number identifier
     /// </summary>
-    public string SubscriptionCriteria { get; set; } = "https://fhir.nhs.uk/Id/nhs-number";
+    public string NemsSubscriptionCriteria { get; set; } = "https://fhir.nhs.uk/Id/nhs-number";
 
     /// <summary>
     /// Whether to bypass server certificate validation (for development only)
     /// Set to true only during local development
     /// </summary>
-    public bool BypassServerCertificateValidation { get; set; } = false;
+    public bool NemsBypassServerCertificateValidation { get; set; } = false;
 
     /// <summary>
     /// Default event types to subscribe to
     /// </summary>
-    public string[] DefaultEventTypes { get; set; } = new[]
+    public string[] NemsDefaultEventTypes { get; set; } = new[]
     {
         "pds-record-change-1"
     };
@@ -112,5 +95,11 @@ public class ManageNemsSubscriptionSettings
     /// HTTP client timeout in seconds for NEMS API requests
     /// Default: 300 seconds (5 minutes)
     /// </summary>
-    public int HttpClientTimeoutSeconds { get; set; } = 300;
+    public int NemsHttpClientTimeoutSeconds { get; set; } = 300;
+
+    /// <summary>
+    /// Custom validation to ensure either KeyVault or local cert is configured
+    /// </summary>
+    public bool IsValid => !string.IsNullOrEmpty(KeyVaultConnectionString) || !string.IsNullOrEmpty(NemsLocalCertPath);
 }
+

--- a/application/CohortManager/src/Functions/DemographicServices/ManageNemsSubscription/Program.cs
+++ b/application/CohortManager/src/Functions/DemographicServices/ManageNemsSubscription/Program.cs
@@ -15,7 +15,7 @@ var host = new HostBuilder();
 // Load configuration
 host.AddConfiguration<ManageNemsSubscriptionConfig>(out ManageNemsSubscriptionConfig config);
 
-var nemsConfig = config.ManageNemsSubscription;
+var nemsConfig = config;
 
 // Load NEMS certificate up-front and inject into DI
 var nemsCertificate = await nemsConfig.LoadNemsCertificateAsync(logger);
@@ -40,8 +40,8 @@ host.AddHttpClient()
         // Log configuration for debugging (without sensitive data)
         logger.LogInformation("NEMS Configuration loaded - Endpoint: {Endpoint}, ODS: {OdsCode}, MESH: {MeshId}",
             nemsConfig.NemsFhirEndpoint,
-            nemsConfig.OdsCode,
-            string.IsNullOrEmpty(nemsConfig.MeshMailboxId) ? "NOT_SET" : "SET");
+            nemsConfig.NemsOdsCode,
+            string.IsNullOrEmpty(nemsConfig.NemsMeshMailboxId) ? "NOT_SET" : "SET");
     })
     .AddDataServicesHandler<DataServicesContext>()
     .AddTelemetry()

--- a/application/CohortManager/src/Functions/DemographicServices/ManageNemsSubscription/README.md
+++ b/application/CohortManager/src/Functions/DemographicServices/ManageNemsSubscription/README.md
@@ -27,11 +27,3 @@ The function requires the certificate file to be included in the build output:
 </ItemGroup>
 ```
 
-### Environment Variable Format
-
-- **Local development**: Use double underscores (`__`) in `local.settings.json`
-- **Docker**: Use double underscores (`__`) in environment variables
-- **Azure Key Vault**: Use double dashes (`--`) for key names (e.g., `ManageNemsSubscription--NemsFhirEndpoint`)
-- **Arrays**: Use indexed syntax like `ManageNemsSubscription__DefaultEventTypes__0`
-
-> ⚠️ **Important**: The configuration system automatically maps between Key Vault's double dash (`--`) format and the application's double underscore (`__`) format. Don't mix these formats in the same environment.

--- a/infrastructure/tf-core/environments/development.tfvars
+++ b/infrastructure/tf-core/environments/development.tfvars
@@ -1244,13 +1244,13 @@ function_apps = {
       ]
       env_vars_static = {
         AcceptableLatencyThresholdMs = "500"
-        "ManageNemsSubscription--NemsFhirEndpoint" = "https://msg.intspineservices.nhs.uk/STU3"
-        "ManageNemsSubscription--FromAsid" = "200000002527"
-        "ManageNemsSubscription--ToAsid" = "200000002527"
-        "ManageNemsSubscription--NemsKeyName" = "nems-client-certificate"
-        "ManageNemsSubscription--SubscriptionProfile" = "https://fhir.nhs.uk/STU3/StructureDefinition/EMS-Subscription-1"
-        "ManageNemsSubscription--SubscriptionCriteria" = "https://fhir.nhs.uk/Id/nhs-number"
-        "ManageNemsSubscription--BypassServerCertificateValidation" = "false"
+        "NemsFhirEndpoint" = "https://msg.intspineservices.nhs.uk/STU3"
+        "NemsFromAsid" = "200000002527"
+        "NemsToAsid" = "200000002527"
+        "NemsKeyName" = "nems-client-certificate"
+        "NemsSubscriptionProfile" = "https://fhir.nhs.uk/STU3/StructureDefinition/EMS-Subscription-1"
+        "NemsSubscriptionCriteria" = "https://fhir.nhs.uk/Id/nhs-number"
+        "NemsBypassServerCertificateValidation" = "false"
       }
     }
 

--- a/infrastructure/tf-core/environments/integration.tfvars
+++ b/infrastructure/tf-core/environments/integration.tfvars
@@ -1244,13 +1244,13 @@ function_apps = {
       ]
       env_vars_static = {
         AcceptableLatencyThresholdMs = "500"
-        "ManageNemsSubscription--NemsFhirEndpoint" = "https://msg.intspineservices.nhs.uk/STU3"
-        "ManageNemsSubscription--FromAsid" = "200000002527"
-        "ManageNemsSubscription--ToAsid" = "200000002527"
-        "ManageNemsSubscription--NemsKeyName" = "nems-client-certificate"
-        "ManageNemsSubscription--SubscriptionProfile" = "https://fhir.nhs.uk/STU3/StructureDefinition/EMS-Subscription-1"
-        "ManageNemsSubscription--SubscriptionCriteria" = "https://fhir.nhs.uk/Id/nhs-number"
-        "ManageNemsSubscription--BypassServerCertificateValidation" = "false"
+        "NemsFhirEndpoint" = "https://msg.intspineservices.nhs.uk/STU3"
+        "NemsFromAsid" = "200000002527"
+        "NemsToAsid" = "200000002527"
+        "NemsKeyName" = "nems-client-certificate"
+        "NemsSubscriptionProfile" = "https://fhir.nhs.uk/STU3/StructureDefinition/EMS-Subscription-1"
+        "NemsSubscriptionCriteria" = "https://fhir.nhs.uk/Id/nhs-number"
+        "NemsBypassServerCertificateValidation" = "false"
       }
     }
 

--- a/infrastructure/tf-core/environments/nft.tfvars
+++ b/infrastructure/tf-core/environments/nft.tfvars
@@ -1243,13 +1243,13 @@ function_apps = {
       ]
       env_vars_static = {
         AcceptableLatencyThresholdMs = "500"
-        "ManageNemsSubscription--NemsFhirEndpoint" = "https://msg.intspineservices.nhs.uk/STU3"
-        "ManageNemsSubscription--FromAsid" = "200000002527"
-        "ManageNemsSubscription--ToAsid" = "200000002527"
-        "ManageNemsSubscription--NemsKeyName" = "nems-client-certificate"
-        "ManageNemsSubscription--SubscriptionProfile" = "https://fhir.nhs.uk/STU3/StructureDefinition/EMS-Subscription-1"
-        "ManageNemsSubscription--SubscriptionCriteria" = "https://fhir.nhs.uk/Id/nhs-number"
-        "ManageNemsSubscription--BypassServerCertificateValidation" = "false"
+        "NemsFhirEndpoint" = "https://msg.intspineservices.nhs.uk/STU3"
+        "NemsFromAsid" = "200000002527"
+        "NemsToAsid" = "200000002527"
+        "NemsKeyName" = "nems-client-certificate"
+        "NemsSubscriptionProfile" = "https://fhir.nhs.uk/STU3/StructureDefinition/EMS-Subscription-1"
+        "NemsSubscriptionCriteria" = "https://fhir.nhs.uk/Id/nhs-number"
+        "NemsBypassServerCertificateValidation" = "false"
       }
     }
 

--- a/infrastructure/tf-core/environments/sandbox.tfvars
+++ b/infrastructure/tf-core/environments/sandbox.tfvars
@@ -1243,13 +1243,13 @@ function_apps = {
       ]
       env_vars_static = {
         AcceptableLatencyThresholdMs = "500"
-        "ManageNemsSubscription--NemsFhirEndpoint" = "https://msg.intspineservices.nhs.uk/STU3"
-        "ManageNemsSubscription--FromAsid" = "200000002527"
-        "ManageNemsSubscription--ToAsid" = "200000002527"
-        "ManageNemsSubscription--NemsKeyName" = "nems-client-certificate"
-        "ManageNemsSubscription--SubscriptionProfile" = "https://fhir.nhs.uk/STU3/StructureDefinition/EMS-Subscription-1"
-        "ManageNemsSubscription--SubscriptionCriteria" = "https://fhir.nhs.uk/Id/nhs-number"
-        "ManageNemsSubscription--BypassServerCertificateValidation" = "false"
+        "NemsFhirEndpoint" = "https://msg.intspineservices.nhs.uk/STU3"
+        "NemsFromAsid" = "200000002527"
+        "NemsToAsid" = "200000002527"
+        "NemsKeyName" = "nems-client-certificate"
+        "NemsSubscriptionProfile" = "https://fhir.nhs.uk/STU3/StructureDefinition/EMS-Subscription-1"
+        "NemsSubscriptionCriteria" = "https://fhir.nhs.uk/Id/nhs-number"
+        "NemsBypassServerCertificateValidation" = "false"
       }
     }
 

--- a/tests/UnitTests/DemographicServicesTests/ManageNemsSubscriptionTests/ManageNemsSubscriptionTests.cs
+++ b/tests/UnitTests/DemographicServicesTests/ManageNemsSubscriptionTests/ManageNemsSubscriptionTests.cs
@@ -32,16 +32,13 @@ public class ManageNemsSubscriptionTests
     {
         var config = new ManageNemsSubscriptionConfig
         {
-            ManageNemsSubscription = new ManageNemsSubscriptionSettings
-            {
-                NemsFhirEndpoint = "https://nems.fhir.endpoint",
-                FromAsid = "FromAsid",
-                ToAsid = "ToAsid",
-                SubscriptionProfile = "SubscriptionProfile",
-                SubscriptionCriteria = "SubscriptionCriteria",
-                NemsLocalCertPath = null,
-                NemsLocalCertPassword = null
-            }
+            NemsFhirEndpoint = "https://nems.fhir.endpoint",
+            NemsFromAsid = "FromAsid",
+            NemsToAsid = "ToAsid",
+            NemsSubscriptionProfile = "SubscriptionProfile",
+            NemsSubscriptionCriteria = "SubscriptionCriteria",
+            NemsLocalCertPath = null,
+            NemsLocalCertPassword = null
         };
 
         _config.Setup(x => x.Value).Returns(config);

--- a/tests/UnitTests/DemographicServicesTests/ManageNemsSubscriptionTests/NemsSubscriptionManagerTests.cs
+++ b/tests/UnitTests/DemographicServicesTests/ManageNemsSubscriptionTests/NemsSubscriptionManagerTests.cs
@@ -27,15 +27,12 @@ public class NemsSubscriptionManagerTests
     {
         var config = new ManageNemsSubscriptionConfig
         {
-            ManageNemsSubscription = new ManageNemsSubscriptionSettings
-            {
-                NemsFhirEndpoint = "https://test.nems.endpoint/STU3",
-                FromAsid = "TestFromAsid",
-                ToAsid = "TestToAsid",
-                OdsCode = "TestOds",
-                MeshMailboxId = "TestMesh123",
-                BypassServerCertificateValidation = false
-            }
+            NemsFhirEndpoint = "https://test.nems.endpoint/STU3",
+            NemsFromAsid = "TestFromAsid",
+            NemsToAsid = "TestToAsid",
+            NemsOdsCode = "TestOds",
+            NemsMeshMailboxId = "TestMesh123",
+            NemsBypassServerCertificateValidation = false
         };
 
         _config.Setup(x => x.Value).Returns(config);
@@ -722,6 +719,11 @@ public class NemsSubscriptionManagerTests
     [DataRow("DUPLICATE_REJECTED subscription already exists : spaced-id-123", "spaced-id-123")]
     [DataRow("DUPLICATE_REJECTED subscription already exists:no-space-id", "no-space-id")]
     [DataRow("Error: DUPLICATE_REJECTED subscription already exists: prefix-test-456 with additional context", "prefix-test-456")]
+    [DataRow("DUPLICATE_REJECTED subscription already exists: \"8965851501ce40bdb85841f84b726d93\"", "8965851501ce40bdb85841f84b726d93")]
+    [DataRow("DUPLICATE_REJECTED subscription already exists: \"8965851501ce40bdb85841f84b726d93\"/>", "8965851501ce40bdb85841f84b726d93")]
+    [DataRow("DUPLICATE_REJECTED subscription already exists: 8965851501ce40bdb85841f84b726d93\"/>", "8965851501ce40bdb85841f84b726d93")]
+    [DataRow("DUPLICATE_REJECTED subscription already exists: \"abc123def456\"/> additional content", "abc123def456")]
+    [DataRow("DUPLICATE_REJECTED subscription already exists: test-id-123\"/> <other>xml</other>", "test-id-123")]
     public async Task CreateAndSendSubscriptionAsync_VariousDuplicateFormats_ExtractsCorrectId(string errorMessage, string expectedId)
     {
         // Arrange
@@ -761,6 +763,9 @@ public class NemsSubscriptionManagerTests
     [DataRow("DUPLICATE_REJECTED subscription already exists")] // No colon
     [DataRow("DUPLICATE_REJECTED something else happened")] // Different error format
     [DataRow("DUPLICATE_REJECTED subscription already exists: ")] // Empty after colon
+    [DataRow("DUPLICATE_REJECTED subscription already exists: <invalid>special@chars</invalid>")] // Invalid characters in ID
+    [DataRow("DUPLICATE_REJECTED subscription already exists: @invalid@id")] // Invalid characters in ID
+    [DataRow("DUPLICATE_REJECTED subscription already exists: \"\"/")] // Empty quoted ID with XML
     public async Task CreateAndSendSubscriptionAsync_MalformedDuplicateMessages_ReturnsFailure(string errorMessage)
     {
         // Arrange


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description
  - Removed nested configuration structure in favor of flat Nems* keys for ManageNemsSubscription
  - Fix regex to properly handle XML tags and quotes in subscription IDs
  - Update all environment files and documentation
  - Add comprehensive test coverage for edge cases

<!-- Describe your changes in detail. -->

## Context

After deploying the changes to production we seemed to hit errors around '--' notation in config for nested objects. This has now been removed and flat names prefixed with 'Nems' have been added instead.

This prefix is needed to differentiate config items in KV.

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [x] I have added tests to cover my changes
- [x] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
