### PR TITLE
fix: DTOSS-9694 corrected formatting of tfvars files for ManageNemsSubscription

### DIFF
--- a/infrastructure/tf-core/environments/development.tfvars
+++ b/infrastructure/tf-core/environments/development.tfvars
@@ -1269,14 +1269,14 @@ function_apps = {
         }
       ]
       env_vars_static = {
-        AcceptableLatencyThresholdMs = "500"
-        "NemsFhirEndpoint" = "https://msg.intspineservices.nhs.uk/STU3"
-        "NemsFromAsid" = "200000002527"
-        "NemsToAsid" = "200000002527"
-        "NemsKeyName" = "nems-client-certificate"
-        "NemsSubscriptionProfile" = "https://fhir.nhs.uk/STU3/StructureDefinition/EMS-Subscription-1"
-        "NemsSubscriptionCriteria" = "https://fhir.nhs.uk/Id/nhs-number"
-        "NemsBypassServerCertificateValidation" = "false"
+        AcceptableLatencyThresholdMs          = "500"
+        NemsFhirEndpoint                      = "https://msg.intspineservices.nhs.uk/STU3"
+        NemsFromAsid                          = "200000002527"
+        NemsToAsid                            = "200000002527"
+        NemsKeyName                           = "nems-client-certificate"
+        NemsSubscriptionProfile               = "https://fhir.nhs.uk/STU3/StructureDefinition/EMS-Subscription-1"
+        NemsSubscriptionCriteria              = "https://fhir.nhs.uk/Id/nhs-number"
+        NemsBypassServerCertificateValidation = "false"
       }
     }
 

--- a/infrastructure/tf-core/environments/integration.tfvars
+++ b/infrastructure/tf-core/environments/integration.tfvars
@@ -1269,14 +1269,14 @@ function_apps = {
         }
       ]
       env_vars_static = {
-        AcceptableLatencyThresholdMs = "500"
-        "NemsFhirEndpoint" = "https://msg.intspineservices.nhs.uk/STU3"
-        "NemsFromAsid" = "200000002527"
-        "NemsToAsid" = "200000002527"
-        "NemsKeyName" = "nems-client-certificate"
-        "NemsSubscriptionProfile" = "https://fhir.nhs.uk/STU3/StructureDefinition/EMS-Subscription-1"
-        "NemsSubscriptionCriteria" = "https://fhir.nhs.uk/Id/nhs-number"
-        "NemsBypassServerCertificateValidation" = "false"
+        AcceptableLatencyThresholdMs          = "500"
+        NemsFhirEndpoint                      = "https://msg.intspineservices.nhs.uk/STU3"
+        NemsFromAsid                          = "200000002527"
+        NemsToAsid                            = "200000002527"
+        NemsKeyName                           = "nems-client-certificate"
+        NemsSubscriptionProfile               = "https://fhir.nhs.uk/STU3/StructureDefinition/EMS-Subscription-1"
+        NemsSubscriptionCriteria              = "https://fhir.nhs.uk/Id/nhs-number"
+        NemsBypassServerCertificateValidation = "false"
       }
     }
 

--- a/infrastructure/tf-core/environments/nft.tfvars
+++ b/infrastructure/tf-core/environments/nft.tfvars
@@ -1268,14 +1268,14 @@ function_apps = {
         }
       ]
       env_vars_static = {
-        AcceptableLatencyThresholdMs = "500"
-        "NemsFhirEndpoint" = "https://msg.intspineservices.nhs.uk/STU3"
-        "NemsFromAsid" = "200000002527"
-        "NemsToAsid" = "200000002527"
-        "NemsKeyName" = "nems-client-certificate"
-        "NemsSubscriptionProfile" = "https://fhir.nhs.uk/STU3/StructureDefinition/EMS-Subscription-1"
-        "NemsSubscriptionCriteria" = "https://fhir.nhs.uk/Id/nhs-number"
-        "NemsBypassServerCertificateValidation" = "false"
+        AcceptableLatencyThresholdMs          = "500"
+        NemsFhirEndpoint                      = "https://msg.intspineservices.nhs.uk/STU3"
+        NemsFromAsid                          = "200000002527"
+        NemsToAsid                            = "200000002527"
+        NemsKeyName                           = "nems-client-certificate"
+        NemsSubscriptionProfile               = "https://fhir.nhs.uk/STU3/StructureDefinition/EMS-Subscription-1"
+        NemsSubscriptionCriteria              = "https://fhir.nhs.uk/Id/nhs-number"
+        NemsBypassServerCertificateValidation = "false"
       }
     }
 

--- a/infrastructure/tf-core/environments/sandbox.tfvars
+++ b/infrastructure/tf-core/environments/sandbox.tfvars
@@ -1268,14 +1268,14 @@ function_apps = {
         }
       ]
       env_vars_static = {
-        AcceptableLatencyThresholdMs = "500"
-        "NemsFhirEndpoint" = "https://msg.intspineservices.nhs.uk/STU3"
-        "NemsFromAsid" = "200000002527"
-        "NemsToAsid" = "200000002527"
-        "NemsKeyName" = "nems-client-certificate"
-        "NemsSubscriptionProfile" = "https://fhir.nhs.uk/STU3/StructureDefinition/EMS-Subscription-1"
-        "NemsSubscriptionCriteria" = "https://fhir.nhs.uk/Id/nhs-number"
-        "NemsBypassServerCertificateValidation" = "false"
+        AcceptableLatencyThresholdMs          = "500"
+        NemsFhirEndpoint                      = "https://msg.intspineservices.nhs.uk/STU3"
+        NemsFromAsid                          = "200000002527"
+        NemsToAsid                            = "200000002527"
+        NemsKeyName                           = "nems-client-certificate"
+        NemsSubscriptionProfile               = "https://fhir.nhs.uk/STU3/StructureDefinition/EMS-Subscription-1"
+        NemsSubscriptionCriteria              = "https://fhir.nhs.uk/Id/nhs-number"
+        NemsBypassServerCertificateValidation = "false"
       }
     }
 


### PR DESCRIPTION

<!-- markdownlint-disable-next-line first-line-heading -->
## Description

<!-- Describe your changes in detail. -->
fix: corrected formatting of tfvars files for ManageNemsSubscription static variables
- Removed extra quotes
- aligned values laterally 

[DTOSS-9694](https://nhsd-jira.digital.nhs.uk/browse/DTOSS-9694)

## Context

<!-- Why is this change required? What problem does it solve? -->
All other static variables lack double quotes, trying to rule out any differences with other applications

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
