### PR TITLE
fix: Incorrect Category for name prefix transform

### DIFF
--- a/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/TransformDataService.cs
+++ b/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/TransformDataService.cs
@@ -19,6 +19,7 @@ using System.Data;
 using RulesEngine.Actions;
 using System.Threading.Tasks;
 using Hl7.Fhir.Rest;
+using Model.Enums;
 
 public class TransformDataService
 {
@@ -168,7 +169,7 @@ public class TransformDataService
 
         if (namePrefixRule == null)
         {
-            _exceptionHandler.CreateTransformExecutedExceptions(participant, $"Name Prefix Invalid", 83);
+            await _exceptionHandler.CreateTransformExecutedExceptions(participant, $"Name Prefix Invalid", 83, ExceptionCategory.TransformExecuted);
             return null;
         }
         if (namePrefixRule.Rule.RuleName == "0.NamePrefix.NamePrefixValid")
@@ -182,7 +183,7 @@ public class TransformDataService
 
         if (prefixTransformed)
         {
-            _exceptionHandler.CreateTransformExecutedExceptions(participant, $"Name Prefix {ruleName}", ruleNumber);
+            await _exceptionHandler.CreateTransformExecutedExceptions(participant, $"Name Prefix {ruleName}", ruleNumber, ExceptionCategory.TransformExecuted);
             return namePrefix;
         }
 

--- a/application/CohortManager/src/Functions/Shared/Common/ExceptionHandler.cs
+++ b/application/CohortManager/src/Functions/Shared/Common/ExceptionHandler.cs
@@ -235,14 +235,23 @@ public class ExceptionHandler : IExceptionHandler
         return isSentSuccessfully;
     }
 
-    public async Task CreateTransformExecutedExceptions(CohortDistributionParticipant participant, string ruleName, int ruleId)
+    public async Task CreateTransformExecutedExceptions(CohortDistributionParticipant participant, string ruleName, int ruleId, ExceptionCategory? exceptionCategory = null)
     {
-        var category = ruleId switch
+
+        ExceptionCategory category;
+        if (exceptionCategory == null)
         {
-            35 => ExceptionCategory.Confusion,
-            60 => ExceptionCategory.Superseded,
-            _ => ExceptionCategory.TransformExecuted
-        };
+            category = ruleId switch
+            {
+                35 => ExceptionCategory.Confusion,
+                60 => ExceptionCategory.Superseded,
+                _ => ExceptionCategory.TransformExecuted
+            };
+        }
+        else
+        {
+            category = exceptionCategory.Value;
+        }
 
         var exception = new ValidationException
         {

--- a/application/CohortManager/src/Functions/Shared/Common/Interfaces/IExceptionHandler.cs
+++ b/application/CohortManager/src/Functions/Shared/Common/Interfaces/IExceptionHandler.cs
@@ -2,6 +2,7 @@ namespace Common;
 
 using System.Net;
 using Model;
+using Model.Enums;
 using RulesEngine.Models;
 
 /// <summary>
@@ -40,5 +41,5 @@ public interface IExceptionHandler
     /// <param name="participant">The participant that caused the exception.</param>
     Task CreateTransformationExceptionLog(IEnumerable<RuleResultTree> transformationErrors, CohortDistributionParticipant participant);
     Task CreateSchemaValidationException(BasicParticipantCsvRecord participantCsvRecord, string description);
-    Task CreateTransformExecutedExceptions(CohortDistributionParticipant participant, string ruleName, int ruleId);
+    Task CreateTransformExecutedExceptions(CohortDistributionParticipant participant, string ruleName, int ruleId, ExceptionCategory? exceptionCategory = null);
 }

--- a/tests/UnitTests/TransformDataServiceTests/TransformDataServiceTests/TransformDataServiceTests.cs
+++ b/tests/UnitTests/TransformDataServiceTests/TransformDataServiceTests/TransformDataServiceTests.cs
@@ -140,7 +140,7 @@ public class TransformDataServiceTests
         string responseBody = await AssertionHelper.ReadResponseBodyAsync(result);
         Assert.AreEqual(JsonSerializer.Serialize(expectedResponse), responseBody);
         Assert.AreEqual(HttpStatusCode.OK, result.StatusCode);
-        _handleException.Verify(i => i.CreateTransformExecutedExceptions(It.IsAny<CohortDistributionParticipant>(), It.IsAny<string>(), ruleId), times: Times.Once);
+        _handleException.Verify(i => i.CreateTransformExecutedExceptions(It.IsAny<CohortDistributionParticipant>(), It.IsAny<string>(), ruleId,ExceptionCategory.TransformExecuted), times: Times.Once);
     }
 
     [TestMethod]
@@ -171,7 +171,7 @@ public class TransformDataServiceTests
         // Assert
         string responseBody = await AssertionHelper.ReadResponseBodyAsync(result);
         Assert.AreEqual(HttpStatusCode.OK, result.StatusCode);
-        _handleException.Verify(i => i.CreateTransformExecutedExceptions(It.IsAny<CohortDistributionParticipant>(), ruleName, ruleId), times: Times.Once);
+        _handleException.Verify(i => i.CreateTransformExecutedExceptions(It.IsAny<CohortDistributionParticipant>(), ruleName, ruleId,null), times: Times.Once);
     }
 
     [TestMethod]
@@ -202,7 +202,7 @@ public class TransformDataServiceTests
         // Assert
         string responseBody = await AssertionHelper.ReadResponseBodyAsync(result);
         Assert.AreEqual(HttpStatusCode.OK, result.StatusCode);
-        _handleException.Verify(i => i.CreateTransformExecutedExceptions(It.IsAny<CohortDistributionParticipant>(), ruleName, ruleId), times: Times.Never);
+        _handleException.Verify(i => i.CreateTransformExecutedExceptions(It.IsAny<CohortDistributionParticipant>(), ruleName, ruleId,null), times: Times.Never);
     }
 
 
@@ -229,7 +229,7 @@ public class TransformDataServiceTests
         string responseBody = await AssertionHelper.ReadResponseBodyAsync(result);
         Assert.AreEqual(JsonSerializer.Serialize(expectedResponse), responseBody);
         Assert.AreEqual(HttpStatusCode.OK, result.StatusCode);
-        _handleException.Verify(i => i.CreateTransformExecutedExceptions(It.IsAny<CohortDistributionParticipant>(), It.IsAny<string>(), 83), times: Times.Once);
+        _handleException.Verify(i => i.CreateTransformExecutedExceptions(It.IsAny<CohortDistributionParticipant>(), It.IsAny<string>(), 83,ExceptionCategory.TransformExecuted), times: Times.Once);
     }
 
     [TestMethod]
@@ -255,7 +255,7 @@ public class TransformDataServiceTests
         var responseBody = await AssertionHelper.ReadResponseBodyAsync(result);
         Assert.AreEqual(JsonSerializer.Serialize(expectedResponse), responseBody);
         Assert.AreEqual(HttpStatusCode.OK, result.StatusCode);
-        _handleException.Verify(i => i.CreateTransformExecutedExceptions(It.IsAny<CohortDistributionParticipant>(), It.IsAny<string>(), 47), times: Times.Once);
+        _handleException.Verify(i => i.CreateTransformExecutedExceptions(It.IsAny<CohortDistributionParticipant>(), It.IsAny<string>(), 47, ExceptionCategory.TransformExecuted), times: Times.Once);
     }
 
 
@@ -306,7 +306,7 @@ public class TransformDataServiceTests
         // Assert
         string responseBody = await AssertionHelper.ReadResponseBodyAsync(result);
         Assert.AreEqual(JsonSerializer.Serialize(expectedResponse), responseBody);
-        _handleException.Verify(i => i.CreateTransformExecutedExceptions(It.IsAny<CohortDistributionParticipant>(), It.IsAny<string>(), It.IsAny<int>()), times: Times.Exactly(13));
+        _handleException.Verify(i => i.CreateTransformExecutedExceptions(It.IsAny<CohortDistributionParticipant>(), It.IsAny<string>(), It.IsAny<int>(),null), times: Times.Exactly(13));
     }
 
     //TODO: This test needs fixing as it doesnt test anything.
@@ -372,7 +372,7 @@ public class TransformDataServiceTests
         string responseBody = await AssertionHelper.ReadResponseBodyAsync(result);
         Assert.AreEqual(JsonSerializer.Serialize(expectedResponse), responseBody);
         Assert.AreEqual(HttpStatusCode.OK, result.StatusCode);
-        _handleException.Verify(i => i.CreateTransformExecutedExceptions(It.IsAny<CohortDistributionParticipant>(), "CharacterRules", 71), times: Times.Once);
+        _handleException.Verify(i => i.CreateTransformExecutedExceptions(It.IsAny<CohortDistributionParticipant>(), "CharacterRules", 71,null), times: Times.Once);
 
     }
 
@@ -405,7 +405,7 @@ public class TransformDataServiceTests
         string responseBody = await AssertionHelper.ReadResponseBodyAsync(result);
         Assert.AreEqual(JsonSerializer.Serialize(expectedResponse), responseBody);
         Assert.AreEqual(HttpStatusCode.OK, result.StatusCode);
-        _handleException.Verify(i => i.CreateTransformExecutedExceptions(It.IsAny<CohortDistributionParticipant>(), "OtherDateOfDeathDoesNotExist", 3), times: Times.Once);
+        _handleException.Verify(i => i.CreateTransformExecutedExceptions(It.IsAny<CohortDistributionParticipant>(), "OtherDateOfDeathDoesNotExist", 3, null), times: Times.Once);
 
     }
 
@@ -434,7 +434,7 @@ public class TransformDataServiceTests
         // Assert
         string responseBody = await AssertionHelper.ReadResponseBodyAsync(result);
         Assert.AreEqual(JsonSerializer.Serialize(expectedResponse), responseBody);
-        _handleException.Verify(i => i.CreateTransformExecutedExceptions(It.IsAny<CohortDistributionParticipant>(), "OtherFirstNameDoesNotExist", 14), times: Times.Once);
+        _handleException.Verify(i => i.CreateTransformExecutedExceptions(It.IsAny<CohortDistributionParticipant>(), "OtherFirstNameDoesNotExist", 14,null), times: Times.Once);
     }
 
     [TestMethod]
@@ -471,7 +471,7 @@ public class TransformDataServiceTests
         // Assert
         string responseBody = await AssertionHelper.ReadResponseBodyAsync(result);
         Assert.AreEqual(JsonSerializer.Serialize(expectedResponse), responseBody);
-        _handleException.Verify(i => i.CreateTransformExecutedExceptions(It.IsAny<CohortDistributionParticipant>(), "OtherInvalidFlagTrueAndNoPrimaryCareProvider", 0), times: Times.Once);
+        _handleException.Verify(i => i.CreateTransformExecutedExceptions(It.IsAny<CohortDistributionParticipant>(), "OtherInvalidFlagTrueAndNoPrimaryCareProvider", 0,null), times: Times.Once);
 
     }
 
@@ -563,7 +563,7 @@ public class TransformDataServiceTests
         string responseBody = await AssertionHelper.ReadResponseBodyAsync(result);
         Assert.AreEqual(JsonSerializer.Serialize(expectedResponse), responseBody);
         _handleException
-            .Verify(i => i.CreateTransformExecutedExceptions(It.IsAny<CohortDistributionParticipant>(), "OtherSupersededNhsNumber", 60),
+            .Verify(i => i.CreateTransformExecutedExceptions(It.IsAny<CohortDistributionParticipant>(), "OtherSupersededNhsNumber", 60,null),
             times: Times.Once);
     }
 


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Fixes a bug where a Name prefix transform (LIEUTENANT COLONEL) was logging with an incorrect category (13)
This now logs correctly to category (11)


## Context

Bug Fix
[DTOSS-10192](https://nhsd-jira.digital.nhs.uk/browse/DTOSS-10192)

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [x] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
