### PR TITLE
fix: DTOSS-9694 fix docker image build + storage account for NEMS

### DIFF
--- a/application/CohortManager/src/Functions/NemsSubscriptionService/NemsMeshRetrieval/Dockerfile
+++ b/application/CohortManager/src/Functions/NemsSubscriptionService/NemsMeshRetrieval/Dockerfile
@@ -14,7 +14,7 @@ RUN mkdir -p /home/site/wwwroot && \
 
 FROM base AS function
 
-COPY ./CaasIntegration/RetrieveMeshFile /src/dotnet-function-app
+COPY ./NemsSubscriptionService/NemsMeshRetrieval /src/dotnet-function-app
 WORKDIR /src/dotnet-function-app
 
 RUN --mount=type=cache,target=/root/.nuget/packages \

--- a/application/CohortManager/src/Functions/NemsSubscriptionService/ProcessNemsUpdate/ProcessNemsUpdate.cs
+++ b/application/CohortManager/src/Functions/NemsSubscriptionService/ProcessNemsUpdate/ProcessNemsUpdate.cs
@@ -49,7 +49,7 @@ public class ProcessNemsUpdate
     /// This function returns nothing, only logs information/errors for successful or failing tasks.
     /// </returns>
     [Function(nameof(ProcessNemsUpdate))]
-    public async Task Run([BlobTrigger("nems-messages/{name}", Connection = "caasfolder_STORAGE")] Stream blobStream, string name)
+    public async Task Run([BlobTrigger("nems-messages/{name}", Connection = "nemsmeshfolder_STORAGE")] Stream blobStream, string name)
     {
         try
         {


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Fix critical Docker image build issue for NemsMeshRetrieval function and correct storage connection for ProcessNemsUpdate to ensure the NEMS workflow functions properly end-to-end.

**Changes made:**
1. **Dockerfile fix:** Corrected NemsMeshRetrieval Dockerfile to copy the correct source code (`./NemsSubscriptionService/NemsMeshRetrieval`) instead of RetrieveMeshFile code (`./CaasIntegration/RetrieveMeshFile`)
2. **Storage connection fix:** Updated ProcessNemsUpdate BlobTrigger to use `nemsmeshfolder_STORAGE` instead of `caasfolder_STORAGE` to match NemsMeshRetrieval's storage configuration

## Context

**Root Cause:** The NemsMeshRetrieval function was failing in Azure with configuration validation errors because the deployed Docker image contained RetrieveMeshFile code instead of NemsMeshRetrieval code.

**Investigation revealed:**
- NemsMeshRetrieval Dockerfile was copying `./CaasIntegration/RetrieveMeshFile` source code
- Azure deployments were running RetrieveMeshFile application code in the NemsMeshRetrieval function app container  
- RetrieveMeshFile code expects `RetrieveMeshFileConfig` and `caasfolder_STORAGE` environment variables
- Azure environment provides `NemsMeshRetrievalConfig` binding and `nemsmeshfolder_STORAGE` 
- Configuration validation failed with: `"DataAnnotation validation failed for 'RetrieveMeshFileConfig' members: 'caasfolder_STORAGE' with the error: 'The caasfolder_STORAGE field is required.'"`

**Additional Issue:** ProcessNemsUpdate was listening for blobs on `caasfolder_STORAGE` while NemsMeshRetrieval writes to `nemsmeshfolder_STORAGE`, breaking the NEMS workflow chain.

This fix ensures:
- NemsMeshRetrieval Azure deployments run the correct application code
- Both NEMS functions use the same storage connection for seamless file processing
- Configuration validation succeeds with matching config classes and environment variables

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.