### PR TITLE
fix: insert datetime being set to null for amends

### DIFF
--- a/application/CohortManager/src/Functions/ParticipantManagementServices/ManageParticipant/ManageParticipant.cs
+++ b/application/CohortManager/src/Functions/ParticipantManagementServices/ManageParticipant/ManageParticipant.cs
@@ -76,6 +76,7 @@ public class ManageParticipant
                 var participantManagement = participant.ToParticipantManagement();
                 participantManagement.ParticipantId = databaseParticipant.ParticipantId;
                 participantManagement.RecordUpdateDateTime = DateTime.UtcNow;
+                participantManagement.RecordInsertDateTime = databaseParticipant.RecordInsertDateTime;
 
                 dataServiceResponse = await _participantManagementClient.Update(participantManagement);
             }


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description
insert datetimes were being set to null in PM for amend records

<!-- Describe your changes in detail. -->

## Context
[DTOSS-10275](https://nhsd-jira.digital.nhs.uk/browse/DTOSS-10275)

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
