### PR TITLE
fix: DTOSS-10352 WAF policy collisions

### DIFF
--- a/infrastructure/tf-core/environments/development.tfvars
+++ b/infrastructure/tf-core/environments/development.tfvars
@@ -1112,7 +1112,7 @@ frontdoor_endpoint = {
     }
     security_policies = {
       AllowedIPs = {
-        cdn_frontdoor_firewall_policy_name    = "wafhubnonliveinternalwhitelist"
+        cdn_frontdoor_firewall_policy_name    = "wafhubnonlivecohmandev"
         cdn_frontdoor_firewall_policy_rg_name = "rg-hub-dev-uks-hub-networking"
         associated_domain_keys                = ["cohort-dev"] # From custom_domains above. Use "endpoint" for the default domain (if linked in Front Door route).
       }

--- a/infrastructure/tf-core/environments/integration.tfvars
+++ b/infrastructure/tf-core/environments/integration.tfvars
@@ -1113,7 +1113,7 @@ frontdoor_endpoint = {
     }
     security_policies = {
       AllowedIPs = {
-        cdn_frontdoor_firewall_policy_name    = "wafhubnonliveinternalwhitelist"
+        cdn_frontdoor_firewall_policy_name    = "wafhubnonlivecohmanint"
         cdn_frontdoor_firewall_policy_rg_name = "rg-hub-dev-uks-hub-networking"
         associated_domain_keys                = ["cohort-int"] # From custom_domains above. Use "endpoint" for the default domain (if linked in Front Door route).
       }

--- a/infrastructure/tf-core/environments/nft.tfvars
+++ b/infrastructure/tf-core/environments/nft.tfvars
@@ -1112,7 +1112,7 @@ frontdoor_endpoint = {
     }
     security_policies = {
       AllowedIPs = {
-        cdn_frontdoor_firewall_policy_name    = "wafhubnonliveinternalwhitelist"
+        cdn_frontdoor_firewall_policy_name    = "wafhubnonlivecohmannft"
         cdn_frontdoor_firewall_policy_rg_name = "rg-hub-dev-uks-hub-networking"
         associated_domain_keys                = ["cohort-nft"] # From custom_domains above. Use "endpoint" for the default domain (if linked in Front Door route).
       }

--- a/infrastructure/tf-core/environments/preprod.tfvars
+++ b/infrastructure/tf-core/environments/preprod.tfvars
@@ -1137,7 +1137,7 @@ frontdoor_endpoint = {
     }
     security_policies = {
       AllowedIPs = {
-        cdn_frontdoor_firewall_policy_name    = "wafhubliveinternalwhitelist"
+        cdn_frontdoor_firewall_policy_name    = "wafhubnonlivecohmanpre"
         cdn_frontdoor_firewall_policy_rg_name = "rg-hub-prod-uks-hub-networking"
         associated_domain_keys                = ["cohort-pre"] # From custom_domains above. Use "endpoint" for the default domain (if linked in Front Door route).
       }

--- a/infrastructure/tf-core/environments/production.tfvars
+++ b/infrastructure/tf-core/environments/production.tfvars
@@ -1372,7 +1372,7 @@ linux_web_app = {
           AUTH_CIS2_ISSUER_URL = ""
           AUTH_CIS2_CLIENT_ID  = ""
           AUTH_TRUST_HOST      = "true"
-          NEXTAUTH_URL         = "https://cohort-prod.screening.nhs.uk/api/auth"
+          NEXTAUTH_URL         = "https://cohort.screening.nhs.uk/api/auth"
           SERVICE_NAME         = "Cohort Manager"
         }
         from_key_vault = {
@@ -1403,14 +1403,14 @@ frontdoor_endpoint = {
     }
     custom_domains = {
       cohort-prod = {
-        host_name        = "cohort-prod.screening.nhs.uk"
+        host_name        = "cohort.screening.nhs.uk"
         dns_zone_name    = "screening.nhs.uk"
         dns_zone_rg_name = "rg-hub-prod-uks-public-dns-zones"
       }
     }
     security_policies = {
       AllowedIPs = {
-        cdn_frontdoor_firewall_policy_name    = "wafhubliveinternalwhitelist"
+        cdn_frontdoor_firewall_policy_name    = "wafhubnonlivecohmanprd"
         cdn_frontdoor_firewall_policy_rg_name = "rg-hub-prod-uks-hub-networking"
         associated_domain_keys                = ["cohort-prod"] # From custom_domains above. Use "endpoint" for the default domain (if linked in Front Door route).
       }


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Each environment now has its own WAFv2 Policy for Azure Front Door.

## Context

It transpires that a single WAF policy cannot be associated with multiple AFD Security Policies within one Front Door Profile.
Since the associations cannot be managed in a granular manner, other than at the creation of the Front Door Security Profile, this requires unnecessary proliferation of WAF policies to avoid entangling separate SDLC environments. There is no cost impact, but their ongoing management will unfortunately be multiplied (for rule exemptions, IP whitelisting etc.). This does appear to be a significant design oversight by Microsoft.
## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
