### PR TITLE
fix: changed name of mailbox config item for nems mesh retrieval func…

### DIFF
--- a/application/CohortManager/src/Functions/NemsSubscriptionService/NemsMeshRetrieval/NemsMeshRetrieval.cs
+++ b/application/CohortManager/src/Functions/NemsSubscriptionService/NemsMeshRetrieval/NemsMeshRetrieval.cs
@@ -31,7 +31,7 @@ public class NemsMeshRetrieval
         _logger = logger;
         _meshToBlobTransferHandler = meshToBlobTransferHandler;
         _blobStorageHelper = blobStorageHelper;
-        _mailboxId = options.Value.BSSMailBox;
+        _mailboxId = options.Value.NEMSMailBox;
         _config = options.Value;
         _blobConnectionString = _config.nemsmeshfolder_STORAGE;
     }

--- a/application/CohortManager/src/Functions/NemsSubscriptionService/NemsMeshRetrieval/NemsMeshRetrievalConfig.cs
+++ b/application/CohortManager/src/Functions/NemsSubscriptionService/NemsMeshRetrieval/NemsMeshRetrievalConfig.cs
@@ -6,7 +6,7 @@ public class NemsMeshRetrievalConfig
 {
     public string MeshApiBaseUrl { get; set; }
     [Required]
-    public string BSSMailBox { get; set; }
+    public string NEMSMailBox { get; set; }
     [Required]
     public string MeshPassword { get; set; }
     [Required]

--- a/tests/UnitTests/NemsSubscriptionServiceTests/NemsMeshRetrievalTests/NemsMeshRetrievalTests.cs
+++ b/tests/UnitTests/NemsSubscriptionServiceTests/NemsMeshRetrievalTests/NemsMeshRetrievalTests.cs
@@ -33,7 +33,7 @@ public class NemsMeshRetrievalTests
     {
         var testConfig = new NemsMeshRetrievalConfig
         {
-            BSSMailBox = mailboxId,
+            NEMSMailBox = mailboxId,
             nemsmeshfolder_STORAGE = "BlobStorage_ConnectionString",
             MeshPassword = "MeshPassword",
             MeshSharedKey = "MeshSharedKey",
@@ -388,7 +388,7 @@ public class NemsMeshRetrievalTests
         
         var customConfig = new NemsMeshRetrievalConfig
         {
-            BSSMailBox = mailboxId,
+            NEMSMailBox = mailboxId,
             nemsmeshfolder_STORAGE = "BlobStorage_ConnectionString",
             MeshPassword = "MeshPassword",
             MeshSharedKey = "MeshSharedKey",
@@ -446,7 +446,7 @@ public class NemsMeshRetrievalTests
         
         var customConfig = new NemsMeshRetrievalConfig
         {
-            BSSMailBox = mailboxId,
+            NEMSMailBox = mailboxId,
             nemsmeshfolder_STORAGE = "BlobStorage_ConnectionString",
             MeshPassword = "MeshPassword",
             MeshSharedKey = "MeshSharedKey",


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Renamed the mailbox configuration property from `BSSMailBox` to `NEMSMailBox` in the NEMS Mesh Retrieval service to correctly reflect its purpose and avoid naming conflicts with existing BSS (Breast Screening Service) mesh functions.

Changes include:
- Updated `NemsMeshRetrievalConfig.cs` to use `NEMSMailBox` property
- Updated `NemsMeshRetrieval.cs` to reference the renamed property
- Updated unit tests to use the correct property name

## Context

The NEMS (National Event Management Service) Mesh Retrieval function was incorrectly using a `BSSMailBox` configuration property, which could cause confusion and potential conflicts with the existing Breast Screening Service mesh functions that legitimately use BSS-related configuration. This change clarifies the purpose of each mailbox configuration and prevents naming collisions.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [x] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.