### PR TITLE
fix: added NemsMesh prefix to all config values in NemsMeshRetrieval function - separating from RetrieveMeshFile

### DIFF
--- a/application/CohortManager/src/Functions/NemsSubscriptionService/NemsMeshRetrieval/NemsMeshRetrieval.cs
+++ b/application/CohortManager/src/Functions/NemsSubscriptionService/NemsMeshRetrieval/NemsMeshRetrieval.cs
@@ -31,7 +31,7 @@ public class NemsMeshRetrieval
         _logger = logger;
         _meshToBlobTransferHandler = meshToBlobTransferHandler;
         _blobStorageHelper = blobStorageHelper;
-        _mailboxId = options.Value.NEMSMailBox;
+        _mailboxId = options.Value.NemsMeshMailBox;
         _config = options.Value;
         _blobConnectionString = _config.nemsmeshfolder_STORAGE;
     }
@@ -51,7 +51,7 @@ public class NemsMeshRetrieval
         try
         {
             var shouldExecuteHandShake = await ShouldExecuteHandShake();
-            var result = await _meshToBlobTransferHandler.MoveFilesFromMeshToBlob(messageFilter, fileNameFunction, _mailboxId, _blobConnectionString, _config.InboundContainer, shouldExecuteHandShake);
+            var result = await _meshToBlobTransferHandler.MoveFilesFromMeshToBlob(messageFilter, fileNameFunction, _mailboxId, _blobConnectionString, _config.NemsMeshInboundContainer, shouldExecuteHandShake);
 
             if (!result)
             {
@@ -74,7 +74,7 @@ public class NemsMeshRetrieval
 
         Dictionary<string, string> configValues;
         TimeSpan handShakeInterval = new TimeSpan(0, 23, 54, 0);
-        var meshState = await _blobStorageHelper.GetFileFromBlobStorage(_blobConnectionString, _config.ConfigContainer, ConfigFileName);
+        var meshState = await _blobStorageHelper.GetFileFromBlobStorage(_blobConnectionString, _config.NemsMeshConfigContainer, ConfigFileName);
         if (meshState == null)
         {
 
@@ -140,7 +140,7 @@ public class NemsMeshRetrieval
             using (var stream = GenerateStreamFromString(jsonString))
             {
                 var blobFile = new BlobFile(stream, ConfigFileName);
-                var result = await _blobStorageHelper.UploadFileToBlobStorage(_blobConnectionString, _config.ConfigContainer, blobFile, true);
+                var result = await _blobStorageHelper.UploadFileToBlobStorage(_blobConnectionString, _config.NemsMeshConfigContainer, blobFile, true);
                 return result;
             }
         }

--- a/application/CohortManager/src/Functions/NemsSubscriptionService/NemsMeshRetrieval/NemsMeshRetrievalConfig.cs
+++ b/application/CohortManager/src/Functions/NemsSubscriptionService/NemsMeshRetrieval/NemsMeshRetrievalConfig.cs
@@ -4,21 +4,21 @@ using System.ComponentModel.DataAnnotations;
 
 public class NemsMeshRetrievalConfig
 {
-    public string MeshApiBaseUrl { get; set; }
+    public string NemsMeshApiBaseUrl { get; set; }
     [Required]
-    public string NEMSMailBox { get; set; }
+    public string NemsMeshMailBox { get; set; }
     [Required]
-    public string MeshPassword { get; set; }
+    public string NemsMeshPassword { get; set; }
     [Required]
-    public string MeshSharedKey {get; set;}
-    public string MeshKeyPassphrase {get; set;}
-    public string MeshKeyName {get; set;}
+    public string NemsMeshSharedKey {get; set;}
+    public string NemsMeshKeyPassphrase {get; set;}
+    public string NemsMeshKeyName {get; set;}
     public string KeyVaultConnectionString {get; set;}
     [Required]
     public string nemsmeshfolder_STORAGE {get; set;}
-    public string InboundContainer { get; set; } = "nems-updates";
-    public string ConfigContainer { get; set; } = "nems-config";
-    public string ServerSideCerts { get; set; }
-    public string MeshCertName { get; set; }
-    public bool? BypassServerCertificateValidation {get;set;}
+    public string NemsMeshInboundContainer { get; set; } = "nems-updates";
+    public string NemsMeshConfigContainer { get; set; } = "nems-config";
+    public string NemsMeshServerSideCerts { get; set; }
+    public string NemsMeshCertName { get; set; }
+    public bool? NemsMeshBypassServerCertificateValidation {get;set;}
 }

--- a/application/CohortManager/src/Functions/NemsSubscriptionService/NemsMeshRetrieval/Program.cs
+++ b/application/CohortManager/src/Functions/NemsSubscriptionService/NemsMeshRetrieval/Program.cs
@@ -31,21 +31,21 @@ try
         // Get CohortManager private key
         logger.LogInformation("Pulling Mesh Certificate from KeyVault");
         var certClient = new CertificateClient(vaultUri: new Uri(config.KeyVaultConnectionString), credential: new DefaultAzureCredential());
-        var certificate = await certClient.DownloadCertificateAsync(config.MeshKeyName);
+        var certificate = await certClient.DownloadCertificateAsync(config.NemsMeshKeyName);
         cohortManagerPrivateKey = certificate.Value;
 
         // Get MESH public certificates (CA chain)
         var secretClient = new SecretClient(vaultUri: new Uri(config.KeyVaultConnectionString), credential: new DefaultAzureCredential());
-        string base64Cert = secretClient.GetSecret(config.MeshCertName).Value.Value;
+        string base64Cert = secretClient.GetSecret(config.NemsMeshCertName).Value.Value;
         meshCerts = CertificateHelper.GetCertificatesFromString(base64Cert);
     }
     // Local
     else
     {
         logger.LogInformation("Pulling Mesh Certificate from local File");
-        cohortManagerPrivateKey = new X509Certificate2(config.MeshKeyName, config.MeshKeyPassphrase);
+        cohortManagerPrivateKey = new X509Certificate2(config.NemsMeshKeyName, config.NemsMeshKeyPassphrase);
 
-        string certsString = await File.ReadAllTextAsync(config.ServerSideCerts);
+        string certsString = await File.ReadAllTextAsync(config.NemsMeshServerSideCerts);
         meshCerts = CertificateHelper.GetCertificatesFromString(certsString);
     }
 
@@ -55,13 +55,13 @@ try
         services
             .AddMeshClient(_ =>
             {
-                _.MeshApiBaseUrl = config.MeshApiBaseUrl;
-                _.BypassServerCertificateValidation = config.BypassServerCertificateValidation ?? false;
+                _.MeshApiBaseUrl = config.NemsMeshApiBaseUrl;
+                _.BypassServerCertificateValidation = config.NemsMeshBypassServerCertificateValidation ?? false;
             })
-            .AddMailbox(config.NEMSMailBox, new NHS.MESH.Client.Configuration.MailboxConfiguration
+            .AddMailbox(config.NemsMeshMailBox, new NHS.MESH.Client.Configuration.MailboxConfiguration
             {
-                Password = config.MeshPassword,
-                SharedKey = config.MeshSharedKey,
+                Password = config.NemsMeshPassword,
+                SharedKey = config.NemsMeshSharedKey,
                 Cert = cohortManagerPrivateKey,
                 serverSideCertCollection = meshCerts
             })

--- a/infrastructure/tf-core/environments/development.tfvars
+++ b/infrastructure/tf-core/environments/development.tfvars
@@ -1023,10 +1023,10 @@ function_apps = {
         }
       ]
       env_vars_static = {
-        MeshCertName     = "MeshCert"
-        InboundContainer = "nems-updates"
-        ConfigContainer  = "nems-config"
-        BypassServerCertificateValidation = "true"
+        NemsMeshCertName                          = "NemsMeshCert"
+        NemsMeshInboundContainer                  = "nems-updates"
+        NemsMeshConfigContainer                   = "nems-config"
+        NemsMeshBypassServerCertificateValidation = "true"
       }
     }
 

--- a/infrastructure/tf-core/environments/integration.tfvars
+++ b/infrastructure/tf-core/environments/integration.tfvars
@@ -1023,9 +1023,9 @@ function_apps = {
         }
       ]
       env_vars_static = {
-        MeshCertName = "MeshCert"
-        InboundContainer = "nems-updates"
-        ConfigContainer = "nems-config"
+        NemsMeshCertName         = "NemsMeshCert"
+        NemsMeshInboundContainer = "nems-updates"
+        NemsMeshConfigContainer  = "nems-config"
       }
     }
 

--- a/infrastructure/tf-core/environments/nft.tfvars
+++ b/infrastructure/tf-core/environments/nft.tfvars
@@ -1022,9 +1022,9 @@ function_apps = {
         }
       ]
       env_vars_static = {
-        MeshCertName = "MeshCert"
-        InboundContainer = "nems-updates"
-        ConfigContainer = "nems-config"
+        NemsMeshCertName         = "NemsMeshCert"
+        NemsMeshInboundContainer = "nems-updates"
+        NemsMeshConfigContainer  = "nems-config"
       }
     }
 

--- a/infrastructure/tf-core/environments/preprod.tfvars
+++ b/infrastructure/tf-core/environments/preprod.tfvars
@@ -1047,9 +1047,9 @@ function_apps = {
         }
       ]
       env_vars_static = {
-        MeshCertName = "MeshCert"
-        InboundContainer = "nems-updates"
-        ConfigContainer = "nems-config"
+        NemsMeshCertName         = "NemsMeshCert"
+        NemsMeshInboundContainer = "nems-updates"
+        NemsMeshConfigContainer  = "nems-config"
       }
     }
 

--- a/infrastructure/tf-core/environments/production.tfvars
+++ b/infrastructure/tf-core/environments/production.tfvars
@@ -1321,9 +1321,9 @@ function_apps = {
         }
       ]
       env_vars_static = {
-        MeshCertName = "MeshCert"
-        InboundContainer = "nems-updates"
-        ConfigContainer = "nems-config"
+        NemsMeshCertName         = "NemsMeshCert"
+        NemsMeshInboundContainer = "nems-updates"
+        NemsMeshConfigContainer  = "nems-config"
       }
     }
 

--- a/infrastructure/tf-core/environments/sandbox.tfvars
+++ b/infrastructure/tf-core/environments/sandbox.tfvars
@@ -1343,9 +1343,9 @@ function_apps = {
         }
       ]
       env_vars_static = {
-        MeshCertName = "MeshCert"
-        InboundContainer = "nems-updates"
-        ConfigContainer = "nems-config"
+        NemsMeshCertName         = "NemsMeshCert"
+        NemsMeshInboundContainer = "nems-updates"
+        NemsMeshConfigContainer  = "nems-config"
       }
     }
 

--- a/tests/UnitTests/NemsSubscriptionServiceTests/NemsMeshRetrievalTests/NemsMeshRetrievalTests.cs
+++ b/tests/UnitTests/NemsSubscriptionServiceTests/NemsMeshRetrievalTests/NemsMeshRetrievalTests.cs
@@ -33,15 +33,15 @@ public class NemsMeshRetrievalTests
     {
         var testConfig = new NemsMeshRetrievalConfig
         {
-            NEMSMailBox = mailboxId,
+            NemsMeshMailBox = mailboxId,
             nemsmeshfolder_STORAGE = "BlobStorage_ConnectionString",
-            MeshPassword = "MeshPassword",
-            MeshSharedKey = "MeshSharedKey",
-            MeshKeyPassphrase = "MeshKeyPassphrase",
-            MeshKeyName = "MeshKeyName",
+            NemsMeshPassword = "MeshPassword",
+            NemsMeshSharedKey = "MeshSharedKey",
+            NemsMeshKeyPassphrase = "MeshKeyPassphrase",
+            NemsMeshKeyName = "MeshKeyName",
             KeyVaultConnectionString = "KeyVaultConnectionString",
-            InboundContainer = TestInboundContainer,
-            ConfigContainer = TestConfigContainer
+            NemsMeshInboundContainer = TestInboundContainer,
+            NemsMeshConfigContainer = TestConfigContainer
         };
 
         _config.Setup(c => c.Value).Returns(testConfig);
@@ -388,15 +388,15 @@ public class NemsMeshRetrievalTests
         
         var customConfig = new NemsMeshRetrievalConfig
         {
-            NEMSMailBox = mailboxId,
+            NemsMeshMailBox = mailboxId,
             nemsmeshfolder_STORAGE = "BlobStorage_ConnectionString",
-            MeshPassword = "MeshPassword",
-            MeshSharedKey = "MeshSharedKey",
-            MeshKeyPassphrase = "MeshKeyPassphrase",
-            MeshKeyName = "MeshKeyName",
+            NemsMeshPassword = "MeshPassword",
+            NemsMeshSharedKey = "MeshSharedKey",
+            NemsMeshKeyPassphrase = "MeshKeyPassphrase",
+            NemsMeshKeyName = "MeshKeyName",
             KeyVaultConnectionString = "KeyVaultConnectionString",
-            InboundContainer = customInboundContainer,
-            ConfigContainer = customConfigContainer
+            NemsMeshInboundContainer = customInboundContainer,
+            NemsMeshConfigContainer = customConfigContainer
         };
 
         var customConfigOptions = new Mock<IOptions<NemsMeshRetrievalConfig>>();
@@ -446,15 +446,15 @@ public class NemsMeshRetrievalTests
         
         var customConfig = new NemsMeshRetrievalConfig
         {
-            NEMSMailBox = mailboxId,
+            NemsMeshMailBox = mailboxId,
             nemsmeshfolder_STORAGE = "BlobStorage_ConnectionString",
-            MeshPassword = "MeshPassword",
-            MeshSharedKey = "MeshSharedKey",
-            MeshKeyPassphrase = "MeshKeyPassphrase", 
-            MeshKeyName = "MeshKeyName",
+            NemsMeshPassword = "MeshPassword",
+            NemsMeshSharedKey = "MeshSharedKey",
+            NemsMeshKeyPassphrase = "MeshKeyPassphrase", 
+            NemsMeshKeyName = "MeshKeyName",
             KeyVaultConnectionString = "KeyVaultConnectionString",
-            InboundContainer = "nems-updates",
-            ConfigContainer = customConfigContainer
+            NemsMeshInboundContainer = "nems-updates",
+            NemsMeshConfigContainer = customConfigContainer
         };
 
         var customConfigOptions = new Mock<IOptions<NemsMeshRetrievalConfig>>();


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Added NEMS-specific prefixes to all MESH configuration properties to fully separate NEMS and CAAS authentication/certificate configuration.

**JIRA Ticket:** [DTOSS-9694](https://nhsd-jira.digital.nhs.uk/browse/DTOSS-9694)

Changes include:
- Added `NemsMesh` prefix to all remaining configuration properties (API base URL, certificates, authentication) in NEMS Mesh Retrieval service
- Updated Program.cs to use the new NEMS-specific configuration properties
- Updated all environment configuration files to include the new prefixed properties
- Updated unit tests to reflect configuration changes

## Context

Following the mailbox configuration separation, this change completes the configuration isolation by ensuring NEMS MESH functions use completely separate configuration properties for certificates, authentication, and API endpoints. This prevents any remaining configuration conflicts between NEMS and CAAS MESH services and allows for independent configuration management.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [x] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.