### PR TITLE
feat: Mapped internal message types to outbound SNow API requests

### DIFF
--- a/application/CohortManager/compose.core.yaml
+++ b/application/CohortManager/compose.core.yaml
@@ -305,6 +305,7 @@ services:
       - ASPNETCORE_URLS=http://*:9092
       - ServiceNowRefreshAccessTokenUrl=https://nhsdigitaldev.service-now.com/oauth_token.do
       - ServiceNowUpdateUrl=https://nhsdigitaldev.service-now.com/api/x_nhsd_intstation/nhs_integration/9c78f87c97912e10dd80f2df9153aff5/CohortCaseUpdate
+      - ServiceNowResolutionUrl=https://nhsdigitaldev.service-now.com/api/x_nhsd_intstation/nhs_integration/9c78f87c97912e10dd80f2df9153aff5/CohortCaseResolution
       - ServiceNowClientId=${SERVICENOW_CLIENT_ID}
       - ServiceNowClientSecret=${SERVICENOW_CLIENT_SECRET}
       - ServiceNowRefreshToken=${SERVICENOW_REFRESH_TOKEN}

--- a/application/CohortManager/src/Functions/ParticipantManagementServices/ManageServiceNowParticipant/ManageServiceNowParticipantFunction.cs
+++ b/application/CohortManager/src/Functions/ParticipantManagementServices/ManageServiceNowParticipant/ManageServiceNowParticipantFunction.cs
@@ -18,11 +18,11 @@ public class ManageServiceNowParticipantFunction
     private readonly IExceptionHandler _exceptionHandler;
     private readonly IDataServiceClient<ParticipantManagement> _participantManagementClient;
 
-    public ManageServiceNowParticipantFunction(ILogger<ManageServiceNowParticipantFunction> logger, IOptions<ManageServiceNowParticipantConfig> addParticipantConfig,
+    public ManageServiceNowParticipantFunction(ILogger<ManageServiceNowParticipantFunction> logger, IOptions<ManageServiceNowParticipantConfig> config,
         IHttpClientFunction httpClientFunction, IExceptionHandler handleException, IDataServiceClient<ParticipantManagement> participantManagementClient)
     {
         _logger = logger;
-        _config = addParticipantConfig.Value;
+        _config = config.Value;
         _httpClientFunction = httpClientFunction;
         _exceptionHandler = handleException;
         _participantManagementClient = participantManagementClient;
@@ -186,7 +186,7 @@ public class ManageServiceNowParticipantFunction
     {
         _logger.LogError(exception, "Exception occurred whilst attempting to add participant from ServiceNow");
         await _exceptionHandler.CreateSystemExceptionLog(exception, serviceNowParticipant);
-        await SendServiceNowMessage(serviceNowParticipant.ServiceNowRecordNumber, serviceNowMessageType);
+        await SendServiceNowMessage(serviceNowParticipant.ServiceNowCaseNumber, serviceNowMessageType);
     }
 
     private static bool CheckParticipantDataMatches(ServiceNowParticipant serviceNowParticipant, ParticipantDemographic participantDemographic)
@@ -196,9 +196,9 @@ public class ManageServiceNowParticipantFunction
                serviceNowParticipant.DateOfBirth.ToString("yyyy-MM-dd") == participantDemographic.DateOfBirth;
     }
 
-    private async Task SendServiceNowMessage(string serviceNowRecordNumber, ServiceNowMessageType servicenowMessageType)
+    private async Task SendServiceNowMessage(string serviceNowCaseNumber, ServiceNowMessageType servicenowMessageType)
     {
-        var url = $"{_config.SendServiceNowMessageURL}/{serviceNowRecordNumber}";
+        var url = $"{_config.SendServiceNowMessageURL}/{serviceNowCaseNumber}";
         var requestBody = new SendServiceNowMessageRequestBody
         {
             MessageType = servicenowMessageType

--- a/application/CohortManager/src/Functions/ParticipantManagementServices/ManageServiceNowParticipant/ManageServiceNowParticipantFunction.cs
+++ b/application/CohortManager/src/Functions/ParticipantManagementServices/ManageServiceNowParticipant/ManageServiceNowParticipantFunction.cs
@@ -18,11 +18,11 @@ public class ManageServiceNowParticipantFunction
     private readonly IExceptionHandler _exceptionHandler;
     private readonly IDataServiceClient<ParticipantManagement> _participantManagementClient;
 
-    public ManageServiceNowParticipantFunction(ILogger<ManageServiceNowParticipantFunction> logger, IOptions<ManageServiceNowParticipantConfig> addParticipantConfig,
+    public ManageServiceNowParticipantFunction(ILogger<ManageServiceNowParticipantFunction> logger, IOptions<ManageServiceNowParticipantConfig> config,
         IHttpClientFunction httpClientFunction, IExceptionHandler handleException, IDataServiceClient<ParticipantManagement> participantManagementClient)
     {
         _logger = logger;
-        _config = addParticipantConfig.Value;
+        _config = config.Value;
         _httpClientFunction = httpClientFunction;
         _exceptionHandler = handleException;
         _participantManagementClient = participantManagementClient;
@@ -128,7 +128,7 @@ public class ManageServiceNowParticipantFunction
     {
         _logger.LogError(exception, "Exception occured whilst attempting to add participant from ServiceNow");
         await _exceptionHandler.CreateSystemExceptionLog(exception, serviceNowParticipant);
-        await SendSeviceNowMessage(serviceNowParticipant.ServiceNowRecordNumber, serviceNowMessageType);
+        await SendSeviceNowMessage(serviceNowParticipant.ServiceNowCaseNumber, serviceNowMessageType);
     }
 
     private static bool CheckParticipantDataMatches(ServiceNowParticipant serviceNowParticipant, ParticipantDemographic participantDemographic)
@@ -143,9 +143,9 @@ public class ManageServiceNowParticipantFunction
         return false;
     }
 
-    private async Task SendSeviceNowMessage(string serviceNowRecordNumber, ServiceNowMessageType servicenowMessageType)
+    private async Task SendSeviceNowMessage(string serviceNowCaseNumber, ServiceNowMessageType servicenowMessageType)
     {
-        var url = $"{_config.SendServiceNowMessageURL}/{serviceNowRecordNumber}";
+        var url = $"{_config.SendServiceNowMessageURL}/{serviceNowCaseNumber}";
         var requestBody = new SendServiceNowMessageRequestBody
         {
             MessageType = servicenowMessageType

--- a/application/CohortManager/src/Functions/ServiceNowIntegration/ServiceNowMessageHandler/IServiceNowClient.cs
+++ b/application/CohortManager/src/Functions/ServiceNowIntegration/ServiceNowMessageHandler/IServiceNowClient.cs
@@ -1,16 +1,24 @@
 namespace NHS.CohortManager.ServiceNowIntegrationService;
 
-using NHS.CohortManager.ServiceNowIntegrationService.Models;
-
 public interface IServiceNowClient
 {
     /// <summary>
     /// Sends an HTTP request to update a ServiceNow case. This method automatically handles access tokens including refresh.
     /// </summary>
-    /// <param name="sysId">The ServiceNow case system identifier (sys_id) used in the HTTP request path.</param>
-    /// <param name="payload">The ServiceNowUpdateRequestBody that will be sent in the HTTP request body.</param>
+    /// <param name="caseNumber">The ServiceNow case number used in the HTTP request path.</param>
+    /// <param name="workNotes">The message to send in the request as the work_notes.</param>
     /// <returns>
     /// An HTTP response indicating the result of the ServiceNow update request OR null if the update request was not made because no access token was found.
     /// </returns>
-    Task<HttpResponseMessage?> SendUpdate(string sysId, ServiceNowUpdateRequestBody payload);
+    Task<HttpResponseMessage?> SendUpdate(string caseNumber, string workNotes);
+
+    /// <summary>
+    /// Sends an HTTP request to resolve a ServiceNow case. This method automatically handles access tokens including refresh.
+    /// </summary>
+    /// <param name="caseNumber">The ServiceNow case number used in the HTTP request path.</param>
+    /// <param name="closeNotes">The message to send in the request as the close_notes.</param>
+    /// <returns>
+    /// An HTTP response indicating the result of the ServiceNow resolution request OR null if the resolution request was not made because no access token was found.
+    /// </returns>
+    Task<HttpResponseMessage?> SendResolution(string caseNumber, string closeNotes);
 }

--- a/application/CohortManager/src/Functions/ServiceNowIntegration/ServiceNowMessageHandler/Models/SendServiceNowMessageRequestBody.cs
+++ b/application/CohortManager/src/Functions/ServiceNowIntegration/ServiceNowMessageHandler/Models/SendServiceNowMessageRequestBody.cs
@@ -1,7 +1,0 @@
-namespace NHS.CohortManager.ServiceNowIntegrationService.Models;
-
-public class SendServiceNowMessageRequestBody
-{
-    public int State { get; set; }
-    public string? WorkNotes { get; set; }
-}

--- a/application/CohortManager/src/Functions/ServiceNowIntegration/ServiceNowMessageHandler/Models/ServiceNowResolutionRequestBody.cs
+++ b/application/CohortManager/src/Functions/ServiceNowIntegration/ServiceNowMessageHandler/Models/ServiceNowResolutionRequestBody.cs
@@ -1,0 +1,15 @@
+namespace NHS.CohortManager.ServiceNowIntegrationService.Models;
+
+using System.Text.Json.Serialization;
+
+public class ServiceNowResolutionRequestBody
+{
+    [JsonPropertyName("state")]
+    public int State { get; set; }
+    [JsonPropertyName("resolution_code")]
+    public required string ResolutionCode { get; set; }
+    [JsonPropertyName("close_notes")]
+    public required string CloseNotes { get; set; }
+    [JsonPropertyName("work_notes")]
+    public string? WorkNotes { get; set; }
+}

--- a/application/CohortManager/src/Functions/ServiceNowIntegration/ServiceNowMessageHandler/ReceiveServiceNowMessageFunction.cs
+++ b/application/CohortManager/src/Functions/ServiceNowIntegration/ServiceNowMessageHandler/ReceiveServiceNowMessageFunction.cs
@@ -70,7 +70,7 @@ public class ReceiveServiceNowMessageFunction
                 FirstName = requestBody.VariableData.FirstName,
                 FamilyName = requestBody.VariableData.FamilyName,
                 DateOfBirth = requestBody.VariableData.DateOfBirth,
-                ServiceNowRecordNumber = requestBody.ServiceNowCaseNumber,
+                ServiceNowCaseNumber = requestBody.ServiceNowCaseNumber,
                 BsoCode = requestBody.VariableData.BsoCode,
                 ReasonForAdding = requestBody.VariableData.ReasonForAdding,
                 RequiredGpCode = requestBody.VariableData.RequiredGpCode

--- a/application/CohortManager/src/Functions/ServiceNowIntegration/ServiceNowMessageHandler/SendServiceNowMessageFunction.cs
+++ b/application/CohortManager/src/Functions/ServiceNowIntegration/ServiceNowMessageHandler/SendServiceNowMessageFunction.cs
@@ -52,7 +52,7 @@ public class SendServiceNowMessageFunction
         }
         catch (JsonException ex)
         {
-            _logger.LogError(ex, "Failed to deserialize json request body to type {type}", nameof(SendServiceNowMessageRequestBody));
+            _logger.LogError(ex, "Failed to deserialize json request body to type {Type}", nameof(SendServiceNowMessageRequestBody));
             return _createResponse.CreateHttpResponse(HttpStatusCode.BadRequest, req);
         }
         catch (Exception ex)
@@ -83,7 +83,7 @@ public class SendServiceNowMessageFunction
 
             if (response == null || !response.IsSuccessStatusCode)
             {
-                _logger.LogError("Failed to update ServiceNow. StatusCode: {statusCode} CaseNumber: {caseNumber}", response?.StatusCode.ToString() ?? "Unknown", caseNumber);
+                _logger.LogError("Failed to update ServiceNow. StatusCode: {StatusCode} CaseNumber: {CaseNumber}", response?.StatusCode.ToString() ?? "Unknown", caseNumber);
                 return _createResponse.CreateHttpResponse(HttpStatusCode.InternalServerError, req);
             }
 

--- a/application/CohortManager/src/Functions/ServiceNowIntegration/ServiceNowMessageHandler/ServiceNowClient.cs
+++ b/application/CohortManager/src/Functions/ServiceNowIntegration/ServiceNowMessageHandler/ServiceNowClient.cs
@@ -66,11 +66,7 @@ public class ServiceNowClient : IServiceNowClient
             return null;
         }
 
-        var request = new HttpRequestMessage(HttpMethod.Put, url)
-        {
-            Content = new StringContent(json, Encoding.UTF8, "application/json")
-        };
-        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var request = CreateRequest(url, json, token);
 
         var response = await httpClient.SendAsync(request);
 
@@ -83,14 +79,14 @@ public class ServiceNowClient : IServiceNowClient
                 _logger.LogError("Failed to get valid access token so exiting without sending request to ServiceNow.");
                 return null;
             }
-            var retryRequest = CreateUpdateRequest(url, json, token);
+            var retryRequest = CreateRequest(url, json, token);
             response = await httpClient.SendAsync(retryRequest);
         }
 
         return response;
     }
 
-    private static HttpRequestMessage CreateUpdateRequest(string url, string json, string token)
+    private static HttpRequestMessage CreateRequest(string url, string json, string token)
     {
         var request = new HttpRequestMessage(HttpMethod.Put, url)
         {

--- a/application/CohortManager/src/Functions/ServiceNowIntegration/ServiceNowMessageHandler/ServiceNowClient.cs
+++ b/application/CohortManager/src/Functions/ServiceNowIntegration/ServiceNowMessageHandler/ServiceNowClient.cs
@@ -32,7 +32,7 @@ public class ServiceNowClient : IServiceNowClient
         var url = $"{_config.ServiceNowUpdateUrl}/{caseNumber}";
         var payload = new ServiceNowUpdateRequestBody
         {
-            State = 10,
+            State = 10, // 'Open' state
             WorkNotes = workNotes
         };
         var json = JsonSerializer.Serialize(payload);
@@ -45,8 +45,8 @@ public class ServiceNowClient : IServiceNowClient
         var url = $"{_config.ServiceNowResolutionUrl}/{caseNumber}";
         var payload = new ServiceNowResolutionRequestBody
         {
-            State = 6,
-            ResolutionCode = "28",
+            State = 6, // 'Resolved' state
+            ResolutionCode = "28", // 'Solved by Automation' resolution code
             CloseNotes = closeNotes
         };
         var json = JsonSerializer.Serialize(payload);

--- a/application/CohortManager/src/Functions/ServiceNowIntegration/ServiceNowMessageHandler/ServiceNowClient.cs
+++ b/application/CohortManager/src/Functions/ServiceNowIntegration/ServiceNowMessageHandler/ServiceNowClient.cs
@@ -27,27 +27,27 @@ public class ServiceNowClient : IServiceNowClient
         _config = config.Value;
     }
 
-    public async Task<HttpResponseMessage?> SendUpdate(string caseNumber, string message)
+    public async Task<HttpResponseMessage?> SendUpdate(string caseNumber, string workNotes)
     {
         var url = $"{_config.ServiceNowUpdateUrl}/{caseNumber}";
         var payload = new ServiceNowUpdateRequestBody
         {
             State = 10,
-            WorkNotes = message
+            WorkNotes = workNotes
         };
         var json = JsonSerializer.Serialize(payload);
 
         return await SendRequest(url, json);
     }
 
-    public async Task<HttpResponseMessage?> SendResolution(string caseNumber, string message)
+    public async Task<HttpResponseMessage?> SendResolution(string caseNumber, string closeNotes)
     {
         var url = $"{_config.ServiceNowResolutionUrl}/{caseNumber}";
         var payload = new ServiceNowResolutionRequestBody
         {
             State = 6,
             ResolutionCode = "28",
-            CloseNotes = message
+            CloseNotes = closeNotes
         };
         var json = JsonSerializer.Serialize(payload);
 

--- a/application/CohortManager/src/Functions/ServiceNowIntegration/ServiceNowMessageHandler/ServiceNowMessageHandlerConfig.cs
+++ b/application/CohortManager/src/Functions/ServiceNowIntegration/ServiceNowMessageHandler/ServiceNowMessageHandlerConfig.cs
@@ -9,6 +9,8 @@ public class ServiceNowMessageHandlerConfig
     [Required]
     public required string ServiceNowUpdateUrl { get; set; }
     [Required]
+    public required string ServiceNowResolutionUrl { get; set; }
+    [Required]
     public required string ServiceNowClientId { get; set; }
     [Required]
     public required string ServiceNowClientSecret { get; set; }

--- a/application/CohortManager/src/Functions/ServiceNowIntegration/ServiceNowMessageHandler/ServiceNowMessageTemplates.cs
+++ b/application/CohortManager/src/Functions/ServiceNowIntegration/ServiceNowMessageHandler/ServiceNowMessageTemplates.cs
@@ -1,0 +1,8 @@
+namespace NHS.CohortManager.ServiceNowIntegrationService;
+
+public static class ServiceNowMessageTemplates
+{
+    public const string UnableToAddParticipantMessageTemplate = "Action needed {0}: the breast screening participant could not be added because either the details do not match Personal Demographics Service (PDS) records or they are not able to be added into Cohort Manager. Verify the participant's information and reason for adding and submit a new form with corrected details.";
+    public const string AddRequestInProgressMessageTemplate = "The request to add a participant to the breast screening programme has been received for {0}. There may be a slight delay while we verify some information. No action is needed from you during this process.";
+    public const string SuccessMessageTemplate = "The request to add a participant to the breast screening programme was successful for {0}. The participant has now been added to Cohort Manager. No further action is needed.";
+}

--- a/application/CohortManager/src/Functions/Shared/Model/ServiceNowParticipant.cs
+++ b/application/CohortManager/src/Functions/Shared/Model/ServiceNowParticipant.cs
@@ -2,12 +2,12 @@ namespace Model;
 
 public class ServiceNowParticipant
 {
+    public required string ServiceNowCaseNumber { get; set; }
     public required long ScreeningId { get; set; }
     public required long NhsNumber { get; set; }
     public required string FirstName { get; set; }
     public required string FamilyName { get; set; }
     public required DateOnly DateOfBirth { get; set; }
-    public required string ServiceNowRecordNumber { get; set; }
     public required string BsoCode { get; set; }
     public required string ReasonForAdding { get; set; }
     public string? RequiredGpCode { get; set; }

--- a/infrastructure/tf-core/environments/development.tfvars
+++ b/infrastructure/tf-core/environments/development.tfvars
@@ -846,6 +846,7 @@ function_apps = {
       env_vars_static = {
         ServiceNowRefreshAccessTokenUrl      = "https://nhsdigitaldev.service-now.com/oauth_token.do"
         ServiceNowUpdateUrl                  = "https://nhsdigitaldev.service-now.com/api/x_nhsd_intstation/nhs_integration/9c78f87c97912e10dd80f2df9153aff5/CohortCaseUpdate"
+        ServiceNowResolutionUrl              = "https://nhsdigitaldev.service-now.com/api/x_nhsd_intstation/nhs_integration/9c78f87c97912e10dd80f2df9153aff5/CohortCaseResolution"
         ServiceNowParticipantManagementTopic = "servicenow-participant-management" # Sends messages to the servicenow participant manage topic
       }
     }

--- a/infrastructure/tf-core/environments/integration.tfvars
+++ b/infrastructure/tf-core/environments/integration.tfvars
@@ -846,6 +846,7 @@ function_apps = {
       env_vars_static = {
         ServiceNowRefreshAccessTokenUrl      = "https://nhsdigitaldev.service-now.com/oauth_token.do"
         ServiceNowUpdateUrl                  = "https://nhsdigitaldev.service-now.com/api/x_nhsd_intstation/nhs_integration/9c78f87c97912e10dd80f2df9153aff5/CohortCaseUpdate"
+        ServiceNowResolutionUrl              = "https://nhsdigitaldev.service-now.com/api/x_nhsd_intstation/nhs_integration/9c78f87c97912e10dd80f2df9153aff5/CohortCaseResolution"
         ServiceNowParticipantManagementTopic = "servicenow-participant-management" # Sends messages to the servicenow participant manage topic
       }
     }

--- a/infrastructure/tf-core/environments/nft.tfvars
+++ b/infrastructure/tf-core/environments/nft.tfvars
@@ -845,6 +845,7 @@ function_apps = {
       env_vars_static = {
         ServiceNowRefreshAccessTokenUrl      = "https://nhsdigitaldev.service-now.com/oauth_token.do"
         ServiceNowUpdateUrl                  = "https://nhsdigitaldev.service-now.com/api/x_nhsd_intstation/nhs_integration/9c78f87c97912e10dd80f2df9153aff5/CohortCaseUpdate"
+        ServiceNowResolutionUrl              = "https://nhsdigitaldev.service-now.com/api/x_nhsd_intstation/nhs_integration/9c78f87c97912e10dd80f2df9153aff5/CohortCaseResolution"
         ServiceNowParticipantManagementTopic = "servicenow-participant-management" # Sends messages to the servicenow participant manage topic
       }
     }

--- a/infrastructure/tf-core/environments/preprod.tfvars
+++ b/infrastructure/tf-core/environments/preprod.tfvars
@@ -868,8 +868,9 @@ function_apps = {
       app_service_plan_key   = "DefaultPlan"
       key_vault_url          = "KeyVaultConnectionString"
       env_vars_static = {
-        ServiceNowRefreshAccessTokenUrl      = ""                                  # TODO: Get value
-        ServiceNowUpdateUrl                  = ""                                  # TODO: Get value
+        ServiceNowRefreshAccessTokenUrl      = "" # TODO: Get value
+        ServiceNowUpdateUrl                  = "" # TODO: Get value
+        ServiceNowResolutionUrl              = "" # TODO: Get value
         ServiceNowParticipantManagementTopic = "servicenow-participant-management" # Sends messages to the servicenow participant manage topic
       }
     }

--- a/infrastructure/tf-core/environments/production.tfvars
+++ b/infrastructure/tf-core/environments/production.tfvars
@@ -837,6 +837,7 @@ function_apps = {
       env_vars_static = {
         ServiceNowRefreshAccessTokenUrl      = "" # TODO: Get value
         ServiceNowUpdateUrl                  = "" # TODO: Get value
+        ServiceNowResolutionUrl              = "" # TODO: Get value
         ServiceNowParticipantManagementTopic = "servicenow-participant-management" # Sends messages to the servicenow participant manage topic
       }
     }

--- a/infrastructure/tf-core/environments/sandbox.tfvars
+++ b/infrastructure/tf-core/environments/sandbox.tfvars
@@ -1166,6 +1166,7 @@ function_apps = {
       env_vars_static = {
         ServiceNowRefreshAccessTokenUrl      = "https://nhsdigitaldev.service-now.com/oauth_token.do"
         ServiceNowUpdateUrl                  = "https://nhsdigitaldev.service-now.com/api/x_nhsd_intstation/nhs_integration/9c78f87c97912e10dd80f2df9153aff5/CohortCaseUpdate"
+        ServiceNowResolutionUrl              = "https://nhsdigitaldev.service-now.com/api/x_nhsd_intstation/nhs_integration/9c78f87c97912e10dd80f2df9153aff5/CohortCaseResolution"
         ServiceNowParticipantManagementTopic = "servicenow-participant-management" # Sends messages to the servicenow participant manage topic
       }
     }

--- a/tests/UnitTests/ParticipantManagementServicesTests/ManageServiceNowParticipantTests/ManageServiceNowParticipantFunctionTests.cs
+++ b/tests/UnitTests/ParticipantManagementServicesTests/ManageServiceNowParticipantTests/ManageServiceNowParticipantFunctionTests.cs
@@ -36,7 +36,7 @@ public class ManageServiceNowParticipantFunctionTests
             FirstName = "Samantha",
             FamilyName = "Bloggs",
             DateOfBirth = new DateOnly(1970, 1, 1),
-            ServiceNowRecordNumber = "CS123",
+            ServiceNowCaseNumber = "CS123",
             BsoCode = "ABC",
             ReasonForAdding = ServiceNowReasonsForAdding.RequiresCeasing
         };
@@ -78,7 +78,7 @@ public class ManageServiceNowParticipantFunctionTests
         await _function.Run(_serviceNowParticipant);
 
         // Assert
-        _httpClientFunctionMock.Verify(x => x.SendPut($"{_configMock.Object.Value.SendServiceNowMessageURL}/{_serviceNowParticipant.ServiceNowRecordNumber}", _messageType1Request), Times.Once());
+        _httpClientFunctionMock.Verify(x => x.SendPut($"{_configMock.Object.Value.SendServiceNowMessageURL}/{_serviceNowParticipant.ServiceNowCaseNumber}", _messageType1Request), Times.Once());
         _httpClientFunctionMock.Verify();
         _httpClientFunctionMock.VerifyNoOtherCalls();
 
@@ -88,7 +88,7 @@ public class ManageServiceNowParticipantFunctionTests
                 && p.FirstName == _serviceNowParticipant.FirstName
                 && p.FamilyName == _serviceNowParticipant.FamilyName
                 && p.DateOfBirth == _serviceNowParticipant.DateOfBirth
-                && p.ServiceNowRecordNumber == _serviceNowParticipant.ServiceNowRecordNumber)), Times.Once);
+                && p.ServiceNowCaseNumber == _serviceNowParticipant.ServiceNowCaseNumber)), Times.Once);
         _handleExceptionMock.VerifyNoOtherCalls();
 
         _dataServiceClientMock.VerifyNoOtherCalls();
@@ -112,7 +112,7 @@ public class ManageServiceNowParticipantFunctionTests
         await _function.Run(_serviceNowParticipant);
 
         // Assert
-        _httpClientFunctionMock.Verify(x => x.SendPut($"{_configMock.Object.Value.SendServiceNowMessageURL}/{_serviceNowParticipant.ServiceNowRecordNumber}", _messageType1Request), Times.Once());
+        _httpClientFunctionMock.Verify(x => x.SendPut($"{_configMock.Object.Value.SendServiceNowMessageURL}/{_serviceNowParticipant.ServiceNowCaseNumber}", _messageType1Request), Times.Once());
         _httpClientFunctionMock.Verify();
         _httpClientFunctionMock.VerifyNoOtherCalls();
 
@@ -122,7 +122,7 @@ public class ManageServiceNowParticipantFunctionTests
                 && p.FirstName == _serviceNowParticipant.FirstName
                 && p.FamilyName == _serviceNowParticipant.FamilyName
                 && p.DateOfBirth == _serviceNowParticipant.DateOfBirth
-                && p.ServiceNowRecordNumber == _serviceNowParticipant.ServiceNowRecordNumber)), Times.Once);
+                && p.ServiceNowCaseNumber == _serviceNowParticipant.ServiceNowCaseNumber)), Times.Once);
         _handleExceptionMock.VerifyNoOtherCalls();
 
         _dataServiceClientMock.VerifyNoOtherCalls();
@@ -141,7 +141,7 @@ public class ManageServiceNowParticipantFunctionTests
         await _function.Run(_serviceNowParticipant);
 
         // Assert
-        _httpClientFunctionMock.Verify(x => x.SendPut($"{_configMock.Object.Value.SendServiceNowMessageURL}/{_serviceNowParticipant.ServiceNowRecordNumber}", _messageType2Request), Times.Once());
+        _httpClientFunctionMock.Verify(x => x.SendPut($"{_configMock.Object.Value.SendServiceNowMessageURL}/{_serviceNowParticipant.ServiceNowCaseNumber}", _messageType2Request), Times.Once());
         _httpClientFunctionMock.Verify();
         _httpClientFunctionMock.VerifyNoOtherCalls();
 
@@ -151,7 +151,7 @@ public class ManageServiceNowParticipantFunctionTests
                 && p.FirstName == _serviceNowParticipant.FirstName
                 && p.FamilyName == _serviceNowParticipant.FamilyName
                 && p.DateOfBirth == _serviceNowParticipant.DateOfBirth
-                && p.ServiceNowRecordNumber == _serviceNowParticipant.ServiceNowRecordNumber)), Times.Once);
+                && p.ServiceNowCaseNumber == _serviceNowParticipant.ServiceNowCaseNumber)), Times.Once);
         _handleExceptionMock.VerifyNoOtherCalls();
 
         _dataServiceClientMock.VerifyNoOtherCalls();
@@ -169,7 +169,7 @@ public class ManageServiceNowParticipantFunctionTests
         await _function.Run(_serviceNowParticipant);
 
         // Assert
-        _httpClientFunctionMock.Verify(x => x.SendPut($"{_configMock.Object.Value.SendServiceNowMessageURL}/{_serviceNowParticipant.ServiceNowRecordNumber}", _messageType2Request), Times.Once());
+        _httpClientFunctionMock.Verify(x => x.SendPut($"{_configMock.Object.Value.SendServiceNowMessageURL}/{_serviceNowParticipant.ServiceNowCaseNumber}", _messageType2Request), Times.Once());
         _httpClientFunctionMock.Verify();
         _httpClientFunctionMock.VerifyNoOtherCalls();
 
@@ -179,7 +179,7 @@ public class ManageServiceNowParticipantFunctionTests
                 && p.FirstName == _serviceNowParticipant.FirstName
                 && p.FamilyName == _serviceNowParticipant.FamilyName
                 && p.DateOfBirth == _serviceNowParticipant.DateOfBirth
-                && p.ServiceNowRecordNumber == _serviceNowParticipant.ServiceNowRecordNumber)));
+                && p.ServiceNowCaseNumber == _serviceNowParticipant.ServiceNowCaseNumber)));
         _handleExceptionMock.VerifyNoOtherCalls();
 
         _dataServiceClientMock.VerifyNoOtherCalls();
@@ -210,7 +210,7 @@ public class ManageServiceNowParticipantFunctionTests
         await _function.Run(_serviceNowParticipant);
 
         // Assert
-        _httpClientFunctionMock.Verify(x => x.SendPut($"{_configMock.Object.Value.SendServiceNowMessageURL}/{_serviceNowParticipant.ServiceNowRecordNumber}", _messageType1Request), Times.Once());
+        _httpClientFunctionMock.Verify(x => x.SendPut($"{_configMock.Object.Value.SendServiceNowMessageURL}/{_serviceNowParticipant.ServiceNowCaseNumber}", _messageType1Request), Times.Once());
         _httpClientFunctionMock.Verify();
         _httpClientFunctionMock.VerifyNoOtherCalls();
 
@@ -220,7 +220,7 @@ public class ManageServiceNowParticipantFunctionTests
                 && p.FirstName == _serviceNowParticipant.FirstName
                 && p.FamilyName == _serviceNowParticipant.FamilyName
                 && p.DateOfBirth == _serviceNowParticipant.DateOfBirth
-                && p.ServiceNowRecordNumber == _serviceNowParticipant.ServiceNowRecordNumber)), Times.Once);
+                && p.ServiceNowCaseNumber == _serviceNowParticipant.ServiceNowCaseNumber)), Times.Once);
         _handleExceptionMock.VerifyNoOtherCalls();
 
         _dataServiceClientMock.VerifyNoOtherCalls();
@@ -296,7 +296,7 @@ public class ManageServiceNowParticipantFunctionTests
         await _function.Run(_serviceNowParticipant);
 
         // Assert
-        _httpClientFunctionMock.Verify(x => x.SendPut($"{_configMock.Object.Value.SendServiceNowMessageURL}/{_serviceNowParticipant.ServiceNowRecordNumber}", _messageType1Request), Times.Once());
+        _httpClientFunctionMock.Verify(x => x.SendPut($"{_configMock.Object.Value.SendServiceNowMessageURL}/{_serviceNowParticipant.ServiceNowCaseNumber}", _messageType1Request), Times.Once());
         _httpClientFunctionMock.Verify();
         _httpClientFunctionMock.VerifyNoOtherCalls();
 
@@ -306,7 +306,7 @@ public class ManageServiceNowParticipantFunctionTests
                 && p.FirstName == _serviceNowParticipant.FirstName
                 && p.FamilyName == _serviceNowParticipant.FamilyName
                 && p.DateOfBirth == _serviceNowParticipant.DateOfBirth
-                && p.ServiceNowRecordNumber == _serviceNowParticipant.ServiceNowRecordNumber)), Times.Once);
+                && p.ServiceNowCaseNumber == _serviceNowParticipant.ServiceNowCaseNumber)), Times.Once);
         _handleExceptionMock.VerifyNoOtherCalls();
 
         _dataServiceClientMock.Verify();

--- a/tests/UnitTests/ParticipantManagementServicesTests/ManageServiceNowParticipantTests/ManageServiceNowParticipantFunctionTests.cs
+++ b/tests/UnitTests/ParticipantManagementServicesTests/ManageServiceNowParticipantTests/ManageServiceNowParticipantFunctionTests.cs
@@ -370,7 +370,7 @@ public class ManageServiceNowParticipantFunctionTests
             FirstName = "Samantha",
             FamilyName = "Bloggs",
             DateOfBirth = new DateOnly(1970, 1, 1),
-            ServiceNowRecordNumber = "CS123",
+            ServiceNowCaseNumber = "CS123",
             BsoCode = "ABC",
             ReasonForAdding = ServiceNowReasonsForAdding.VeryHighRisk
         };
@@ -479,7 +479,7 @@ public class ManageServiceNowParticipantFunctionTests
             FirstName = "Samantha",
             FamilyName = "Bloggs",
             DateOfBirth = new DateOnly(1970, 1, 1),
-            ServiceNowRecordNumber = "CS123",
+            ServiceNowCaseNumber = "CS123",
             BsoCode = "ABC",
             ReasonForAdding = ServiceNowReasonsForAdding.VeryHighRisk
         };

--- a/tests/UnitTests/ServiceNowMessageHandlerTests/ReceiveServiceNowMessageFunctionTests.cs
+++ b/tests/UnitTests/ServiceNowMessageHandlerTests/ReceiveServiceNowMessageFunctionTests.cs
@@ -29,6 +29,7 @@ public class ReceiveServiceNowMessageFunctionTests
         {
             ServiceNowRefreshAccessTokenUrl = "https://www.example.net/refresh",
             ServiceNowUpdateUrl = "https://www.example.net/update",
+            ServiceNowResolutionUrl = "https://www.example.net/resolution",
             ServiceNowClientId = "123",
             ServiceNowClientSecret = "ABC",
             ServiceNowRefreshToken = "DEF",
@@ -61,7 +62,7 @@ public class ReceiveServiceNowMessageFunctionTests
         _mockHttpRequest.Setup(r => r.Body).Returns(requestBodyStream);
         _mockQueueClient.Setup(x => x.AddAsync(It.Is<ServiceNowParticipant>(p =>
                 p.ScreeningId == 1 &&
-                p.ServiceNowRecordNumber == caseNumber &&
+                p.ServiceNowCaseNumber == caseNumber &&
                 p.NhsNumber == long.Parse(nhsNumber) &&
                 p.FirstName == forename &&
                 p.FamilyName == familyName &&
@@ -140,7 +141,7 @@ public class ReceiveServiceNowMessageFunctionTests
         _mockHttpRequest.Setup(r => r.Body).Returns(requestBodyStream);
         _mockQueueClient.Setup(x => x.AddAsync(It.Is<ServiceNowParticipant>(p =>
                 p.ScreeningId == 1 &&
-                p.ServiceNowRecordNumber == caseNumber &&
+                p.ServiceNowCaseNumber == caseNumber &&
                 p.NhsNumber == long.Parse(nhsNumber) &&
                 p.FirstName == forename &&
                 p.FamilyName == familyName &&


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

- Maps the internal message types to outbound SNow API requests
- Replaces all mention of sys Id with case number

## Context

[DTOSS-8425](https://nhsd-jira.digital.nhs.uk/browse/DTOSS-8425)

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [x] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
