### PR TITLE
fix: corrected terraform for ProcessNemsUpdate to fix the storage connection

### DIFF
--- a/infrastructure/tf-core/environments/development.tfvars
+++ b/infrastructure/tf-core/environments/development.tfvars
@@ -320,7 +320,7 @@ function_apps = {
       function_endpoint_name       = "ProcessNemsUpdate"
       app_service_plan_key         = "DefaultPlan"
       key_vault_url                = "KeyVaultConnectionString"
-      storage_account_env_var_name = "caasfolder_STORAGE"
+      storage_account_env_var_name = "nemsmeshfolder_STORAGE"
       app_urls = [
         {
           env_var_name     = "ExceptionFunctionURL"
@@ -338,7 +338,7 @@ function_apps = {
       storage_containers = [
         {
           env_var_name   = "NemsMessages"
-          container_name = "nems-messages"
+          container_name = "nems-updates"
         }
       ]
       env_vars_static = {

--- a/infrastructure/tf-core/environments/integration.tfvars
+++ b/infrastructure/tf-core/environments/integration.tfvars
@@ -320,7 +320,7 @@ function_apps = {
       function_endpoint_name       = "ProcessNemsUpdate"
       app_service_plan_key         = "DefaultPlan"
       key_vault_url                = "KeyVaultConnectionString"
-      storage_account_env_var_name = "caasfolder_STORAGE"
+      storage_account_env_var_name = "nemsmeshfolder_STORAGE"
       app_urls = [
         {
           env_var_name     = "ExceptionFunctionURL"
@@ -338,7 +338,7 @@ function_apps = {
       storage_containers = [
         {
           env_var_name   = "NemsMessages"
-          container_name = "nems-messages"
+          container_name = "nems-updates"
         }
       ]
       env_vars_static = {

--- a/infrastructure/tf-core/environments/nft.tfvars
+++ b/infrastructure/tf-core/environments/nft.tfvars
@@ -319,7 +319,7 @@ function_apps = {
       function_endpoint_name       = "ProcessNemsUpdate"
       app_service_plan_key         = "DefaultPlan"
       key_vault_url                = "KeyVaultConnectionString"
-      storage_account_env_var_name = "caasfolder_STORAGE"
+      storage_account_env_var_name = "nemsmeshfolder_STORAGE"
       app_urls = [
         {
           env_var_name     = "ExceptionFunctionURL"
@@ -337,7 +337,7 @@ function_apps = {
       storage_containers = [
         {
           env_var_name   = "NemsMessages"
-          container_name = "nems-messages"
+          container_name = "nems-updates"
         }
       ]
       env_vars_static = {

--- a/infrastructure/tf-core/environments/preprod.tfvars
+++ b/infrastructure/tf-core/environments/preprod.tfvars
@@ -344,7 +344,7 @@ function_apps = {
       function_endpoint_name       = "ProcessNemsUpdate"
       app_service_plan_key         = "DefaultPlan"
       key_vault_url                = "KeyVaultConnectionString"
-      storage_account_env_var_name = "caasfolder_STORAGE"
+      storage_account_env_var_name = "nemsmeshfolder_STORAGE"
       app_urls = [
         {
           env_var_name     = "ExceptionFunctionURL"
@@ -362,7 +362,7 @@ function_apps = {
       storage_containers = [
         {
           env_var_name   = "NemsMessages"
-          container_name = "nems-messages"
+          container_name = "nems-updates"
         }
       ]
       env_vars_static = {

--- a/infrastructure/tf-core/environments/production.tfvars
+++ b/infrastructure/tf-core/environments/production.tfvars
@@ -311,7 +311,7 @@ function_apps = {
       function_endpoint_name       = "ProcessNemsUpdate"
       app_service_plan_key         = "DefaultPlan"
       key_vault_url                = "KeyVaultConnectionString"
-      storage_account_env_var_name = "caasfolder_STORAGE"
+      storage_account_env_var_name = "nemsmeshfolder_STORAGE"
       app_urls = [
         {
           env_var_name     = "ExceptionFunctionURL"
@@ -329,7 +329,7 @@ function_apps = {
       storage_containers = [
         {
           env_var_name   = "NemsMessages"
-          container_name = "nems-messages"
+          container_name = "nems-updates"
         }
       ]
       env_vars_static = {

--- a/infrastructure/tf-core/environments/sandbox.tfvars
+++ b/infrastructure/tf-core/environments/sandbox.tfvars
@@ -334,7 +334,7 @@ function_apps = {
       function_endpoint_name       = "ProcessNemsUpdate"
       app_service_plan_key         = "DefaultPlan"
       key_vault_url                = "KeyVaultConnectionString"
-      storage_account_env_var_name = "caasfolder_STORAGE"
+      storage_account_env_var_name = "nemsmeshfolder_STORAGE"
       app_urls = [
         {
           env_var_name     = "ExceptionFunctionURL"
@@ -352,7 +352,7 @@ function_apps = {
       storage_containers = [
         {
           env_var_name   = "NemsMessages"
-          container_name = "nems-messages"
+          container_name = "nems-updates"
         }
       ]
       env_vars_static = {


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Fixed ProcessNemsUpdate function storage configuration to correctly connect to storage account and monitor the proper blob container for NEMS updates.

  **JIRA Ticket:** [DTOSS-9294](https://nhsd-jira.digital.nhs.uk/browse/DTOSS-9294)

  Changes include:

  **Storage Configuration Fix:**
  - Changed `storage_account_env_var_name` from
  `caasfolder_STORAGE` to `nemsmeshfolder_STORAGE` in all environment tfvars files
  - Changed container name from `nems-messages` to
  `nems-updates` to match function blob trigger
  - Applied fixes across all 6 environments: development, sandbox, nft, integration, preprod, production

  ## Context

  The ProcessNemsUpdate function had a critical
  storage configuration mismatch that prevented it
  from functioning:

  1. **Storage Connection Issue**: Function expected connection string in `nemsmeshfolder_STORAGE` environment variable, but Terraform was setting `caasfolder_STORAGE`
  2. **Container Mismatch**: Function blob trigger monitored `nems-updates` container, but Terraform configured `nems-messages` container
  3. **Result**: Function couldn't connect to storage and wouldn't trigger when NEMS XML files were uploaded

  The function code defines:

```c#
 [BlobTrigger("nems-updates/{name}", Connection ="nemsmeshfolder_STORAGE")]
``` 


  But Terraform was configured with:
  - storage_account_env_var_name = "caasfolder_STORAGE"
  - container_name = "nems-messages"

  This fix ensures the ProcessNemsUpdate function can properly:
  - Connect to the shared storage account via the correct environment variable
  - Trigger when files are uploaded to the nems-updates container
  - Process NEMS XML files as intended

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
