### PR TITLE
fix: now returns from mocked http function code

### DIFF
--- a/application/CohortManager/src/Functions/Shared/Common/PdsHttpClientMock.cs
+++ b/application/CohortManager/src/Functions/Shared/Common/PdsHttpClientMock.cs
@@ -7,6 +7,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using System.Text.Json;
 using Model;
+using Common.Interfaces;
 
 /// <summary>
 /// Mock implementation of IHttpClientFunction specifically designed for PDS (Personal Demographics Service) calls.
@@ -17,6 +18,14 @@ using Model;
 /// </summary>
 public class PdsHttpClientMock : IHttpClientFunction
 {
+
+    private readonly IFhirPatientDemographicMapper _fhirPatientDemographicMapper;
+
+    public PdsHttpClientMock(IFhirPatientDemographicMapper fhirPatientDemographicMapper)
+    {
+        _fhirPatientDemographicMapper = fhirPatientDemographicMapper;
+    }
+
     public async Task<HttpResponseMessage> SendPost(string url, string data)
     {
         await Task.CompletedTask;
@@ -26,7 +35,11 @@ public class PdsHttpClientMock : IHttpClientFunction
     public async Task<string> SendGet(string url, Dictionary<string, string> parameters)
     {
         await Task.CompletedTask;
-        return JsonSerializer.Serialize(new PdsDemographic());
+        var patient = GetPatientMockObject("complete-patient.json");
+        var pdsDemographic = _fhirPatientDemographicMapper.ParseFhirJson(patient);
+        var participantDemographic = pdsDemographic.ToParticipantDemographic();
+
+        return JsonSerializer.Serialize(participantDemographic);
     }
 
     public async Task<string> SendGet(string url)

--- a/application/CohortManager/src/Functions/Shared/DataServices.Client/DataServiceClient.cs
+++ b/application/CohortManager/src/Functions/Shared/DataServices.Client/DataServiceClient.cs
@@ -86,10 +86,10 @@ public class DataServiceClient<TEntity> : IDataServiceClient<TEntity> where TEnt
         var jsonString = await GetJsonStringByFilter(predicate, true);
         if (string.IsNullOrEmpty(jsonString))
         {
-            return null;
+            return null!;
         }
-        TEntity result = JsonSerializer.Deserialize<TEntity>(jsonString);
-        return result;
+        TEntity result = JsonSerializer.Deserialize<TEntity>(jsonString)!;
+        return result!;
     }
 
     public async Task<bool> Delete(string id)


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

- the PDS function was throwing an error whenever we would call the fake PDS services
- now gets a fake "real" record from the database by reading the json of the participant from local

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
