### PR TITLE
test: adding automated test for epic4b dtoss-7617-01

### DIFF
--- a/tests/playwright-tests/src/tests/e2e/testFiles/@DTOSS-7617-01/ADD_-_CAAS_BREAST_SCREENING_COHORT.json
+++ b/tests/playwright-tests/src/tests/e2e/testFiles/@DTOSS-7617-01/ADD_-_CAAS_BREAST_SCREENING_COHORT.json
@@ -1,0 +1,55 @@
+{
+  "validations": [
+    {
+      "validations": {
+        "apiEndpoint": "api/ParticipantManagementDataService",
+        "NHSNumber": 9997322886
+      }
+    }
+  ],
+  "inputParticipantRecord": [
+    {
+      "record_type": "ADD",
+      "change_time_stamp": "20250801120000",
+      "serial_change_number": 1,
+      "nhs_number": "9997322886",
+      "superseded_by_nhs_number": null,
+      "primary_care_provider": "F83043",
+      "primary_care_effective_from_date": "20130319",
+      "current_posting": "CH",
+      "current_posting_effective_from_date": "20130319",
+      "name_prefix": "MR",
+      "given_name": "TestBlocked",
+      "other_given_name": "User",
+      "family_name": "Participant",
+      "previous_family_name": null,
+      "date_of_birth": "19700101",
+      "gender": 1,
+      "address_line_1": "123 Test Street",
+      "address_line_2": "Testville",
+      "address_line_3": null,
+      "address_line_4": "Testington",
+      "address_line_5": "United Kingdom",
+      "postcode": "AB43 8FJ",
+      "paf_key": "Z3S4Q5X9",
+      "address_effective_from_date": "20250801",
+      "reason_for_removal": null,
+      "reason_for_removal_effective_from_date": null,
+      "date_of_death": null,
+      "death_status": null,
+      "home_telephone_number": "01619999999",
+      "home_telephone_effective_from_date": "20240501",
+      "mobile_telephone_number": "07888888888",
+      "mobile_telephone_effective_from_date": "20240501",
+      "email_address": "test7617@example.com",
+      "email_address_effective_from_date": "20250801",
+      "preferred_language": "en",
+      "is_interpreter_required": false,
+      "invalid_flag": false,
+      "eligibility": true
+    }
+  ],
+  "nhsNumbers": [
+    "9997322886"
+  ]
+}

--- a/tests/playwright-tests/src/tests/e2e/testFiles/@DTOSS-7617-01/AMEND_BLOCKED_-_CAAS_BREAST_SCREENING_COHORT.json
+++ b/tests/playwright-tests/src/tests/e2e/testFiles/@DTOSS-7617-01/AMEND_BLOCKED_-_CAAS_BREAST_SCREENING_COHORT.json
@@ -1,0 +1,55 @@
+{
+  "validations": [
+    {
+      "validations": {
+        "apiEndpoint": "api/ParticipantManagementDataService",
+        "NHSNumber": 9997322886
+      }
+    }
+  ],
+  "inputParticipantRecord": [
+    {
+      "record_type": "AMENDED",
+      "change_time_stamp": "20250802120000",
+      "serial_change_number": 2,
+      "nhs_number": "9997322886",
+      "superseded_by_nhs_number": null,
+      "primary_care_provider": "F83043",
+      "primary_care_effective_from_date": "20130319",
+      "current_posting": "CH",
+      "current_posting_effective_from_date": "20130319",
+      "name_prefix": "MR",
+      "given_name": "TestBlockedUpdated",
+      "other_given_name": "UserUpdated",
+      "family_name": "ParticipantUpdated",
+      "previous_family_name": null,
+      "date_of_birth": "19700101",
+      "gender": 1,
+      "address_line_1": "456 New Street",
+      "address_line_2": "New Town",
+      "address_line_3": null,
+      "address_line_4": "New City",
+      "address_line_5": "United Kingdom",
+      "postcode": "AB43 8FJ",
+      "paf_key": "Z3S4Q5X9",
+      "address_effective_from_date": "20250802",
+      "reason_for_removal": null,
+      "reason_for_removal_effective_from_date": null,
+      "date_of_death": null,
+      "death_status": null,
+      "home_telephone_number": "01619999999",
+      "home_telephone_effective_from_date": "20240501",
+      "mobile_telephone_number": "07999999999",
+      "mobile_telephone_effective_from_date": "20250802",
+      "email_address": "test7617updated@example.com",
+      "email_address_effective_from_date": "20250802",
+      "preferred_language": "en",
+      "is_interpreter_required": false,
+      "invalid_flag": false,
+      "eligibility": true
+    }
+  ],
+  "nhsNumbers": [
+    "9997322886"
+  ]
+}


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description
Added Playwright test to test suite for blocked participant AMEND exception not raising to NBO.

<!-- Describe your changes in detail. -->

## Context

Added a Playwright test for DTOSS-7617 that verifies no exception is raised to NBO when attempting to amend a record for a participant that is marked as blocked.

- Added test files for participant ADD and AMEND scenarios.
- Implemented waiting logic to ensure DB operations complete.
- Verified the participant remains blocked and data is not updated.
- Test ensures no exception is raised to NBO as required.
- This helps complete coverage for the blocked participant scenarios in DTOSS-2622.
-  Test passes as expected and full suite passes.

<!-- Why is this change required? What problem does it solve? -->

This test is required as part of User Story DTOSS-2622 for Epic 4B.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [x] I have added tests to cover my changes
- [x] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
