### PR TITLE
fix: correct environment variable name from ParticipantDemographicDat…

### DIFF
--- a/infrastructure/tf-core/environments/development.tfvars
+++ b/infrastructure/tf-core/environments/development.tfvars
@@ -336,7 +336,7 @@ function_apps = {
           function_app_key = "ManageNemsSubscription"
         },
         {
-          env_var_name     = "ParticipantDemographicDataServiceURL"
+          env_var_name     = "DemographicDataServiceURL"
           function_app_key = "ParticipantDemographicDataService"
         }
       ],

--- a/infrastructure/tf-core/environments/integration.tfvars
+++ b/infrastructure/tf-core/environments/integration.tfvars
@@ -336,7 +336,7 @@ function_apps = {
           function_app_key = "ManageNemsSubscription"
         },
         {
-          env_var_name     = "ParticipantDemographicDataServiceURL"
+          env_var_name     = "DemographicDataServiceURL"
           function_app_key = "ParticipantDemographicDataService"
         }
       ],

--- a/infrastructure/tf-core/environments/nft.tfvars
+++ b/infrastructure/tf-core/environments/nft.tfvars
@@ -335,7 +335,7 @@ function_apps = {
           function_app_key = "ManageNemsSubscription"
         },
         {
-          env_var_name     = "ParticipantDemographicDataServiceURL"
+          env_var_name     = "DemographicDataServiceURL"
           function_app_key = "ParticipantDemographicDataService"
         }
       ],

--- a/infrastructure/tf-core/environments/preprod.tfvars
+++ b/infrastructure/tf-core/environments/preprod.tfvars
@@ -342,7 +342,7 @@ function_apps = {
           function_app_key = "ManageNemsSubscription"
         },
         {
-          env_var_name     = "ParticipantDemographicDataServiceURL"
+          env_var_name     = "DemographicDataServiceURL"
           function_app_key = "ParticipantDemographicDataService"
         }
       ],

--- a/infrastructure/tf-core/environments/production.tfvars
+++ b/infrastructure/tf-core/environments/production.tfvars
@@ -327,7 +327,7 @@ function_apps = {
           function_app_key = "ManageNemsSubscription"
         },
         {
-          env_var_name     = "ParticipantDemographicDataServiceURL"
+          env_var_name     = "DemographicDataServiceURL"
           function_app_key = "ParticipantDemographicDataService"
         }
       ],

--- a/infrastructure/tf-core/environments/sandbox.tfvars
+++ b/infrastructure/tf-core/environments/sandbox.tfvars
@@ -350,7 +350,7 @@ function_apps = {
           function_app_key = "ManageNemsSubscription"
         },
         {
-          env_var_name     = "ParticipantDemographicDataServiceURL"
+          env_var_name     = "DemographicDataServiceURL"
           function_app_key = "ParticipantDemographicDataService"
         }
       ],


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Fixed configuration mismatch in ProcessNemsUpdate terraform files where the environment variable name `ParticipantDemographicDataServiceURL` was changed to `DemographicDataServiceURL` to match what the code expects in `ProcessNemsUpdateConfig.cs`. This resolves the `System.ArgumentNullException: No URL was provided when registering DataService of type Model.ParticipantDemographic` error that was occurring during function startup.

## Context

The ProcessNemsUpdate function was failing to start in Azure with the error "No URL was provided when registering DataService of type Model.ParticipantDemographic" because there was a naming mismatch between:
- Code configuration: Expected `DemographicDataServiceURL`
- Terraform configuration: Provided `ParticipantDemographicDataServiceURL`

This prevented the dependency injection container from properly registering the `IDataServiceClient<ParticipantDemographic>` service with its required URL.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.