### PR TITLE
fix: Retrieve PDS Demographic service bus connection string - named explicitly to match terraform

### DIFF
--- a/application/CohortManager/src/Functions/DemographicServices/RetrievePDSDemographic/Program.cs
+++ b/application/CohortManager/src/Functions/DemographicServices/RetrievePDSDemographic/Program.cs
@@ -25,7 +25,7 @@ var host = new HostBuilder()
     })
     .AddJwtTokenSigning(config.UseFakePDSServices)
     .AddTelemetry()
-    .AddServiceBusClient(config.ServiceBusConnectionString)
+    .AddServiceBusClient(config.EffectiveServiceBusConnectionString)
     .AddHttpClient(config.UseFakePDSServices)
     .Build();
 

--- a/application/CohortManager/src/Functions/DemographicServices/RetrievePDSDemographic/Program.cs
+++ b/application/CohortManager/src/Functions/DemographicServices/RetrievePDSDemographic/Program.cs
@@ -25,7 +25,7 @@ var host = new HostBuilder()
     })
     .AddJwtTokenSigning(config.UseFakePDSServices)
     .AddTelemetry()
-    .AddServiceBusClient(config.EffectiveServiceBusConnectionString)
+    .AddServiceBusClient(config.ServiceBusConnectionString_client_internal)
     .AddHttpClient(config.UseFakePDSServices)
     .Build();
 

--- a/application/CohortManager/src/Functions/DemographicServices/RetrievePDSDemographic/RetrievePDSDemographicConfig.cs
+++ b/application/CohortManager/src/Functions/DemographicServices/RetrievePDSDemographic/RetrievePDSDemographicConfig.cs
@@ -1,11 +1,9 @@
 namespace NHS.CohortManager.DemographicServices;
 
 using System.ComponentModel.DataAnnotations;
-using Microsoft.Extensions.Configuration;
 
 public class RetrievePDSDemographicConfig
 {
-
     [Required]
     public required string RetrievePdsParticipantURL { get; set; }
 
@@ -24,33 +22,9 @@ public class RetrievePDSDemographicConfig
     [Required]
     public required string ParticipantManagementTopic { get; set; }
 
-    [Required]
-    public required string ServiceBusConnectionString { get; set; }
+    public string ServiceBusConnectionString_client_internal { get; set; }
 
     public required bool UseFakePDSServices { get; set; } = false;
+
     public string ClientId { get; set; } = string.Empty;
-
-    [ConfigurationKeyName("ServiceBusConnectionString_client_internal")]
-    public string? ServiceBusConnectionStringClientInternal { get; set; }
-
-    [Required]
-    public string EffectiveServiceBusConnectionString
-    {
-        get
-        {
-            if (!string.IsNullOrWhiteSpace(ServiceBusConnectionString))
-            {
-                return ServiceBusConnectionString;
-            }
-
-            if (!string.IsNullOrWhiteSpace(ServiceBusConnectionStringClientInternal))
-            {
-                return ServiceBusConnectionStringClientInternal;
-            }
-
-            throw new InvalidOperationException(
-                "Missing Service Bus connection string. " +
-                "Set ServiceBusConnectionString or ServiceBusConnectionString_client_internal.");
-        }
-    }
 }

--- a/application/CohortManager/src/Functions/DemographicServices/RetrievePDSDemographic/RetrievePDSDemographicConfig.cs
+++ b/application/CohortManager/src/Functions/DemographicServices/RetrievePDSDemographic/RetrievePDSDemographicConfig.cs
@@ -23,33 +23,10 @@ public class RetrievePDSDemographicConfig
     [Required]
     public required string ParticipantManagementTopic { get; set; }
 
-    public string ServiceBusConnectionString_client_internal { get; set; }
+    [Required]
+    public required string ServiceBusConnectionString_client_internal { get; set; }
 
     public required bool UseFakePDSServices { get; set; } = false;
 
     public string ClientId { get; set; } = string.Empty;
-
-    [ConfigurationKeyName("ServiceBusConnectionString_client_internal")]
-    public string? ServiceBusConnectionStringClientInternal { get; set; }
-
-    [Required]
-    public string EffectiveServiceBusConnectionString
-    {
-        get
-        {
-            if (!string.IsNullOrWhiteSpace(ServiceBusConnectionString))
-            {
-                return ServiceBusConnectionString;
-            }
-
-            if (!string.IsNullOrWhiteSpace(ServiceBusConnectionStringClientInternal))
-            {
-                return ServiceBusConnectionStringClientInternal;
-            }
-
-            throw new InvalidOperationException(
-                "Missing Service Bus connection string. " +
-                "Set ServiceBusConnectionString or ServiceBusConnectionString_client_internal.");
-        }
-    }
 }

--- a/application/CohortManager/src/Functions/DemographicServices/RetrievePDSDemographic/RetrievePDSDemographicConfig.cs
+++ b/application/CohortManager/src/Functions/DemographicServices/RetrievePDSDemographic/RetrievePDSDemographicConfig.cs
@@ -1,6 +1,7 @@
 namespace NHS.CohortManager.DemographicServices;
 
 using System.ComponentModel.DataAnnotations;
+using Microsoft.Extensions.Configuration;
 
 public class RetrievePDSDemographicConfig
 {
@@ -28,4 +29,28 @@ public class RetrievePDSDemographicConfig
 
     public required bool UseFakePDSServices { get; set; } = false;
     public string ClientId { get; set; } = string.Empty;
+
+    [ConfigurationKeyName("ServiceBusConnectionString_client_internal")]
+    public string? ServiceBusConnectionStringClientInternal { get; set; }
+
+    [Required]
+    public string EffectiveServiceBusConnectionString
+    {
+        get
+        {
+            if (!string.IsNullOrWhiteSpace(ServiceBusConnectionString))
+            {
+                return ServiceBusConnectionString;
+            }
+
+            if (!string.IsNullOrWhiteSpace(ServiceBusConnectionStringClientInternal))
+            {
+                return ServiceBusConnectionStringClientInternal;
+            }
+
+            throw new InvalidOperationException(
+                "Missing Service Bus connection string. " +
+                "Set ServiceBusConnectionString or ServiceBusConnectionString_client_internal.");
+        }
+    }
 }


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

This PR updates the RetrievePDSDemographic function to use a more specific Service Bus connection string configuration. The change replaces the generic `ServiceBusConnectionString` with `ServiceBusConnectionString_client_internal` to match with terraform, without the use of decorators.

## Context

RetrievePDSDemographic is still not starting in dev, this hopes to rectify the issue.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the contributing guidelines (../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.