### PR TITLE
fix: Update response serialisation for demographic record in RetrievePDSDemographic

### DIFF
--- a/application/CohortManager/src/Functions/DemographicServices/RetrievePDSDemographic/RetrievePDSDemographic.cs
+++ b/application/CohortManager/src/Functions/DemographicServices/RetrievePDSDemographic/RetrievePDSDemographic.cs
@@ -84,7 +84,7 @@ public class RetrievePdsDemographic
             var upsertResult = await _pdsProcessor.UpsertDemographicRecordFromPDS(participantDemographic);
 
             return upsertResult ?
-                _createResponse.CreateHttpResponse(HttpStatusCode.OK, req, JsonSerializer.Serialize(participantDemographic)) :
+                _createResponse.CreateHttpResponse(HttpStatusCode.OK, req, JsonSerializer.Serialize(participantDemographic.ToDemographic())) :
                 _createResponse.CreateHttpResponse(HttpStatusCode.InternalServerError, req);
         }
         catch (Exception ex)


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

 **JSON Response Fix**: Fixes a JSON serialization issue where `ParticipantId` was being returned as a number instead of a string, causing deserialization errors in downstream services (ProcessNemsUpdate)

## Context

**API Response Issue**: The function was serializing the `ParticipantDemographic` object directly, which returned `ParticipantId` as a number. This caused JSON deserialization errors in ProcessNemsUpdate which expected `ParticipantId` as a string. The fix ensures the response uses the `ToDemographic()` conversion method to maintain API contract consistency.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.