### PR TITLE
feat: DTOSS-10566 define asp SKU per instance

### DIFF
--- a/infrastructure/tf-core/app_service_plan.tf
+++ b/infrastructure/tf-core/app_service_plan.tf
@@ -31,7 +31,7 @@ module "app-service-plan" {
   log_analytics_workspace_id                        = data.terraform_remote_state.audit.outputs.log_analytics_workspace_id[local.primary_region]
   monitor_diagnostic_setting_appserviceplan_metrics = local.monitor_diagnostic_setting_appserviceplan_metrics
   os_type                                           = lookup(each.value, "os_type", var.app_service_plan.os_type)
-  sku_name                                          = lookup(each.value, "sku_name", var.app_service_plan.sku_name)
+  sku_name                                          = each.value.sku_name
   zone_balancing_enabled                            = lookup(each.value, "zone_balancing_enabled", var.app_service_plan.zone_balancing_enabled)
   vnet_integration_subnet_id                        = module.subnets["${module.regions_config[each.value.region].names.subnet}-apps"].id
   wildcard_ssl_cert_name                            = each.value.wildcard_ssl_cert_key

--- a/infrastructure/tf-core/environments/development.tfvars
+++ b/infrastructure/tf-core/environments/development.tfvars
@@ -107,7 +107,6 @@ routes = {
 
 app_service_plan = {
   os_type                  = "Linux"
-  sku_name                 = "P3v3"
   vnet_integration_enabled = true
 
   autoscale = {
@@ -141,6 +140,7 @@ app_service_plan = {
 
   instances = {
     DefaultPlan = {
+      sku_name = "P1v3"
       autoscale_override = {
         scaling_rule = {
           metric = "CpuPercentage"
@@ -152,6 +152,7 @@ app_service_plan = {
       }
     }
     HighLoadFunctions = {
+      sku_name = "P2v3"
       autoscale_override = {
         scaling_rule = {
           metric = "CpuPercentage"
@@ -170,6 +171,7 @@ app_service_plan = {
       }
     }
     RetrieveMeshFile = {
+      sku_name = "P3v3"
       autoscale_override = {
         scaling_rule = {
           metric = "CpuPercentage"

--- a/infrastructure/tf-core/environments/development.tfvars
+++ b/infrastructure/tf-core/environments/development.tfvars
@@ -197,9 +197,29 @@ app_service_plan = {
         scaling_rule = {
           metric = "CpuPercentage"
 
-          capacity_min = "1"
-          capacity_max = "1"
-          capacity_def = "1"
+      capacity_min = "1"
+      capacity_max = "1"
+      capacity_def = "1"
+
+      time_grain       = "PT1M"
+      statistic        = "Average"
+      time_window      = "PT1M"
+      time_aggregation = "Average"
+
+      inc_operator        = "GreaterThanOrEqual"
+      inc_threshold       = 20
+      inc_scale_direction = "Increase"
+      inc_scale_type      = "ExactCount"
+      inc_scale_value     = 1
+      inc_scale_cooldown  = "PT10M"
+
+      dec_operator        = "LessThan"
+      dec_threshold       = 20
+      dec_scale_direction = "Decrease"
+      dec_scale_type      = "ExactCount"
+      dec_scale_value     = 1
+      dec_scale_cooldown  = "PT5M"
+
         }
       }
     }
@@ -228,9 +248,29 @@ app_service_plan = {
         scaling_rule = {
           metric = "CpuPercentage"
 
-          capacity_min = "1"
-          capacity_max = "1"
-          capacity_def = "1"
+      capacity_min = "1"
+      capacity_max = "1"
+      capacity_def = "1"
+
+      time_grain       = "PT1M"
+      statistic        = "Average"
+      time_window      = "PT1M"
+      time_aggregation = "Average"
+
+      inc_operator        = "GreaterThanOrEqual"
+      inc_threshold       = 20
+      inc_scale_direction = "Increase"
+      inc_scale_type      = "ExactCount"
+      inc_scale_value     = 1
+      inc_scale_cooldown  = "PT10M"
+
+      dec_operator        = "LessThan"
+      dec_threshold       = 20
+      dec_scale_direction = "Decrease"
+      dec_scale_type      = "ExactCount"
+      dec_scale_value     = 1
+      dec_scale_cooldown  = "PT5M"
+
         }
       }
     }

--- a/infrastructure/tf-core/environments/development.tfvars
+++ b/infrastructure/tf-core/environments/development.tfvars
@@ -139,58 +139,7 @@ app_service_plan = {
   }
 
   instances = {
-    DefaultPlan = {
-      sku_name = "P1v3"
-      autoscale_override = {
-        scaling_rule = {
-          metric = "CpuPercentage"
 
-          capacity_min = "1"
-          capacity_max = "4"
-          capacity_def = "2"
-        }
-      }
-    }
-    HighLoadFunctions = {
-      sku_name = "P2v3"
-      autoscale_override = {
-        scaling_rule = {
-          metric = "CpuPercentage"
-
-          capacity_min = "1"
-          capacity_max = "4"
-          capacity_def = "2"
-
-          inc_threshold   = 5
-          dec_threshold   = 5
-          inc_scale_value = 4
-
-          dec_scale_type  = "ChangeCount"
-          dec_scale_value = 1
-        }
-      }
-    }
-    RetrieveMeshFile = {
-      sku_name = "P3v3"
-      autoscale_override = {
-        scaling_rule = {
-          metric = "CpuPercentage"
-
-          capacity_min = "1"
-          capacity_max = "1"
-          capacity_def = "1"
-
-          inc_threshold   = 5
-          dec_threshold   = 5
-          inc_scale_value = 1
-
-          dec_scale_type  = "ChangeCount"
-          dec_scale_value = 1
-        }
-      }
-    }
-
-    ## New Instances
     NonScaling = {
       sku_name = "P2v3"
       autoscale_override = {

--- a/infrastructure/tf-core/environments/development.tfvars
+++ b/infrastructure/tf-core/environments/development.tfvars
@@ -1196,7 +1196,7 @@ linux_web_app = {
 
     FrontEndUi = {
       name_suffix          = "web"
-      app_service_plan_key = "DefaultPlan"
+      app_service_plan_key = "NonScaling"
       env_vars = {
         static = {
           AUTH_CIS2_ISSUER_URL = "https://am.nhsint.auth-ptl.cis2.spineservices.nhs.uk:443"

--- a/infrastructure/tf-core/environments/development.tfvars
+++ b/infrastructure/tf-core/environments/development.tfvars
@@ -189,6 +189,109 @@ app_service_plan = {
         }
       }
     }
+
+    ## New Instances
+    NonScaling = {
+      sku_name = "P2v3"
+      autoscale_override = {
+        scaling_rule = {
+          metric = "CpuPercentage"
+
+          capacity_min = "1"
+          capacity_max = "1"
+          capacity_def = "1"
+        }
+      }
+    }
+    CohortDistributionPlan = {
+      sku_name = "P3v3"
+      autoscale_override = {
+        scaling_rule = {
+          metric = "CpuPercentage"
+
+          capacity_min = "1"
+          capacity_max = "5"
+          capacity_def = "1"
+
+          inc_threshold   = 5
+          dec_threshold   = 5
+          inc_scale_value = 5
+
+          dec_scale_type  = "ChangeCount"
+          dec_scale_value = 1
+        }
+      }
+    }
+    TarpitPlan = {
+      sku_name = "P1v3"
+      autoscale_override = {
+        scaling_rule = {
+          metric = "CpuPercentage"
+
+          capacity_min = "1"
+          capacity_max = "1"
+          capacity_def = "1"
+        }
+      }
+    }
+    ParticipantManagementPlan = {
+      sku_name = "P3v3"
+      autoscale_override = {
+        scaling_rule = {
+          metric = "CpuPercentage"
+
+          capacity_min = "1"
+          capacity_max = "5"
+          capacity_def = "1"
+
+          inc_threshold   = 5
+          dec_threshold   = 5
+          inc_scale_value = 5
+
+          dec_scale_type  = "ChangeCount"
+          dec_scale_value = 1
+        }
+      }
+    }
+    CohortDistributionOrchPlan = {
+      sku_name = "P1v3"
+      autoscale_override = {
+        scaling_rule = {
+          metric = "CpuPercentage"
+
+          capacity_min = "1"
+          capacity_max = "3"
+          capacity_def = "1"
+
+          inc_threshold   = 5
+          dec_threshold   = 5
+          inc_scale_value = 3
+
+          dec_scale_type  = "ChangeCount"
+          dec_scale_value = 1
+        }
+      }
+    }
+    ParticipantManagementOrchPlan = {
+      sku_name = "P1v3"
+      autoscale_override = {
+        scaling_rule = {
+          metric = "CpuPercentage"
+
+          capacity_min = "1"
+          capacity_max = "3"
+          capacity_def = "1"
+
+          inc_threshold   = 5
+          dec_threshold   = 5
+          inc_scale_value = 3
+
+          dec_scale_type  = "ChangeCount"
+          dec_scale_value = 1
+        }
+      }
+    }
+
   }
 }
 
@@ -244,7 +347,7 @@ function_apps = {
     ReceiveCaasFile = {
       name_suffix                  = "receive-caas-file"
       function_endpoint_name       = "ReceiveCaasFile"
-      app_service_plan_key         = "DefaultPlan"
+      app_service_plan_key         = "NonScaling"
       db_connection_string         = "DtOsDatabaseConnectionString"
       service_bus_connections      = ["internal"]
       storage_account_env_var_name = "caasfolder_STORAGE"
@@ -302,7 +405,7 @@ function_apps = {
     RetrieveMeshFile = {
       name_suffix                  = "retrieve-mesh-file"
       function_endpoint_name       = "RetrieveMeshFile"
-      app_service_plan_key         = "RetrieveMeshFile"
+      app_service_plan_key         = "NonScaling"
       key_vault_url                = "KeyVaultConnectionString"
       storage_account_env_var_name = "caasfolder_STORAGE"
       app_urls = [
@@ -320,7 +423,7 @@ function_apps = {
     ProcessNemsUpdate = {
       name_suffix                  = "process-nems-update"
       function_endpoint_name       = "ProcessNemsUpdate"
-      app_service_plan_key         = "DefaultPlan"
+      app_service_plan_key         = "NonScaling"
       key_vault_url                = "KeyVaultConnectionString"
       storage_account_env_var_name = "nemsmeshfolder_STORAGE"
       service_bus_connections      = ["internal"]
@@ -357,7 +460,7 @@ function_apps = {
     ManageParticipant = {
       name_suffix             = "manage-participant"
       function_endpoint_name  = "ManageParticipant"
-      app_service_plan_key    = "DefaultPlan"
+      app_service_plan_key    = "ParticipantManagementOrchPlan"
       service_bus_connections = ["internal"]
       app_urls = [
         {
@@ -382,7 +485,7 @@ function_apps = {
     ManageServiceNowParticipant = {
       name_suffix             = "manage-servicenow-participant"
       function_endpoint_name  = "ManageServiceNowParticipant"
-      app_service_plan_key    = "DefaultPlan"
+      app_service_plan_key    = "NonScaling"
       service_bus_connections = ["internal"]
       app_urls = [
         {
@@ -413,7 +516,7 @@ function_apps = {
     update-blocked-flag = {
       name_suffix            = "update-blocked-flag"
       function_endpoint_name = "UpdateBlockedFlag"
-      app_service_plan_key   = "DefaultPlan"
+      app_service_plan_key   = "NonScaling"
       app_urls = [
         {
           env_var_name     = "ParticipantDemographicDataServiceURL"
@@ -447,7 +550,7 @@ function_apps = {
     DeleteParticipant = {
       name_suffix            = "delete-participant"
       function_endpoint_name = "DeleteParticipant"
-      app_service_plan_key   = "DefaultPlan"
+      app_service_plan_key   = "ParticipantManagementPlan"
       app_urls = [
         {
           env_var_name     = "ExceptionFunctionURL"
@@ -463,7 +566,7 @@ function_apps = {
     CreateException = {
       name_suffix             = "create-exception"
       function_endpoint_name  = "CreateException"
-      app_service_plan_key    = "DefaultPlan"
+      app_service_plan_key    = "ParticipantManagementPlan"
       db_connection_string    = "DtOsDatabaseConnectionString"
       service_bus_connections = ["internal"]
       app_urls = [
@@ -489,7 +592,7 @@ function_apps = {
     GetValidationExceptions = {
       name_suffix            = "get-validation-exceptions"
       function_endpoint_name = "GetValidationExceptions"
-      app_service_plan_key   = "DefaultPlan"
+      app_service_plan_key   = "NonScaling"
       db_connection_string   = "DtOsDatabaseConnectionString"
       app_urls = [
         {
@@ -513,7 +616,7 @@ function_apps = {
     StaticValidation = {
       name_suffix             = "static-validation"
       function_endpoint_name  = "StaticValidation"
-      app_service_plan_key    = "DefaultPlan"
+      app_service_plan_key    = "CohortDistributionPlan"
       db_connection_string    = "DtOsDatabaseConnectionString"
       service_bus_connections = ["internal"]
       app_urls = [
@@ -537,7 +640,7 @@ function_apps = {
     LookupValidation = {
       name_suffix             = "lookup-validation"
       function_endpoint_name  = "LookupValidation"
-      app_service_plan_key    = "DefaultPlan"
+      app_service_plan_key    = "CohortDistributionPlan"
       db_connection_string    = "DtOsDatabaseConnectionString"
       service_bus_connections = ["internal"]
       app_urls = [
@@ -577,7 +680,7 @@ function_apps = {
     RetrieveCohortDistributionData = {
       name_suffix            = "retrieve-cohort-distribution-data"
       function_endpoint_name = "RetrieveCohortDistributionData"
-      app_service_plan_key   = "DefaultPlan"
+      app_service_plan_key   = "CohortDistributionPlan"
       db_connection_string   = "DtOsDatabaseConnectionString"
       app_urls = [
         {
@@ -601,7 +704,7 @@ function_apps = {
     TransformDataService = {
       name_suffix            = "transform-data-service"
       function_endpoint_name = "TransformDataService"
-      app_service_plan_key   = "DefaultPlan"
+      app_service_plan_key   = "CohortDistributionPlan"
       db_connection_string   = "DtOsDatabaseConnectionString"
       app_urls = [
         {
@@ -639,7 +742,7 @@ function_apps = {
     DistributeParticipant = {
       name_suffix             = "distribute-participant"
       function_endpoint_name  = "DistributeParticipant"
-      app_service_plan_key    = "DefaultPlan"
+      app_service_plan_key    = "CohortDistributionOrchPlan"
       service_bus_connections = ["internal"]
       app_urls = [
         {
@@ -693,7 +796,7 @@ function_apps = {
     RemoveValidationExceptionData = {
       name_suffix            = "remove-validation-exception-data"
       function_endpoint_name = "RemoveValidationExceptionData"
-      app_service_plan_key   = "DefaultPlan"
+      app_service_plan_key   = "CohortDistributionPlan"
       db_connection_string   = "DtOsDatabaseConnectionString"
       app_urls = [
         {
@@ -718,7 +821,7 @@ function_apps = {
     RetrieveCohortRequestAudit = {
       name_suffix            = "retrieve-cohort-request-audit"
       function_endpoint_name = "RetrieveCohortRequestAudit"
-      app_service_plan_key   = "DefaultPlan"
+      app_service_plan_key   = "NonScaling"
       db_connection_string   = "DtOsDatabaseConnectionString"
       app_urls = [
         {
@@ -739,7 +842,7 @@ function_apps = {
     ParticipantManagementDataService = {
       name_suffix            = "participant-management-data-service"
       function_endpoint_name = "ParticipantManagementDataService"
-      app_service_plan_key   = "HighLoadFunctions"
+      app_service_plan_key   = "ParticipantManagementPlan"
       db_connection_string   = "DtOsDatabaseConnectionString"
       app_urls = [
         {
@@ -752,7 +855,7 @@ function_apps = {
     ParticipantDemographicDataService = {
       name_suffix            = "participant-demographic-data-service"
       function_endpoint_name = "ParticipantDemographicDataService"
-      app_service_plan_key   = "HighLoadFunctions"
+      app_service_plan_key   = "ParticipantManagementPlan"
       db_connection_string   = "DtOsDatabaseConnectionString"
       app_urls = [
         {
@@ -768,7 +871,7 @@ function_apps = {
     DurableDemographicFunction = {
       name_suffix            = "durable-demographic-function"
       function_endpoint_name = "DurableDemographicFunction"
-      app_service_plan_key   = "DefaultPlan"
+      app_service_plan_key   = "ParticipantManagementPlan"
       db_connection_string   = "DtOsDatabaseConnectionString"
       app_urls = [
         {
@@ -788,7 +891,7 @@ function_apps = {
     GPPracticeDataService = {
       name_suffix            = "gppractice-data-service"
       function_endpoint_name = "GPPracticeDataService"
-      app_service_plan_key   = "DefaultPlan"
+      app_service_plan_key   = "TarpitPlan"
       db_connection_string   = "DtOsDatabaseConnectionString"
       app_urls = [
         {
@@ -804,7 +907,7 @@ function_apps = {
     ExceptionManagementDataService = {
       name_suffix            = "exception-management-data-service"
       function_endpoint_name = "ExceptionManagementDataService"
-      app_service_plan_key   = "DefaultPlan"
+      app_service_plan_key   = "CohortDistributionPlan"
       db_connection_string   = "DtOsDatabaseConnectionString"
       app_urls = [
         {
@@ -820,7 +923,7 @@ function_apps = {
     GeneCodeLkpDataService = {
       name_suffix            = "gene-code-lkp-data-service"
       function_endpoint_name = "GeneCodeLkpDataService"
-      app_service_plan_key   = "DefaultPlan"
+      app_service_plan_key   = "TarpitPlan"
       db_connection_string   = "DtOsDatabaseConnectionString"
       app_urls = [
         {
@@ -836,7 +939,7 @@ function_apps = {
     HigherRiskReferralReasonLkpDataService = {
       name_suffix            = "higher-risk-referral-reason-lkp-data-service"
       function_endpoint_name = "HigherRiskReferralReasonLkpDataService"
-      app_service_plan_key   = "DefaultPlan"
+      app_service_plan_key   = "TarpitPlan"
       db_connection_string   = "DtOsDatabaseConnectionString"
       app_urls = [
         {
@@ -852,7 +955,7 @@ function_apps = {
     CohortDistributionDataService = {
       name_suffix            = "cohort-distribution-data-service"
       function_endpoint_name = "CohortDistributionDataService"
-      app_service_plan_key   = "HighLoadFunctions"
+      app_service_plan_key   = "CohortDistributionPlan"
       db_connection_string   = "DtOsDatabaseConnectionString"
       app_urls = [
         {
@@ -868,7 +971,7 @@ function_apps = {
     ServiceNowMessageHandler = {
       name_suffix             = "servicenow-message-handler"
       function_endpoint_name  = "ServiceNowMessageHandler"
-      app_service_plan_key    = "DefaultPlan"
+      app_service_plan_key    = "NonScaling"
       key_vault_url           = "KeyVaultConnectionString"
       service_bus_connections = ["internal"]
       env_vars_static = {
@@ -882,7 +985,7 @@ function_apps = {
     BsSelectRequestAuditDataService = {
       name_suffix            = "bs-request-audit-data-service"
       function_endpoint_name = "BsSelectRequestAuditDataService"
-      app_service_plan_key   = "DefaultPlan"
+      app_service_plan_key   = "CohortDistributionPlan"
       db_connection_string   = "DtOsDatabaseConnectionString"
       app_urls = [
         {
@@ -898,7 +1001,7 @@ function_apps = {
     ScreeningLkpDataService = {
       name_suffix            = "screening-lkp-data-service"
       function_endpoint_name = "ScreeningLkpDataService"
-      app_service_plan_key   = "DefaultPlan"
+      app_service_plan_key   = "NonScaling"
       db_connection_string   = "DtOsDatabaseConnectionString"
       app_urls = [
         {
@@ -914,7 +1017,7 @@ function_apps = {
     ServiceNowCasesDataService = {
       name_suffix            = "servicenow-cases-data-service"
       function_endpoint_name = "ServiceNowCasesDataService"
-      app_service_plan_key   = "DefaultPlan"
+      app_service_plan_key   = "NonScaling"
       db_connection_string   = "DtOsDatabaseConnectionString"
       app_urls = [
         {
@@ -930,7 +1033,7 @@ function_apps = {
     ServiceNowCohortLookup = {
       name_suffix            = "servicenow-cohort-lookup"
       function_endpoint_name = "ServiceNowCohortLookup"
-      app_service_plan_key   = "DefaultPlan"
+      app_service_plan_key   = "NonScaling"
       app_urls = [
         {
           env_var_name     = "ExceptionFunctionURL"
@@ -950,7 +1053,7 @@ function_apps = {
     RetrievePDSDemographic = {
       name_suffix             = "retrieve-pds-demographic"
       function_endpoint_name  = "RetrievePDSDemographic"
-      app_service_plan_key    = "DefaultPlan"
+      app_service_plan_key    = "NonScaling"
       service_bus_connections = ["internal"]
       key_vault_url           = "KeyVaultConnectionString"
       app_urls = [
@@ -981,7 +1084,7 @@ function_apps = {
     ManageNemsSubscription = {
       name_suffix            = "manage-nems-subscription"
       function_endpoint_name = "ManageNemsSubscription"
-      app_service_plan_key   = "DefaultPlan"
+      app_service_plan_key   = "NonScaling"
       db_connection_string   = "DtOsDatabaseConnectionString"
       key_vault_url          = "KeyVaultConnectionString"
       app_urls = [
@@ -1005,7 +1108,7 @@ function_apps = {
     ReferenceDataService = {
       name_suffix            = "reference-data-service"
       function_endpoint_name = "ReferenceDataService"
-      app_service_plan_key   = "DefaultPlan"
+      app_service_plan_key   = "NonScaling"
       db_connection_string   = "DtOsDatabaseConnectionString"
       app_urls = [
         {
@@ -1021,7 +1124,7 @@ function_apps = {
     NemsSubscribe = {
       name_suffix            = "nems-subscribe"
       function_endpoint_name = "NemsSubscribe"
-      app_service_plan_key   = "DefaultPlan"
+      app_service_plan_key   = "NonScaling"
       app_urls = [
         {
           env_var_name     = "ExceptionFunctionURL"
@@ -1044,7 +1147,7 @@ function_apps = {
     NemsMeshRetrieval = {
       name_suffix                  = "nems-mesh-retrieval"
       function_endpoint_name       = "NemsMeshRetrieval"
-      app_service_plan_key         = "RetrieveMeshFile"
+      app_service_plan_key         = "NonScaling"
       key_vault_url                = "KeyVaultConnectionString"
       storage_account_env_var_name = "nemsmeshfolder_STORAGE"
       app_urls = [
@@ -1064,7 +1167,7 @@ function_apps = {
     UpdateException = {
       name_suffix            = "update-exception"
       function_endpoint_name = "UpdateException"
-      app_service_plan_key   = "DefaultPlan"
+      app_service_plan_key   = "NonScaling"
       db_connection_string   = "DtOsDatabaseConnectionString"
       app_urls = [
         {

--- a/infrastructure/tf-core/function_app.tf
+++ b/infrastructure/tf-core/function_app.tf
@@ -163,7 +163,7 @@ locals {
 
             # Database connection string
             length(config.db_connection_string) > 0 ? {
-              (config.db_connection_string) = "Server=${module.regions_config[region].names.sql-server}.database.windows.net; Authentication=Active Directory Managed Identity; Database=${var.sqlserver.dbs.cohman.db_name_suffix}; ApplicationIntent=ReadWrite; Pooling=true; Connection Timeout=30; Max Pool Size=300;"
+              (config.db_connection_string) = "Server=${module.regions_config[region].names.sql-server}.database.windows.net; Authentication=Active Directory Managed Identity; Database=${var.sqlserver.dbs.cohman.db_name_suffix}; ApplicationIntent=ReadWrite; Pooling=true; Connection Timeout=30; Max Pool Size=100;"
             } : {},
 
             # Service Bus connections are stored in the config as a list of strings, so we need to iterate over them

--- a/infrastructure/tf-core/variables.tf
+++ b/infrastructure/tf-core/variables.tf
@@ -103,7 +103,6 @@ variable "regions" {
 variable "app_service_plan" {
   description = "Configuration for the app service plan"
   type = object({
-    sku_name                 = optional(string, "P2v3")
     os_type                  = optional(string, "Linux")
     vnet_integration_enabled = optional(bool, false)
     zone_balancing_enabled   = optional(bool, false)
@@ -134,6 +133,7 @@ variable "app_service_plan" {
     })
 
     instances = map(object({
+      sku_name           = optional(string, "P2v3")
       autoscale_override = optional(object({
         scaling_rule = object({
           metric              = optional(string)


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

This change includes a change to the App Service Plan implementation:

- the SKU defined per instance, not globally
- new set of instances with different SKUs and scaling rules, based on the performance analysis
- limit the Max Pool Size to 100 from 300

## Context

Changes from this branch have been successfully implemented in Development environment, following a required manual deletion of all the function apps in Dev:
https://dev.azure.com/nhse-dtos/dtos-cohort-manager/_build/results?buildId=25346&view=results

Roll out to NFT and Integration will happen once we're able to take those environments down for 1-2 hours.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [X] Refactoring (non-breaking change)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [X] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [X] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
