### PR TITLE
fix: RetrievePdsDemographic API to return PdsDemographic objects instead of ParticipantDemographic

### DIFF
--- a/application/CohortManager/src/Functions/DemographicServices/RetrievePDSDemographic/RetrievePDSDemographic.cs
+++ b/application/CohortManager/src/Functions/DemographicServices/RetrievePDSDemographic/RetrievePDSDemographic.cs
@@ -84,7 +84,7 @@ public class RetrievePdsDemographic
             var upsertResult = await _pdsProcessor.UpsertDemographicRecordFromPDS(participantDemographic);
 
             return upsertResult ?
-                _createResponse.CreateHttpResponse(HttpStatusCode.OK, req, JsonSerializer.Serialize(participantDemographic)) :
+                _createResponse.CreateHttpResponse(HttpStatusCode.OK, req, JsonSerializer.Serialize(participantDemographic.ToDemographic())) :
                 _createResponse.CreateHttpResponse(HttpStatusCode.InternalServerError, req);
         }
         catch (Exception ex)

--- a/application/CohortManager/src/Functions/DemographicServices/RetrievePDSDemographic/RetrievePDSDemographic.cs
+++ b/application/CohortManager/src/Functions/DemographicServices/RetrievePDSDemographic/RetrievePDSDemographic.cs
@@ -84,7 +84,7 @@ public class RetrievePdsDemographic
             var upsertResult = await _pdsProcessor.UpsertDemographicRecordFromPDS(participantDemographic);
 
             return upsertResult ?
-                _createResponse.CreateHttpResponse(HttpStatusCode.OK, req, JsonSerializer.Serialize(participantDemographic.ToDemographic())) :
+                _createResponse.CreateHttpResponse(HttpStatusCode.OK, req, JsonSerializer.Serialize(participantDemographic)) :
                 _createResponse.CreateHttpResponse(HttpStatusCode.InternalServerError, req);
         }
         catch (Exception ex)

--- a/application/CohortManager/src/Functions/DemographicServices/RetrievePDSDemographic/RetrievePDSDemographic.cs
+++ b/application/CohortManager/src/Functions/DemographicServices/RetrievePDSDemographic/RetrievePDSDemographic.cs
@@ -84,7 +84,7 @@ public class RetrievePdsDemographic
             var upsertResult = await _pdsProcessor.UpsertDemographicRecordFromPDS(participantDemographic);
 
             return upsertResult ?
-                _createResponse.CreateHttpResponse(HttpStatusCode.OK, req, JsonSerializer.Serialize(participantDemographic)) :
+                _createResponse.CreateHttpResponse(HttpStatusCode.OK, req, JsonSerializer.Serialize(pdsDemographic)) :
                 _createResponse.CreateHttpResponse(HttpStatusCode.InternalServerError, req);
         }
         catch (Exception ex)

--- a/application/CohortManager/src/Functions/NemsSubscriptionService/ProcessNemsUpdate/ProcessNemsUpdate.cs
+++ b/application/CohortManager/src/Functions/NemsSubscriptionService/ProcessNemsUpdate/ProcessNemsUpdate.cs
@@ -83,8 +83,7 @@ public class ProcessNemsUpdate
 
             pdsResponse.EnsureSuccessStatusCode();
 
-            var participantDemographic = await pdsResponse.Content.ReadFromJsonAsync<ParticipantDemographic>();
-            var retrievedPdsRecord = participantDemographic?.ToPdsDemographic();
+            var retrievedPdsRecord = await pdsResponse.Content.ReadFromJsonAsync<PdsDemographic>();
 
             if (retrievedPdsRecord?.NhsNumber == nhsNumber)
             {

--- a/application/CohortManager/src/Functions/NemsSubscriptionService/ProcessNemsUpdate/ProcessNemsUpdate.cs
+++ b/application/CohortManager/src/Functions/NemsSubscriptionService/ProcessNemsUpdate/ProcessNemsUpdate.cs
@@ -83,7 +83,8 @@ public class ProcessNemsUpdate
 
             pdsResponse.EnsureSuccessStatusCode();
 
-            var retrievedPdsRecord = await pdsResponse.Content.ReadFromJsonAsync<PdsDemographic>();
+            var participantDemographic = await pdsResponse.Content.ReadFromJsonAsync<ParticipantDemographic>();
+            var retrievedPdsRecord = participantDemographic?.ToPdsDemographic();
 
             if (retrievedPdsRecord?.NhsNumber == nhsNumber)
             {

--- a/application/CohortManager/src/Functions/ParticipantManagementServices/ManageServiceNowParticipant/ManageServiceNowParticipantFunction.cs
+++ b/application/CohortManager/src/Functions/ParticipantManagementServices/ManageServiceNowParticipant/ManageServiceNowParticipantFunction.cs
@@ -41,8 +41,8 @@ public class ManageServiceNowParticipantFunction
     {
         try
         {
-            var participantDemographic = await ValidateAndRetrieveParticipantFromPds(serviceNowParticipant);
-            if (participantDemographic is null)
+            var pdsDemographic = await ValidateAndRetrieveParticipantFromPds(serviceNowParticipant);
+            if (pdsDemographic is null)
             {
                 return;
             }
@@ -58,7 +58,7 @@ public class ManageServiceNowParticipantFunction
 
             // TODO: Add call to subscribe to NEMS (DTOSS-3881)
 
-            var participantForDistribution = new BasicParticipantCsvRecord(serviceNowParticipant, participantDemographic, participantManagement);
+            var participantForDistribution = new BasicParticipantCsvRecord(serviceNowParticipant, pdsDemographic, participantManagement);
 
             var sendToQueueSuccess = await _queueClient.AddAsync(participantForDistribution, _config.CohortDistributionTopic);
 
@@ -73,7 +73,7 @@ public class ManageServiceNowParticipantFunction
         }
     }
 
-    private async Task<ParticipantDemographic?> ValidateAndRetrieveParticipantFromPds(ServiceNowParticipant serviceNowParticipant)
+    private async Task<PdsDemographic?> ValidateAndRetrieveParticipantFromPds(ServiceNowParticipant serviceNowParticipant)
     {
         var pdsResponse = await _httpClientFunction.SendGetResponse($"{_config.RetrievePdsDemographicURL}?nhsNumber={serviceNowParticipant.NhsNumber}");
         string responseMessage = await _httpClientFunction.GetResponseText(pdsResponse);
@@ -90,37 +90,37 @@ public class ManageServiceNowParticipantFunction
             return null;
         }
 
-        var participantDemographic = await DeserializeParticipantDemographic(pdsResponse, serviceNowParticipant);
-        if (participantDemographic is null) return null;
+        var pdsDemographic = await DeserializePdsDemographic(pdsResponse, serviceNowParticipant);
+        if (pdsDemographic is null) return null;
 
-        return await ValidateParticipantData(serviceNowParticipant, participantDemographic)
-            ? participantDemographic
+        return await ValidateParticipantData(serviceNowParticipant, pdsDemographic)
+            ? pdsDemographic
             : null;
     }
 
-    private async Task<ParticipantDemographic?> DeserializeParticipantDemographic(HttpResponseMessage pdsResponse, ServiceNowParticipant serviceNowParticipant)
+    private async Task<PdsDemographic?> DeserializePdsDemographic(HttpResponseMessage pdsResponse, ServiceNowParticipant serviceNowParticipant)
     {
         var jsonString = await pdsResponse.Content.ReadAsStringAsync();
-        var participantDemographic = JsonSerializer.Deserialize<ParticipantDemographic>(jsonString);
+        var pdsDemographic = JsonSerializer.Deserialize<PdsDemographic>(jsonString);
 
-        if (participantDemographic is null)
+        if (pdsDemographic is null)
         {
-            await HandleException(new Exception($"Deserialisation of PDS for ServiceNow Participant response to {typeof(ParticipantDemographic)} returned null"), serviceNowParticipant, ServiceNowMessageType.AddRequestInProgress);
+            await HandleException(new Exception($"Deserialisation of PDS for ServiceNow Participant response to {typeof(PdsDemographic)} returned null"), serviceNowParticipant, ServiceNowMessageType.AddRequestInProgress);
             return null;
         }
 
-        return participantDemographic;
+        return pdsDemographic;
     }
 
-    private async Task<bool> ValidateParticipantData(ServiceNowParticipant serviceNowParticipant, ParticipantDemographic participantDemographic)
+    private async Task<bool> ValidateParticipantData(ServiceNowParticipant serviceNowParticipant, PdsDemographic pdsDemographic)
     {
-        if (participantDemographic.NhsNumber != serviceNowParticipant.NhsNumber)
+        if (pdsDemographic.NhsNumber != serviceNowParticipant.NhsNumber.ToString())
         {
             await HandleException(new Exception("NHS Numbers don't match for ServiceNow Participant and PDS, NHS Number must have been superseded"), serviceNowParticipant, ServiceNowMessageType.UnableToAddParticipant);
             return false;
         }
 
-        if (!CheckParticipantDataMatches(serviceNowParticipant, participantDemographic))
+        if (!CheckParticipantDataMatches(serviceNowParticipant, pdsDemographic))
         {
             await HandleException(new Exception("Participant data from ServiceNow does not match participant data from PDS"), serviceNowParticipant, ServiceNowMessageType.UnableToAddParticipant);
             return false;
@@ -219,11 +219,11 @@ public class ManageServiceNowParticipantFunction
         await SendServiceNowMessage(serviceNowParticipant.ServiceNowCaseNumber, serviceNowMessageType);
     }
 
-    private static bool CheckParticipantDataMatches(ServiceNowParticipant serviceNowParticipant, ParticipantDemographic participantDemographic)
+    private static bool CheckParticipantDataMatches(ServiceNowParticipant serviceNowParticipant, PdsDemographic pdsDemographic)
     {
-        return serviceNowParticipant.FirstName == participantDemographic.GivenName &&
-               serviceNowParticipant.FamilyName == participantDemographic.FamilyName &&
-               serviceNowParticipant.DateOfBirth.ToString("yyyy-MM-dd") == participantDemographic.DateOfBirth;
+        return serviceNowParticipant.FirstName == pdsDemographic.FirstName &&
+               serviceNowParticipant.FamilyName == pdsDemographic.FamilyName &&
+               serviceNowParticipant.DateOfBirth.ToString("yyyy-MM-dd") == pdsDemographic.DateOfBirth;
     }
 
     private async Task SendServiceNowMessage(string serviceNowCaseNumber, ServiceNowMessageType servicenowMessageType)

--- a/application/CohortManager/src/Functions/Shared/Model/BasicParticipantCsvRecord.cs
+++ b/application/CohortManager/src/Functions/Shared/Model/BasicParticipantCsvRecord.cs
@@ -17,7 +17,7 @@ public class BasicParticipantCsvRecord
 
     }
 
-    public BasicParticipantCsvRecord(ServiceNowParticipant serviceNowParticipant, ParticipantDemographic participantDemographic, ParticipantManagement? participantManagement)
+    public BasicParticipantCsvRecord(ServiceNowParticipant serviceNowParticipant, PdsDemographic pdsDemographic, ParticipantManagement? participantManagement)
     {
         FileName = serviceNowParticipant.ServiceNowCaseNumber;
         BasicParticipantData = new BasicParticipantData
@@ -29,7 +29,7 @@ public class BasicParticipantCsvRecord
         Participant = new Participant
         {
             ReferralFlag = "1",
-            Postcode = participantDemographic.PostCode,
+            Postcode = pdsDemographic.Postcode,
             ScreeningAcronym = "BSS" // TODO: Remove hardcoding when adding support for additional screening programs
         };
     }

--- a/application/CohortManager/src/Functions/Shared/Model/EFModels/ParticipantDemographic.cs
+++ b/application/CohortManager/src/Functions/Shared/Model/EFModels/ParticipantDemographic.cs
@@ -156,4 +156,48 @@ public class ParticipantDemographic
         };
     }
 
+    public PdsDemographic ToPdsDemographic()
+    {
+        return new PdsDemographic
+        {
+            ParticipantId = ParticipantId.ToString(),
+            NhsNumber = NhsNumber.ToString(),
+            SupersededByNhsNumber = SupersededByNhsNumber?.ToString(),
+            PrimaryCareProvider = PrimaryCareProvider,
+            PrimaryCareProviderEffectiveFromDate = PrimaryCareProviderFromDate,
+            CurrentPosting = CurrentPosting,
+            CurrentPostingEffectiveFromDate = CurrentPostingFromDate,
+            NamePrefix = NamePrefix,
+            FirstName = GivenName,
+            OtherGivenNames = OtherGivenName,
+            FamilyName = FamilyName,
+            PreviousFamilyName = PreviousFamilyName,
+            DateOfBirth = DateOfBirth,
+            Gender = Gender.HasValue ? (Gender?)Gender.Value : null,
+            AddressLine1 = AddressLine1,
+            AddressLine2 = AddressLine2,
+            AddressLine3 = AddressLine3,
+            AddressLine4 = AddressLine4,
+            AddressLine5 = AddressLine5,
+            Postcode = PostCode,
+            PafKey = PafKey,
+            UsualAddressEffectiveFromDate = UsualAddressFromDate,
+            DateOfDeath = DateOfDeath,
+            DeathStatus = DeathStatus.HasValue ? (Status?)DeathStatus.Value : null,
+            TelephoneNumber = TelephoneNumberHome,
+            TelephoneNumberEffectiveFromDate = TelephoneNumberHomeFromDate,
+            MobileNumber = TelephoneNumberMob,
+            MobileNumberEffectiveFromDate = TelephoneNumberMobFromDate,
+            EmailAddress = EmailAddressHome,
+            EmailAddressEffectiveFromDate = EmailAddressHomeFromDate,
+            PreferredLanguage = PreferredLanguage,
+            IsInterpreterRequired = InterpreterRequired.HasValue ? InterpreterRequired.Value.ToString() : null,
+            InvalidFlag = InvalidFlag.HasValue ? InvalidFlag.Value.ToString() : null,
+            RecordInsertDateTime = RecordInsertDateTime?.ToString("o"),
+            RecordUpdateDateTime = RecordUpdateDateTime?.ToString("o"),
+            ReasonForRemoval = null, // ParticipantDemographic doesn't have this field
+            RemovalEffectiveFromDate = null // ParticipantDemographic doesn't have this field
+        };
+    }
+
 }

--- a/application/CohortManager/src/Functions/Shared/Model/EFModels/ParticipantDemographic.cs
+++ b/application/CohortManager/src/Functions/Shared/Model/EFModels/ParticipantDemographic.cs
@@ -156,48 +156,5 @@ public class ParticipantDemographic
         };
     }
 
-    public PdsDemographic ToPdsDemographic()
-    {
-        return new PdsDemographic
-        {
-            ParticipantId = ParticipantId.ToString(),
-            NhsNumber = NhsNumber.ToString(),
-            SupersededByNhsNumber = SupersededByNhsNumber?.ToString(),
-            PrimaryCareProvider = PrimaryCareProvider,
-            PrimaryCareProviderEffectiveFromDate = PrimaryCareProviderFromDate,
-            CurrentPosting = CurrentPosting,
-            CurrentPostingEffectiveFromDate = CurrentPostingFromDate,
-            NamePrefix = NamePrefix,
-            FirstName = GivenName,
-            OtherGivenNames = OtherGivenName,
-            FamilyName = FamilyName,
-            PreviousFamilyName = PreviousFamilyName,
-            DateOfBirth = DateOfBirth,
-            Gender = Gender.HasValue ? (Gender?)Gender.Value : null,
-            AddressLine1 = AddressLine1,
-            AddressLine2 = AddressLine2,
-            AddressLine3 = AddressLine3,
-            AddressLine4 = AddressLine4,
-            AddressLine5 = AddressLine5,
-            Postcode = PostCode,
-            PafKey = PafKey,
-            UsualAddressEffectiveFromDate = UsualAddressFromDate,
-            DateOfDeath = DateOfDeath,
-            DeathStatus = DeathStatus.HasValue ? (Status?)DeathStatus.Value : null,
-            TelephoneNumber = TelephoneNumberHome,
-            TelephoneNumberEffectiveFromDate = TelephoneNumberHomeFromDate,
-            MobileNumber = TelephoneNumberMob,
-            MobileNumberEffectiveFromDate = TelephoneNumberMobFromDate,
-            EmailAddress = EmailAddressHome,
-            EmailAddressEffectiveFromDate = EmailAddressHomeFromDate,
-            PreferredLanguage = PreferredLanguage,
-            IsInterpreterRequired = InterpreterRequired.HasValue ? InterpreterRequired.Value.ToString() : null,
-            InvalidFlag = InvalidFlag.HasValue ? InvalidFlag.Value.ToString() : null,
-            RecordInsertDateTime = RecordInsertDateTime?.ToString("o"),
-            RecordUpdateDateTime = RecordUpdateDateTime?.ToString("o"),
-            ReasonForRemoval = null, // ParticipantDemographic doesn't have this field
-            RemovalEffectiveFromDate = null // ParticipantDemographic doesn't have this field
-        };
-    }
 
 }

--- a/tests/UnitTests/ParticipantManagementServicesTests/ManageServiceNowParticipantTests/ManageServiceNowParticipantFunctionTests.cs
+++ b/tests/UnitTests/ParticipantManagementServicesTests/ManageServiceNowParticipantTests/ManageServiceNowParticipantFunctionTests.cs
@@ -113,9 +113,9 @@ public class ManageServiceNowParticipantFunctionTests
     public async Task Run_WhenNhsNumberSuperseded_SendsServiceNowMessageType1()
     {
         // Arrange
-        var json = JsonSerializer.Serialize(new ParticipantDemographic
+        var json = JsonSerializer.Serialize(new PdsDemographic
         {
-            NhsNumber = 123
+            NhsNumber = "123"
         });
         _httpClientFunctionMock.Setup(x => x.SendGetResponse($"{_configMock.Object.Value.RetrievePdsDemographicURL}?nhsNumber={_serviceNowParticipant.NhsNumber}"))
             .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
@@ -205,10 +205,10 @@ public class ManageServiceNowParticipantFunctionTests
         string firstName, string familyName, string dateOfBirth)
     {
         // Arrange
-        var json = JsonSerializer.Serialize(new ParticipantDemographic
+        var json = JsonSerializer.Serialize(new PdsDemographic
         {
-            NhsNumber = _serviceNowParticipant.NhsNumber,
-            GivenName = firstName,
+            NhsNumber = _serviceNowParticipant.NhsNumber.ToString(),
+            FirstName = firstName,
             FamilyName = familyName,
             DateOfBirth = dateOfBirth
         });
@@ -241,7 +241,14 @@ public class ManageServiceNowParticipantFunctionTests
     public async Task Run_WhenServiceNowParticipantIsValidAndDoesNotExistInTheDataStore_AddsTheNewParticipant()
     {
         // Arrange
-        var json = JsonSerializer.Serialize(_demographic);
+        var json = JsonSerializer.Serialize(new PdsDemographic
+        {
+            NhsNumber = _serviceNowParticipant.NhsNumber.ToString(),
+            FirstName = _serviceNowParticipant.FirstName,
+            FamilyName = _serviceNowParticipant.FamilyName,
+            DateOfBirth = _serviceNowParticipant.DateOfBirth.ToString("yyyy-MM-dd"),
+            Postcode = "SW1A 2AA"
+        });
         _httpClientFunctionMock.Setup(x => x.SendGetResponse($"{_configMock.Object.Value.RetrievePdsDemographicURL}?nhsNumber={_serviceNowParticipant.NhsNumber}"))
             .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
             {
@@ -292,7 +299,14 @@ public class ManageServiceNowParticipantFunctionTests
     public async Task Run_WhenServiceNowParticipantIsValidAndExistsInTheDataStoreButIsBlocked_DoesNotUpdateTheParticipantAndSendsMessageType1()
     {
         // Arrange
-        var json = JsonSerializer.Serialize(_demographic);
+        var json = JsonSerializer.Serialize(new PdsDemographic
+        {
+            NhsNumber = _serviceNowParticipant.NhsNumber.ToString(),
+            FirstName = _serviceNowParticipant.FirstName,
+            FamilyName = _serviceNowParticipant.FamilyName,
+            DateOfBirth = _serviceNowParticipant.DateOfBirth.ToString("yyyy-MM-dd"),
+            Postcode = "SW1A 2AA"
+        });
         _httpClientFunctionMock.Setup(x => x.SendGetResponse($"{_configMock.Object.Value.RetrievePdsDemographicURL}?nhsNumber={_serviceNowParticipant.NhsNumber}"))
             .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
             {
@@ -341,7 +355,14 @@ public class ManageServiceNowParticipantFunctionTests
     public async Task Run_WhenServiceNowParticipantIsValidAndExistsInTheDataStoreAndIsNotBlocked_UpdatesTheParticipant()
     {
         // Arrange
-        var json = JsonSerializer.Serialize(_demographic);
+        var json = JsonSerializer.Serialize(new PdsDemographic
+        {
+            NhsNumber = _serviceNowParticipant.NhsNumber.ToString(),
+            FirstName = _serviceNowParticipant.FirstName,
+            FamilyName = _serviceNowParticipant.FamilyName,
+            DateOfBirth = _serviceNowParticipant.DateOfBirth.ToString("yyyy-MM-dd"),
+            Postcode = "SW1A 2AA"
+        });
         _httpClientFunctionMock.Setup(x => x.SendGetResponse($"{_configMock.Object.Value.RetrievePdsDemographicURL}?nhsNumber={_serviceNowParticipant.NhsNumber}"))
             .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
             {
@@ -405,7 +426,14 @@ public class ManageServiceNowParticipantFunctionTests
             ReasonForAdding = ServiceNowReasonsForAdding.VeryHighRisk
         };
 
-        var json = JsonSerializer.Serialize(_demographic);
+        var json = JsonSerializer.Serialize(new PdsDemographic
+        {
+            NhsNumber = _serviceNowParticipant.NhsNumber.ToString(),
+            FirstName = _serviceNowParticipant.FirstName,
+            FamilyName = _serviceNowParticipant.FamilyName,
+            DateOfBirth = _serviceNowParticipant.DateOfBirth.ToString("yyyy-MM-dd"),
+            Postcode = "SW1A 2AA"
+        });
 
         _httpClientFunctionMock.Setup(x => x.SendGetResponse($"{_configMock.Object.Value.RetrievePdsDemographicURL}?nhsNumber={vhrParticipant.NhsNumber}"))
             .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
@@ -461,7 +489,14 @@ public class ManageServiceNowParticipantFunctionTests
     public async Task Run_WhenServiceNowParticipantIsNotVhrAndDoesNotExistInDataStore_AddsNewParticipantWithoutVhrFlag()
     {
         // Arrange
-        var json = JsonSerializer.Serialize(_demographic);
+        var json = JsonSerializer.Serialize(new PdsDemographic
+        {
+            NhsNumber = _serviceNowParticipant.NhsNumber.ToString(),
+            FirstName = _serviceNowParticipant.FirstName,
+            FamilyName = _serviceNowParticipant.FamilyName,
+            DateOfBirth = _serviceNowParticipant.DateOfBirth.ToString("yyyy-MM-dd"),
+            Postcode = "SW1A 2AA"
+        });
 
         _httpClientFunctionMock.Setup(x => x.SendGetResponse($"{_configMock.Object.Value.RetrievePdsDemographicURL}?nhsNumber={_serviceNowParticipant.NhsNumber}"))
             .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
@@ -528,7 +563,14 @@ public class ManageServiceNowParticipantFunctionTests
             ReasonForAdding = ServiceNowReasonsForAdding.VeryHighRisk
         };
 
-        var json = JsonSerializer.Serialize(_demographic);
+        var json = JsonSerializer.Serialize(new PdsDemographic
+        {
+            NhsNumber = _serviceNowParticipant.NhsNumber.ToString(),
+            FirstName = _serviceNowParticipant.FirstName,
+            FamilyName = _serviceNowParticipant.FamilyName,
+            DateOfBirth = _serviceNowParticipant.DateOfBirth.ToString("yyyy-MM-dd"),
+            Postcode = "SW1A 2AA"
+        });
 
         var existingParticipant = new ParticipantManagement
         {
@@ -594,7 +636,14 @@ public class ManageServiceNowParticipantFunctionTests
     public async Task Run_WhenParticipantExistsWithVhrFlagAlreadySet_MaintainsVhrFlag()
     {
         // Arrange
-        var json = JsonSerializer.Serialize(_demographic);
+        var json = JsonSerializer.Serialize(new PdsDemographic
+        {
+            NhsNumber = _serviceNowParticipant.NhsNumber.ToString(),
+            FirstName = _serviceNowParticipant.FirstName,
+            FamilyName = _serviceNowParticipant.FamilyName,
+            DateOfBirth = _serviceNowParticipant.DateOfBirth.ToString("yyyy-MM-dd"),
+            Postcode = "SW1A 2AA"
+        });
 
         var existingParticipant = new ParticipantManagement
         {
@@ -659,7 +708,14 @@ public class ManageServiceNowParticipantFunctionTests
     public async Task Run_WhenNonVhrParticipantExistsWithNullVhrFlag_LeavesVhrFlagAsNull()
     {
         // Arrange
-        var json = JsonSerializer.Serialize(_demographic);
+        var json = JsonSerializer.Serialize(new PdsDemographic
+        {
+            NhsNumber = _serviceNowParticipant.NhsNumber.ToString(),
+            FirstName = _serviceNowParticipant.FirstName,
+            FamilyName = _serviceNowParticipant.FamilyName,
+            DateOfBirth = _serviceNowParticipant.DateOfBirth.ToString("yyyy-MM-dd"),
+            Postcode = "SW1A 2AA"
+        });
 
         var existingParticipant = new ParticipantManagement
         {

--- a/tests/UnitTests/ParticipantManagementServicesTests/UpdateBlockedFlagTests/UpdateBlockedFlagTests.cs
+++ b/tests/UnitTests/ParticipantManagementServicesTests/UpdateBlockedFlagTests/UpdateBlockedFlagTests.cs
@@ -122,9 +122,9 @@ public class UpdateBlockedFlagTests
 
 
         var pdsDemoResponse = JsonSerializer.Serialize(
-            new ParticipantDemographic
+            new PdsDemographic
             {
-                NhsNumber = 6427635034,
+                NhsNumber = "6427635034",
                 FamilyName = "Jones",
                 DateOfBirth = "19231012"
             });
@@ -256,9 +256,9 @@ public class UpdateBlockedFlagTests
 
 
         var pdsDemoResponse = JsonSerializer.Serialize(
-            new ParticipantDemographic
+            new PdsDemographic
             {
-                NhsNumber = 6427635034,
+                NhsNumber = "6427635034",
                 FamilyName = "Davies",
                 DateOfBirth = "19231012"
             });
@@ -329,9 +329,9 @@ public class UpdateBlockedFlagTests
             .Returns(Task.FromResult<ParticipantDemographic>(null!));
 
         var pdsDemoResponse = JsonSerializer.Serialize(
-            new ParticipantDemographic
+            new PdsDemographic
             {
-                NhsNumber = 6427635034,
+                NhsNumber = "6427635034",
                 FamilyName = "Jones",
                 DateOfBirth = "19231012"
             });
@@ -367,9 +367,9 @@ public class UpdateBlockedFlagTests
             .Returns(Task.FromResult<ParticipantDemographic>(null!));
 
         var pdsDemoResponse = JsonSerializer.Serialize(
-            new ParticipantDemographic
+            new PdsDemographic
             {
-                NhsNumber = 6427635034,
+                NhsNumber = "6427635034",
                 FamilyName = "Jones",
                 DateOfBirth = "19231012"
             });


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

This PR implements an architectural improvement to the RetrievePdsDemographic API to return `PdsDemographic` objects instead of `ParticipantDemographic` objects, ensuring type consistency and resolving JSON deserialization errors.

The RetrievePdsDemographic function was incorrectly returning `ParticipantDemographic` objects (where `ParticipantId` is a `long`) instead of `PdsDemographic` objects (where properties are strings). This caused JSON deserialization errors in ProcessNemsUpdate.

Changes made include updating the API response serialisation, updating all consuming functions to work with `PdsDemographic` objects, adding method overloading for backward compatibility, and fixing all test mocks to use the correct types.

## Context

The RetrievePdsDemographic function name suggests it returns `PdsDemographic` objects, but it was actually returning `ParticipantDemographic` objects. This type mismatch caused JSON deserialisation failures in ProcessNemsUpdate function that expected string-based properties but received numeric values for fields like `ParticipantId`.

This architectural inconsistency needed to be resolved to ensure proper API contract adherence and eliminate runtime errors.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [x] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.