### PR TITLE
fix: add supersededByNhsNumber and clean up mock data

### DIFF
--- a/application/CohortManager/src/Web/app/api/GetValidationExceptions/route.ts
+++ b/application/CohortManager/src/Web/app/api/GetValidationExceptions/route.ts
@@ -1,6 +1,279 @@
 import { NextResponse } from "next/server";
 import { ExceptionAPIDetails } from "@/app/types/exceptionsApi";
 
+// Mock data store
+const mockExceptions: Record<number, ExceptionAPIDetails> = {
+  2073: {
+    ExceptionId: 2073,
+    NhsNumber: "1211111881",
+    DateCreated: "2025-05-16T14:26:09.28",
+    DateResolved: "9999-12-31T00:00:00",
+    RuleId: -2146233088,
+    RuleDescription:
+      "There was problem posting the participant to the database",
+    Category: 5,
+    ScreeningName: "Breast Screening",
+    ExceptionDate: "2025-01-15T00:00:00",
+    CohortName: "",
+    Fatal: 1,
+    ExceptionDetails: {
+      GivenName: "Alice",
+      FamilyName: "Smith",
+      DateOfBirth: "19800101",
+      ParticipantAddressLine1: "123 Main Street",
+      ParticipantAddressLine2: "Flat 2B",
+      ParticipantAddressLine3: "Central District",
+      ParticipantAddressLine4: "London",
+      ParticipantAddressLine5: "England",
+      ParticipantPostCode: "E1 6AN",
+      TelephoneNumberHome: "07123456789",
+      EmailAddressHome: "alice.smith@example.com",
+      PrimaryCareProvider: "E12345",
+      Gender: 2,
+      SupersededByNhsNumber: "",
+    },
+    ServiceNowId: "",
+    ServiceNowCreatedDate: "",
+    RecordUpdatedDate: "2025-01-17T09:27:18.25",
+  },
+  2075: {
+    ExceptionId: 2075,
+    NhsNumber: "1211111881",
+    DateCreated: "2025-05-16T14:26:09.28",
+    DateResolved: "9999-12-31T00:00:00",
+    RuleId: 21,
+    RuleDescription: "The 'Superseded by NHS number' field is not null",
+    Category: 5,
+    ScreeningName: "Breast Screening",
+    ExceptionDate: "2025-01-15T00:00:00",
+    CohortName: "",
+    Fatal: 1,
+    ExceptionDetails: {
+      GivenName: "Alice",
+      FamilyName: "Smith",
+      DateOfBirth: "19800101",
+      ParticipantAddressLine1: "123 Main Street",
+      ParticipantAddressLine2: "Flat 2B",
+      ParticipantAddressLine3: "Central District",
+      ParticipantAddressLine4: "London",
+      ParticipantAddressLine5: "England",
+      ParticipantPostCode: "E1 6AN",
+      TelephoneNumberHome: "07123456789",
+      EmailAddressHome: "alice.smith@example.com",
+      PrimaryCareProvider: "E12345",
+      Gender: 2,
+      SupersededByNhsNumber: "1211111882",
+    },
+    ServiceNowId: "",
+    ServiceNowCreatedDate: "",
+    RecordUpdatedDate: "2025-01-17T09:27:18.25",
+  },
+  2083: {
+    ExceptionId: 2083,
+    NhsNumber: "1211111881",
+    DateCreated: "2025-05-16T14:26:09.28",
+    DateResolved: "9999-12-31T00:00:00",
+    RuleId: -2146233088,
+    RuleDescription:
+      "There was problem posting the participant to the database",
+    Category: 5,
+    ScreeningName: "Breast Screening",
+    ExceptionDate: "2025-01-15T00:00:00",
+    CohortName: "",
+    Fatal: 1,
+    ExceptionDetails: {
+      GivenName: "Bob",
+      FamilyName: "Johnson",
+      DateOfBirth: "19751212",
+      ParticipantAddressLine1: "456 Oak Avenue",
+      ParticipantAddressLine2: "",
+      ParticipantAddressLine3: "West End",
+      ParticipantAddressLine4: "Manchester",
+      ParticipantAddressLine5: "UK",
+      ParticipantPostCode: "M1 2AB",
+      TelephoneNumberHome: "07234567890",
+      EmailAddressHome: "bob.johnson@example.com",
+      PrimaryCareProvider: "E54321",
+      Gender: 1,
+      SupersededByNhsNumber: "",
+    },
+    ServiceNowId: "INC0002765",
+    ServiceNowCreatedDate: "2025-06-16T00:00:00",
+    RecordUpdatedDate: "2025-01-17T09:27:18.25",
+  },
+  2085: {
+    ExceptionId: 2085,
+    NhsNumber: "1211111881",
+    DateCreated: "2025-05-16T14:26:09.28",
+    DateResolved: "9999-12-31T00:00:00",
+    RuleId: 21,
+    RuleDescription: "The 'Superseded by NHS number' field is not null",
+    Category: 5,
+    ScreeningName: "Breast Screening",
+    ExceptionDate: "2025-01-15T00:00:00",
+    CohortName: "",
+    Fatal: 1,
+    ExceptionDetails: {
+      GivenName: "Alice",
+      FamilyName: "Smith",
+      DateOfBirth: "19800101",
+      ParticipantAddressLine1: "123 Main Street",
+      ParticipantAddressLine2: "Flat 2B",
+      ParticipantAddressLine3: "Central District",
+      ParticipantAddressLine4: "London",
+      ParticipantAddressLine5: "England",
+      ParticipantPostCode: "E1 6AN",
+      TelephoneNumberHome: "07123456789",
+      EmailAddressHome: "alice.smith@example.com",
+      PrimaryCareProvider: "E12345",
+      Gender: 2,
+      SupersededByNhsNumber: "1211111882",
+    },
+    ServiceNowId: "INC0002768",
+    ServiceNowCreatedDate: "2025-06-16T00:00:00",
+    RecordUpdatedDate: "2025-01-17T09:27:18.25",
+  },
+};
+
+// List data for different exception types
+const notRaisedExceptions = [
+  {
+    ExceptionId: 2073,
+    NhsNumber: "1211111881",
+    DateCreated: "2025-05-16T14:26:09.28",
+    DateResolved: "9999-12-31T00:00:00",
+    RuleId: -2146233088,
+    RuleDescription:
+      "There was problem posting the participant to the database",
+    Category: 5,
+    ScreeningName: "Breast Screening",
+    ExceptionDate: "2025-01-15T00:00:00",
+    CohortName: "",
+    Fatal: 1,
+    ServiceNowId: "",
+    ServiceNowCreatedDate: "",
+    RecordUpdatedDate: "2025-01-17T09:27:18.25",
+  },
+  {
+    ExceptionId: 2074,
+    NhsNumber: "1211111882",
+    DateCreated: "2025-05-17T10:00:00.00",
+    DateResolved: "9999-12-31T00:00:00",
+    RuleId: -2146233089,
+    RuleDescription: "Another error posting the participant to the database",
+    Category: 5,
+    ScreeningName: "Breast Screening",
+    ExceptionDate: "2025-01-16T00:00:00",
+    CohortName: "",
+    Fatal: 1,
+    ServiceNowId: "",
+    ServiceNowCreatedDate: "",
+    RecordUpdatedDate: "2025-01-18T09:27:18.25",
+  },
+  {
+    ExceptionId: 2075,
+    NhsNumber: "1211111881",
+    DateCreated: "2025-05-16T14:26:09.28",
+    DateResolved: "9999-12-31T00:00:00",
+    RuleId: 21,
+    RuleDescription: "The 'Superseded by NHS number' field is not null",
+    Category: 5,
+    ScreeningName: "Breast Screening",
+    ExceptionDate: "2025-01-15T00:00:00",
+    CohortName: "",
+    Fatal: 1,
+    ServiceNowId: "",
+    ServiceNowCreatedDate: "",
+    RecordUpdatedDate: "2025-01-17T09:27:18.25",
+  },
+];
+
+const raisedExceptions = [
+  {
+    ExceptionId: 2083,
+    NhsNumber: "1211111881",
+    DateCreated: "2025-05-16T14:26:09.28",
+    DateResolved: "9999-12-31T00:00:00",
+    RuleId: -2146233088,
+    RuleDescription:
+      "There was problem posting the participant to the database",
+    Category: 5,
+    ScreeningName: "Breast Screening",
+    ExceptionDate: "2025-01-15T00:00:00",
+    CohortName: "",
+    Fatal: 1,
+    ServiceNowId: "INC0002764",
+    ServiceNowCreatedDate: "2025-06-16:00:00",
+    RecordUpdatedDate: "2025-01-17T09:27:18.25",
+  },
+  {
+    ExceptionId: 2084,
+    NhsNumber: "1211111882",
+    DateCreated: "2025-05-17T10:00:00.00",
+    DateResolved: "9999-12-31T00:00:00",
+    RuleId: -2146233089,
+    RuleDescription: "Another error posting the participant to the database",
+    Category: 5,
+    ScreeningName: "Breast Screening",
+    ExceptionDate: "2025-01-16T00:00:00",
+    CohortName: "",
+    Fatal: 1,
+    ServiceNowId: "INC0002765",
+    ServiceNowCreatedDate: "2025-06-10T00:00:00",
+    RecordUpdatedDate: "2025-01-18T09:27:18.25",
+  },
+  {
+    ExceptionId: 2085,
+    NhsNumber: "1211111883",
+    DateCreated: "2025-05-18T11:00:00.00",
+    DateResolved: "9999-12-31T00:00:00",
+    RuleId: 21,
+    RuleDescription: "The 'Superseded by NHS number' field is not null",
+    Category: 5,
+    ScreeningName: "Breast Screening",
+    ExceptionDate: "2025-01-17T00:00:00",
+    CohortName: "",
+    Fatal: 1,
+    ServiceNowId: "INC0002766",
+    ServiceNowCreatedDate: "2025-06-12T00:00:00",
+    RecordUpdatedDate: "2025-01-19T09:27:18.25",
+  },
+];
+
+// Helper functions
+function sortExceptions<
+  T extends { DateCreated: string; ServiceNowCreatedDate?: string }
+>(items: T[], sortBy: string | null, dateField: keyof T = "DateCreated"): T[] {
+  if (sortBy === "1") {
+    return items.sort(
+      (a, b) =>
+        new Date(a[dateField] as string).getTime() -
+        new Date(b[dateField] as string).getTime()
+    );
+  } else if (sortBy === "0") {
+    return items.sort(
+      (a, b) =>
+        new Date(b[dateField] as string).getTime() -
+        new Date(a[dateField] as string).getTime()
+    );
+  }
+  return items;
+}
+
+function createExceptionListResponse<T extends { ExceptionId: number }>(
+  items: T[]
+) {
+  return {
+    Items: items,
+    IsFirstPage: true,
+    HasNextPage: false,
+    LastResultId: items[items.length - 1]?.ExceptionId ?? null,
+    TotalItems: items.length,
+    TotalPages: 1,
+    CurrentPage: 1,
+  };
+}
+
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const exceptionId = searchParams.get("exceptionId");
@@ -8,314 +281,41 @@ export async function GET(request: Request) {
   const notRaisedOnly = searchParams.get("notRaisedOnly");
   const sortBy = searchParams.get("sortBy");
 
-  // Mock data for not raised exception ID 2073
-  if (exceptionId !== null && Number(exceptionId) === 2073) {
-    const exception: ExceptionAPIDetails = {
-      ExceptionId: 2073,
-      NhsNumber: "1211111881",
-      DateCreated: "2025-05-16T14:26:09.28",
-      DateResolved: "9999-12-31T00:00:00",
-      RuleId: -2146233088,
-      RuleDescription:
-        "There was problem posting the participant to the database",
-      Category: 5,
-      ScreeningName: "Breast Screening",
-      ExceptionDate: "2025-01-15T00:00:00",
-      CohortName: "",
-      Fatal: 1,
-      ExceptionDetails: {
-        GivenName: "Alice",
-        FamilyName: "Smith",
-        DateOfBirth: "19800101",
-        ParticipantAddressLine1: "123 Main Street",
-        ParticipantAddressLine2: "Flat 2B",
-        ParticipantAddressLine3: "Central District",
-        ParticipantAddressLine4: "London",
-        ParticipantAddressLine5: "England",
-        ParticipantPostCode: "E1 6AN",
-        TelephoneNumberHome: "07123456789",
-        EmailAddressHome: "alice.smith@example.com",
-        PrimaryCareProvider: "E12345",
-        Gender: 2,
-        SupersededByNhsNumber: "",
-      },
-      ServiceNowId: "",
-      ServiceNowCreatedDate: "",
-      RecordUpdatedDate: "2025-01-17T09:27:18.25",
-    };
-    return NextResponse.json(exception, { status: 200 });
-  }
+  // Handle single exception requests
+  if (exceptionId !== null) {
+    const id = Number(exceptionId);
+    const exception = mockExceptions[id];
 
-  // Mock data for not raised exception with superseded NHS number ID 2075
-  if (
-    (exceptionId !== null && Number(exceptionId) === 2075) ||
-    Number(exceptionId) === 2085
-  ) {
-    const exception: ExceptionAPIDetails = {
-      ExceptionId: 2073,
-      NhsNumber: "1211111881",
-      DateCreated: "2025-05-16T14:26:09.28",
-      DateResolved: "9999-12-31T00:00:00",
-      RuleId: 21,
-      RuleDescription: "The 'Superseded by NHS number' field is not null",
-      Category: 5,
-      ScreeningName: "Breast Screening",
-      ExceptionDate: "2025-01-15T00:00:00",
-      CohortName: "",
-      Fatal: 1,
-      ExceptionDetails: {
-        GivenName: "Alice",
-        FamilyName: "Smith",
-        DateOfBirth: "19800101",
-        ParticipantAddressLine1: "123 Main Street",
-        ParticipantAddressLine2: "Flat 2B",
-        ParticipantAddressLine3: "Central District",
-        ParticipantAddressLine4: "London",
-        ParticipantAddressLine5: "England",
-        ParticipantPostCode: "E1 6AN",
-        TelephoneNumberHome: "07123456789",
-        EmailAddressHome: "alice.smith@example.com",
-        PrimaryCareProvider: "E12345",
-        Gender: 2,
-        SupersededByNhsNumber: "1211111882",
-      },
-      ServiceNowId: "",
-      ServiceNowCreatedDate: "",
-      RecordUpdatedDate: "2025-01-17T09:27:18.25",
-    };
-    return NextResponse.json(exception, { status: 200 });
-  }
-
-  // Mock data for raised exception ID 2083
-  if (exceptionId !== null && Number(exceptionId) === 2083) {
-    const exception: ExceptionAPIDetails = {
-      ExceptionId: 2083,
-      NhsNumber: "1211111881",
-      DateCreated: "2025-05-16T14:26:09.28",
-      DateResolved: "9999-12-31T00:00:00",
-      RuleId: -2146233088,
-      RuleDescription:
-        "There was problem posting the participant to the database",
-      Category: 5,
-      ScreeningName: "Breast Screening",
-      ExceptionDate: "2025-01-15T00:00:00",
-      CohortName: "",
-      Fatal: 1,
-      ExceptionDetails: {
-        GivenName: "Bob",
-        FamilyName: "Johnson",
-        DateOfBirth: "19751212",
-        ParticipantAddressLine1: "456 Oak Avenue",
-        ParticipantAddressLine2: "",
-        ParticipantAddressLine3: "West End",
-        ParticipantAddressLine4: "Manchester",
-        ParticipantAddressLine5: "UK",
-        ParticipantPostCode: "M1 2AB",
-        TelephoneNumberHome: "07234567890",
-        EmailAddressHome: "bob.johnson@example.com",
-        PrimaryCareProvider: "E54321",
-        Gender: 1,
-        SupersededByNhsNumber: "",
-      },
-      ServiceNowId: "INC0002765",
-      ServiceNowCreatedDate: "2025-06-16T00:00:00",
-      RecordUpdatedDate: "2025-01-17T09:27:18.25",
-    };
-    return NextResponse.json(exception, { status: 200 });
-  }
-
-  // Mock data for not raised exception with superseded NHS number ID 2085
-  if (exceptionId !== null && Number(exceptionId) === 2085) {
-    const exception: ExceptionAPIDetails = {
-      ExceptionId: 2073,
-      NhsNumber: "1211111881",
-      DateCreated: "2025-05-16T14:26:09.28",
-      DateResolved: "9999-12-31T00:00:00",
-      RuleId: 21,
-      RuleDescription: "The 'Superseded by NHS number' field is not null",
-      Category: 5,
-      ScreeningName: "Breast Screening",
-      ExceptionDate: "2025-01-15T00:00:00",
-      CohortName: "",
-      Fatal: 1,
-      ExceptionDetails: {
-        GivenName: "Alice",
-        FamilyName: "Smith",
-        DateOfBirth: "19800101",
-        ParticipantAddressLine1: "123 Main Street",
-        ParticipantAddressLine2: "Flat 2B",
-        ParticipantAddressLine3: "Central District",
-        ParticipantAddressLine4: "London",
-        ParticipantAddressLine5: "England",
-        ParticipantPostCode: "E1 6AN",
-        TelephoneNumberHome: "07123456789",
-        EmailAddressHome: "alice.smith@example.com",
-        PrimaryCareProvider: "E12345",
-        Gender: 2,
-        SupersededByNhsNumber: "1211111882",
-      },
-      ServiceNowId: "INC0002768",
-      ServiceNowCreatedDate: "",
-      RecordUpdatedDate: "2025-01-17T09:27:18.25",
-    };
-    return NextResponse.json(exception, { status: 200 });
-  }
-
-  if (notRaisedOnly) {
-    let items = [
-      {
-        ExceptionId: 2073,
-        NhsNumber: "1211111881",
-        DateCreated: "2025-05-16T14:26:09.28",
-        DateResolved: "9999-12-31T00:00:00",
-        RuleId: -2146233088,
-        RuleDescription:
-          "There was problem posting the participant to the database",
-        Category: 5,
-        ScreeningName: "Breast Screening",
-        ExceptionDate: "2025-01-15T00:00:00",
-        CohortName: "",
-        Fatal: 1,
-        ServiceNowId: "",
-        ServiceNowCreatedDate: "",
-        RecordUpdatedDate: "2025-01-17T09:27:18.25",
-      },
-      {
-        ExceptionId: 2074,
-        NhsNumber: "1211111882",
-        DateCreated: "2025-05-17T10:00:00.00",
-        DateResolved: "9999-12-31T00:00:00",
-        RuleId: -2146233089,
-        RuleDescription:
-          "Another error posting the participant to the database",
-        Category: 5,
-        ScreeningName: "Breast Screening",
-        ExceptionDate: "2025-01-16T00:00:00",
-        CohortName: "",
-        Fatal: 1,
-        ServiceNowId: "",
-        ServiceNowCreatedDate: "",
-        RecordUpdatedDate: "2025-01-18T09:27:18.25",
-      },
-      {
-        ExceptionId: 2075,
-        NhsNumber: "1211111881",
-        DateCreated: "2025-05-16T14:26:09.28",
-        DateResolved: "9999-12-31T00:00:00",
-        RuleId: 21,
-        RuleDescription: "The 'Superseded by NHS number' field is not null",
-        Category: 5,
-        ScreeningName: "Breast Screening",
-        ExceptionDate: "2025-01-15T00:00:00",
-        CohortName: "",
-        Fatal: 1,
-        ServiceNowId: "",
-        ServiceNowCreatedDate: "",
-        RecordUpdatedDate: "2025-01-17T09:27:18.25",
-      },
-    ];
-
-    if (sortBy === "1") {
-      items = items.sort(
-        (a, b) =>
-          new Date(a.DateCreated).getTime() - new Date(b.DateCreated).getTime()
-      );
-    } else if (sortBy === "0") {
-      items = items.sort(
-        (a, b) =>
-          new Date(b.DateCreated).getTime() - new Date(a.DateCreated).getTime()
-      );
+    if (exception) {
+      return NextResponse.json(exception, { status: 200 });
     }
 
-    const exceptions = {
-      Items: items,
-      IsFirstPage: true,
-      HasNextPage: false,
-      LastResultId: items[items.length - 1]?.ExceptionId ?? null,
-      TotalItems: items.length,
-      TotalPages: 1,
-      CurrentPage: 1,
-    };
-    return NextResponse.json(exceptions, { status: 200 });
+    return NextResponse.json(
+      { error: `Exception with ID ${exceptionId} not found` },
+      { status: 404 }
+    );
+  }
+
+  // Handle list requests
+  if (notRaisedOnly) {
+    const sortedItems = sortExceptions([...notRaisedExceptions], sortBy);
+    const response = createExceptionListResponse(sortedItems);
+    return NextResponse.json(response, { status: 200 });
   }
 
   if (raisedOnly) {
-    let items = [
-      {
-        ExceptionId: 2083,
-        NhsNumber: "1211111881",
-        DateCreated: "2025-05-16T14:26:09.28",
-        DateResolved: "9999-12-31T00:00:00",
-        RuleId: -2146233088,
-        RuleDescription:
-          "There was problem posting the participant to the database",
-        Category: 5,
-        ScreeningName: "Breast Screening",
-        ExceptionDate: "2025-01-15T00:00:00",
-        CohortName: "",
-        Fatal: 1,
-        ServiceNowId: "INC0002764",
-        ServiceNowCreatedDate: "2025-06-16:00:00",
-        RecordUpdatedDate: "2025-01-17T09:27:18.25",
-      },
-      {
-        ExceptionId: 2084,
-        NhsNumber: "1211111882",
-        DateCreated: "2025-05-17T10:00:00.00",
-        DateResolved: "9999-12-31T00:00:00",
-        RuleId: -2146233089,
-        RuleDescription:
-          "Another error posting the participant to the database",
-        Category: 5,
-        ScreeningName: "Breast Screening",
-        ExceptionDate: "2025-01-16T00:00:00",
-        CohortName: "",
-        Fatal: 1,
-        ServiceNowId: "INC0002765",
-        ServiceNowCreatedDate: "2025-06-10T00:00:00",
-        RecordUpdatedDate: "2025-01-18T09:27:18.25",
-      },
-      {
-        ExceptionId: 2085,
-        NhsNumber: "1211111883",
-        DateCreated: "2025-05-18T11:00:00.00",
-        DateResolved: "9999-12-31T00:00:00",
-        RuleId: 21,
-        RuleDescription: "The 'Superseded by NHS number' field is not null",
-        Category: 5,
-        ScreeningName: "Breast Screening",
-        ExceptionDate: "2025-01-17T00:00:00",
-        CohortName: "",
-        Fatal: 1,
-        ServiceNowId: "INC0002766",
-        ServiceNowCreatedDate: "2025-06-12T00:00:00",
-        RecordUpdatedDate: "2025-01-19T09:27:18.25",
-      },
-    ];
-
-    if (sortBy === "1") {
-      items = items.sort(
-        (a, b) =>
-          new Date(a.ServiceNowCreatedDate).getTime() -
-          new Date(b.ServiceNowCreatedDate).getTime()
-      );
-    } else if (sortBy === "0") {
-      items = items.sort(
-        (a, b) =>
-          new Date(b.ServiceNowCreatedDate).getTime() -
-          new Date(a.ServiceNowCreatedDate).getTime()
-      );
-    }
-
-    const exceptions = {
-      Items: items,
-      IsFirstPage: true,
-      HasNextPage: false,
-      LastResultId: items[items.length - 1]?.ExceptionId ?? null,
-      TotalItems: items.length,
-      TotalPages: 1,
-      CurrentPage: 1,
-    };
-    return NextResponse.json(exceptions, { status: 200 });
+    const sortedItems = sortExceptions(
+      [...raisedExceptions],
+      sortBy,
+      "ServiceNowCreatedDate"
+    );
+    const response = createExceptionListResponse(sortedItems);
+    return NextResponse.json(response, { status: 200 });
   }
+
+  // Default fallback
+  return NextResponse.json(
+    { error: "No valid query parameters provided" },
+    { status: 400 }
+  );
 }

--- a/application/CohortManager/src/Web/app/api/GetValidationExceptions/route.ts
+++ b/application/CohortManager/src/Web/app/api/GetValidationExceptions/route.ts
@@ -8,19 +8,16 @@ export async function GET(request: Request) {
   const notRaisedOnly = searchParams.get("notRaisedOnly");
   const sortBy = searchParams.get("sortBy");
 
+  // Mock data for not raised exception ID 2073
   if (exceptionId !== null && Number(exceptionId) === 2073) {
     const exception: ExceptionAPIDetails = {
       ExceptionId: 2073,
-      FileName:
-        "202411261720028838554_1B8F53_-_CAAS_BREAST_SCREENING_COHORT.parquet",
       NhsNumber: "1211111881",
       DateCreated: "2025-05-16T14:26:09.28",
       DateResolved: "9999-12-31T00:00:00",
       RuleId: -2146233088,
       RuleDescription:
         "There was problem posting the participant to the database",
-      ErrorRecord:
-        '{"RecordType":"ADD","NhsNumber":"1211111881","RemovalReason":"","RemovalEffectiveFromDate":"","ScreeningId":"1","ScreeningName":"Breast Screening","EligibilityFlag":"1"}',
       Category: 5,
       ScreeningName: "Breast Screening",
       ExceptionDate: "2025-01-15T00:00:00",
@@ -40,6 +37,7 @@ export async function GET(request: Request) {
         EmailAddressHome: "alice.smith@example.com",
         PrimaryCareProvider: "E12345",
         Gender: 2,
+        SupersededByNhsNumber: "",
       },
       ServiceNowId: "",
       ServiceNowCreatedDate: "",
@@ -48,19 +46,56 @@ export async function GET(request: Request) {
     return NextResponse.json(exception, { status: 200 });
   }
 
+  // Mock data for not raised exception with superseded NHS number ID 2075
+  if (
+    (exceptionId !== null && Number(exceptionId) === 2075) ||
+    Number(exceptionId) === 2085
+  ) {
+    const exception: ExceptionAPIDetails = {
+      ExceptionId: 2073,
+      NhsNumber: "1211111881",
+      DateCreated: "2025-05-16T14:26:09.28",
+      DateResolved: "9999-12-31T00:00:00",
+      RuleId: 21,
+      RuleDescription: "The 'Superseded by NHS number' field is not null",
+      Category: 5,
+      ScreeningName: "Breast Screening",
+      ExceptionDate: "2025-01-15T00:00:00",
+      CohortName: "",
+      Fatal: 1,
+      ExceptionDetails: {
+        GivenName: "Alice",
+        FamilyName: "Smith",
+        DateOfBirth: "19800101",
+        ParticipantAddressLine1: "123 Main Street",
+        ParticipantAddressLine2: "Flat 2B",
+        ParticipantAddressLine3: "Central District",
+        ParticipantAddressLine4: "London",
+        ParticipantAddressLine5: "England",
+        ParticipantPostCode: "E1 6AN",
+        TelephoneNumberHome: "07123456789",
+        EmailAddressHome: "alice.smith@example.com",
+        PrimaryCareProvider: "E12345",
+        Gender: 2,
+        SupersededByNhsNumber: "1211111882",
+      },
+      ServiceNowId: "",
+      ServiceNowCreatedDate: "",
+      RecordUpdatedDate: "2025-01-17T09:27:18.25",
+    };
+    return NextResponse.json(exception, { status: 200 });
+  }
+
+  // Mock data for raised exception ID 2083
   if (exceptionId !== null && Number(exceptionId) === 2083) {
     const exception: ExceptionAPIDetails = {
       ExceptionId: 2083,
-      FileName:
-        "202411261720028838554_1B8F53_-_CAAS_BREAST_SCREENING_COHORT.parquet",
       NhsNumber: "1211111881",
       DateCreated: "2025-05-16T14:26:09.28",
       DateResolved: "9999-12-31T00:00:00",
       RuleId: -2146233088,
       RuleDescription:
         "There was problem posting the participant to the database",
-      ErrorRecord:
-        '{"RecordType":"ADD","NhsNumber":"1211111881","RemovalReason":"","RemovalEffectiveFromDate":"","ScreeningId":"1","ScreeningName":"Breast Screening","EligibilityFlag":"1"}',
       Category: 5,
       ScreeningName: "Breast Screening",
       ExceptionDate: "2025-01-15T00:00:00",
@@ -80,9 +115,47 @@ export async function GET(request: Request) {
         EmailAddressHome: "bob.johnson@example.com",
         PrimaryCareProvider: "E54321",
         Gender: 1,
+        SupersededByNhsNumber: "",
       },
       ServiceNowId: "INC0002765",
       ServiceNowCreatedDate: "2025-06-16T00:00:00",
+      RecordUpdatedDate: "2025-01-17T09:27:18.25",
+    };
+    return NextResponse.json(exception, { status: 200 });
+  }
+
+  // Mock data for not raised exception with superseded NHS number ID 2085
+  if (exceptionId !== null && Number(exceptionId) === 2085) {
+    const exception: ExceptionAPIDetails = {
+      ExceptionId: 2073,
+      NhsNumber: "1211111881",
+      DateCreated: "2025-05-16T14:26:09.28",
+      DateResolved: "9999-12-31T00:00:00",
+      RuleId: 21,
+      RuleDescription: "The 'Superseded by NHS number' field is not null",
+      Category: 5,
+      ScreeningName: "Breast Screening",
+      ExceptionDate: "2025-01-15T00:00:00",
+      CohortName: "",
+      Fatal: 1,
+      ExceptionDetails: {
+        GivenName: "Alice",
+        FamilyName: "Smith",
+        DateOfBirth: "19800101",
+        ParticipantAddressLine1: "123 Main Street",
+        ParticipantAddressLine2: "Flat 2B",
+        ParticipantAddressLine3: "Central District",
+        ParticipantAddressLine4: "London",
+        ParticipantAddressLine5: "England",
+        ParticipantPostCode: "E1 6AN",
+        TelephoneNumberHome: "07123456789",
+        EmailAddressHome: "alice.smith@example.com",
+        PrimaryCareProvider: "E12345",
+        Gender: 2,
+        SupersededByNhsNumber: "1211111882",
+      },
+      ServiceNowId: "INC0002768",
+      ServiceNowCreatedDate: "",
       RecordUpdatedDate: "2025-01-17T09:27:18.25",
     };
     return NextResponse.json(exception, { status: 200 });
@@ -92,75 +165,53 @@ export async function GET(request: Request) {
     let items = [
       {
         ExceptionId: 2073,
-        FileName:
-          "202411261720028838554_1B8F53_-_CAAS_BREAST_SCREENING_COHORT.parquet",
         NhsNumber: "1211111881",
         DateCreated: "2025-05-16T14:26:09.28",
         DateResolved: "9999-12-31T00:00:00",
         RuleId: -2146233088,
         RuleDescription:
           "There was problem posting the participant to the database",
-        ErrorRecord:
-          '{"RecordType":"ADD","NhsNumber":"1211111881","RemovalReason":"","RemovalEffectiveFromDate":"","ScreeningId":"1","ScreeningName":"Breast Screening","EligibilityFlag":"1"}',
         Category: 5,
         ScreeningName: "Breast Screening",
         ExceptionDate: "2025-01-15T00:00:00",
         CohortName: "",
         Fatal: 1,
-        ExceptionDetails: {
-          GivenName: "Charlie",
-          FamilyName: "Williams",
-          DateOfBirth: "19900228",
-          ParticipantAddressLine1: "789 Pine Road",
-          ParticipantAddressLine2: "Suite 5",
-          ParticipantAddressLine3: "East Side",
-          ParticipantAddressLine4: "Birmingham",
-          ParticipantAddressLine5: "United Kingdom",
-          ParticipantPostCode: "B2 4QA",
-          TelephoneNumberHome: "07345678901",
-          EmailAddressHome: "charlie.williams@example.com",
-          PrimaryCareProvider: "E67890",
-          Gender: 1,
-        },
         ServiceNowId: "",
         ServiceNowCreatedDate: "",
         RecordUpdatedDate: "2025-01-17T09:27:18.25",
       },
       {
         ExceptionId: 2074,
-        FileName:
-          "202411261720028838554_1B8F53_-_CAAS_BREAST_SCREENING_COHORT.parquet",
         NhsNumber: "1211111882",
         DateCreated: "2025-05-17T10:00:00.00",
         DateResolved: "9999-12-31T00:00:00",
         RuleId: -2146233089,
         RuleDescription:
           "Another error posting the participant to the database",
-        ErrorRecord:
-          '{"RecordType":"ADD","NhsNumber":"1211111882","RemovalReason":"","RemovalEffectiveFromDate":"","ScreeningId":"1","ScreeningName":"Breast Screening","EligibilityFlag":"1"}',
         Category: 5,
         ScreeningName: "Breast Screening",
         ExceptionDate: "2025-01-16T00:00:00",
         CohortName: "",
         Fatal: 1,
-        ExceptionDetails: {
-          GivenName: "Diana",
-          FamilyName: "Brown",
-          DateOfBirth: "19851130",
-          ParticipantAddressLine1: "321 Maple Lane",
-          ParticipantAddressLine2: "",
-          ParticipantAddressLine3: "Northfield",
-          ParticipantAddressLine4: "Leeds",
-          ParticipantAddressLine5: "England",
-          ParticipantPostCode: "LS1 4DT",
-          TelephoneNumberHome: "07456789012",
-          EmailAddressHome: "diana.brown@example.com",
-          PrimaryCareProvider: "E98765",
-          Gender: 2,
-        },
         ServiceNowId: "",
         ServiceNowCreatedDate: "",
         RecordUpdatedDate: "2025-01-18T09:27:18.25",
+      },
+      {
+        ExceptionId: 2075,
+        NhsNumber: "1211111881",
+        DateCreated: "2025-05-16T14:26:09.28",
+        DateResolved: "9999-12-31T00:00:00",
+        RuleId: 21,
+        RuleDescription: "The 'Superseded by NHS number' field is not null",
+        Category: 5,
+        ScreeningName: "Breast Screening",
+        ExceptionDate: "2025-01-15T00:00:00",
+        CohortName: "",
+        Fatal: 1,
+        ServiceNowId: "",
+        ServiceNowCreatedDate: "",
+        RecordUpdatedDate: "2025-01-17T09:27:18.25",
       },
     ];
 
@@ -192,107 +243,50 @@ export async function GET(request: Request) {
     let items = [
       {
         ExceptionId: 2083,
-        FileName:
-          "202411261720028838554_1B8F53_-_CAAS_BREAST_SCREENING_COHORT.parquet",
         NhsNumber: "1211111881",
         DateCreated: "2025-05-16T14:26:09.28",
         DateResolved: "9999-12-31T00:00:00",
         RuleId: -2146233088,
         RuleDescription:
           "There was problem posting the participant to the database",
-        ErrorRecord:
-          '{"RecordType":"ADD","NhsNumber":"1211111881","RemovalReason":"","RemovalEffectiveFromDate":"","ScreeningId":"1","ScreeningName":"Breast Screening","EligibilityFlag":"1"}',
         Category: 5,
         ScreeningName: "Breast Screening",
         ExceptionDate: "2025-01-15T00:00:00",
         CohortName: "",
         Fatal: 1,
-        ExceptionDetails: {
-          GivenName: "Charlie",
-          FamilyName: "Williams",
-          DateOfBirth: "19900228",
-          ParticipantAddressLine1: "789 Pine Road",
-          ParticipantAddressLine2: "Suite 5",
-          ParticipantAddressLine3: "East Side",
-          ParticipantAddressLine4: "Birmingham",
-          ParticipantAddressLine5: "United Kingdom",
-          ParticipantPostCode: "B2 4QA",
-          TelephoneNumberHome: "07345678901",
-          EmailAddressHome: "charlie.williams@example.com",
-          PrimaryCareProvider: "E67890",
-          Gender: 1,
-        },
         ServiceNowId: "INC0002764",
         ServiceNowCreatedDate: "2025-06-16:00:00",
         RecordUpdatedDate: "2025-01-17T09:27:18.25",
       },
       {
         ExceptionId: 2084,
-        FileName:
-          "202411261720028838554_1B8F53_-_CAAS_BREAST_SCREENING_COHORT.parquet",
         NhsNumber: "1211111882",
         DateCreated: "2025-05-17T10:00:00.00",
         DateResolved: "9999-12-31T00:00:00",
         RuleId: -2146233089,
         RuleDescription:
           "Another error posting the participant to the database",
-        ErrorRecord:
-          '{"RecordType":"ADD","NhsNumber":"1211111882","RemovalReason":"","RemovalEffectiveFromDate":"","ScreeningId":"1","ScreeningName":"Breast Screening","EligibilityFlag":"1"}',
         Category: 5,
         ScreeningName: "Breast Screening",
         ExceptionDate: "2025-01-16T00:00:00",
         CohortName: "",
         Fatal: 1,
-        ExceptionDetails: {
-          GivenName: "Diana",
-          FamilyName: "Brown",
-          DateOfBirth: "19851130",
-          ParticipantAddressLine1: "321 Maple Lane",
-          ParticipantAddressLine2: "",
-          ParticipantAddressLine3: "Northfield",
-          ParticipantAddressLine4: "Leeds",
-          ParticipantAddressLine5: "England",
-          ParticipantPostCode: "LS1 4DT",
-          TelephoneNumberHome: "07456789012",
-          EmailAddressHome: "diana.brown@example.com",
-          PrimaryCareProvider: "E98765",
-          Gender: 2,
-        },
         ServiceNowId: "INC0002765",
         ServiceNowCreatedDate: "2025-06-10T00:00:00",
         RecordUpdatedDate: "2025-01-18T09:27:18.25",
       },
       {
         ExceptionId: 2085,
-        FileName:
-          "202411261720028838554_1B8F53_-_CAAS_BREAST_SCREENING_COHORT.parquet",
         NhsNumber: "1211111883",
         DateCreated: "2025-05-18T11:00:00.00",
         DateResolved: "9999-12-31T00:00:00",
-        RuleId: -2146233090,
-        RuleDescription: "Third error posting the participant to the database",
-        ErrorRecord:
-          '{"RecordType":"ADD","NhsNumber":"1211111883","RemovalReason":"","RemovalEffectiveFromDate":"","ScreeningId":"1","ScreeningName":"Breast Screening","EligibilityFlag":"1"}',
+        RuleId: 21,
+        RuleDescription: "The 'Superseded by NHS number' field is not null",
         Category: 5,
         ScreeningName: "Breast Screening",
         ExceptionDate: "2025-01-17T00:00:00",
         CohortName: "",
         Fatal: 1,
-        ExceptionDetails: {
-          GivenName: "Edward",
-          FamilyName: "Green",
-          DateOfBirth: "19890214",
-          ParticipantAddressLine1: "654 Willow Street",
-          ParticipantAddressLine2: "Apt 7",
-          ParticipantAddressLine3: "South Park",
-          ParticipantAddressLine4: "Liverpool",
-          ParticipantAddressLine5: "England",
-          ParticipantPostCode: "L1 8JQ",
-          TelephoneNumberHome: "07567890123",
-          EmailAddressHome: "edward.green@example.com",
-          PrimaryCareProvider: "E24680",
-          Gender: 1,
-        },
         ServiceNowId: "INC0002766",
         ServiceNowCreatedDate: "2025-06-12T00:00:00",
         RecordUpdatedDate: "2025-01-19T09:27:18.25",

--- a/application/CohortManager/src/Web/app/types/exceptionsApi/index.d.ts
+++ b/application/CohortManager/src/Web/app/types/exceptionsApi/index.d.ts
@@ -1,12 +1,10 @@
 export interface ExceptionsAPI {
   ExceptionId: number;
-  FileName: string;
   NhsNumber: string;
   DateCreated: string;
   DateResolved: string;
   RuleId: number;
   RuleDescription: string;
-  ErrorRecord: string;
   Category: number;
   ScreeningName: string;
   ExceptionDate: string;
@@ -32,5 +30,6 @@ export interface ExceptionAPIDetails extends ExceptionsAPI {
     TelephoneNumberHome: string;
     EmailAddressHome: string;
     PrimaryCareProvider: string;
+    SupersededByNhsNumber?: string;
   };
 }


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Adds `supersededByNhsNumber` to the UI mock data following the changes to the API, to allow for testing. Also clean up some of the data that we don't use in the UI in the mock API response (`FileName`/`ErrorRecord`)

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
