### PR TITLE
fix: now allows the bypassing of checking outcodes when a postcode is a dummy code

### DIFF
--- a/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/TransformDataLookupFacade.cs
+++ b/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/TransformDataLookupFacade.cs
@@ -60,14 +60,21 @@ public class TransformDataLookupFacade : ITransformDataLookupFacade
 
         return excludedSMUData!;
     }
+
     public bool ValidateOutcode(string postcode)
     {
-        string outcode = ValidationHelper.ParseOutcode(postcode)
+        var parsedOutCode = ValidationHelper.ParseOutcode(postcode);
+        _ = parsedOutCode.outcode
             ?? throw new TransformationException("Postcode format invalid");
 
-        var result = _outcodeClient.GetSingle(outcode).Result;
+        // we can bypass checking the database if it's a dummy postcode
+        if (!parsedOutCode.isDummyPostCode)
+        {
+            var result = _outcodeClient.GetSingle(parsedOutCode.outcode).Result;
+            return result != null;
+        }
 
-        return result != null;
+        return true;
     }
 
     /// <summary>
@@ -83,7 +90,7 @@ public class TransformDataLookupFacade : ITransformDataLookupFacade
 
     public string GetBsoCode(string postcode)
     {
-        string outcode = ValidationHelper.ParseOutcode(postcode)
+        string outcode = ValidationHelper.ParseOutcode(postcode).outcode
             ?? throw new TransformationException("Postcode format invalid");
 
         var result = _outcodeClient.GetSingle(outcode).Result;


### PR DESCRIPTION
… dummy code

<!-- markdownlint-disable-next-line first-line-heading -->
## Description
https://nhsd-jira.digital.nhs.uk/browse/DTOSS-3887

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
