### PR TITLE
feat: Pass through file names downstream in NEMS process flow

### DIFF
--- a/application/CohortManager/src/Functions/DemographicServices/RetrievePDSDemographic/IPdsProcessor.cs
+++ b/application/CohortManager/src/Functions/DemographicServices/RetrievePDSDemographic/IPdsProcessor.cs
@@ -1,10 +1,8 @@
 namespace NHS.CohortManager.DemographicServices;
 
-using Model;
-
 public interface IPdsProcessor
 {
-    Task ProcessPdsNotFoundResponse(HttpResponseMessage pdsResponse, string nhsNumber);
-    Task ProcessRecord(Participant participant);
+    Task ProcessPdsNotFoundResponse(HttpResponseMessage pdsResponse, string nhsNumber, string? sourceFileName = null);
+    Task ProcessRecord(Participant participant, string? fileName = null);
     Task<bool> UpsertDemographicRecordFromPDS(ParticipantDemographic participantDemographic);
 }

--- a/application/CohortManager/src/Functions/DemographicServices/RetrievePDSDemographic/IPdsProcessor.cs
+++ b/application/CohortManager/src/Functions/DemographicServices/RetrievePDSDemographic/IPdsProcessor.cs
@@ -1,5 +1,8 @@
 namespace NHS.CohortManager.DemographicServices;
 
+using System.Net.Http;
+using Model;
+
 public interface IPdsProcessor
 {
     Task ProcessPdsNotFoundResponse(HttpResponseMessage pdsResponse, string nhsNumber, string? sourceFileName = null);

--- a/application/CohortManager/src/Functions/DemographicServices/RetrievePDSDemographic/PdsProcessor.cs
+++ b/application/CohortManager/src/Functions/DemographicServices/RetrievePDSDemographic/PdsProcessor.cs
@@ -38,7 +38,7 @@ public class PdsProcessor : IPdsProcessor
     /// <param name="pdsResponse"></param>
     /// <param name="nhsNumber"></param>
     /// <returns></returns>
-    public async Task ProcessPdsNotFoundResponse(HttpResponseMessage pdsResponse, string nhsNumber)
+    public async Task ProcessPdsNotFoundResponse(HttpResponseMessage pdsResponse, string nhsNumber, string? sourceFileName = null)
     {
         var errorResponse = await pdsResponse!.Content.ReadFromJsonAsync<PdsErrorResponse>();
         // we now create a record as an update record and send to the manage participant function. Reason for removal for date should be today and the reason for remove of ORR
@@ -54,7 +54,7 @@ public class PdsProcessor : IPdsProcessor
             var participant = new Participant(pdsDemographic);
             participant.RecordType = Actions.Removed;
             //sends record for an update
-            await ProcessRecord(participant);
+            await ProcessRecord(participant, sourceFileName);
             return;
         }
         _logger.LogError("the PDS function has returned a 404 error. function now stopping processing");
@@ -65,7 +65,7 @@ public class PdsProcessor : IPdsProcessor
     /// </summary>
     /// <param name="participant"></param>
     /// <returns></returns>
-    public async Task ProcessRecord(Participant participant)
+    public async Task ProcessRecord(Participant participant, string? fileName = null)
     {
         var updateRecord = new ConcurrentQueue<BasicParticipantCsvRecord>();
         participant.RecordType = Actions.Removed;
@@ -73,7 +73,7 @@ public class PdsProcessor : IPdsProcessor
         var basicParticipantCsvRecord = new BasicParticipantCsvRecord
         {
             BasicParticipantData = _createBasicParticipantData.BasicParticipantData(participant),
-            FileName = PdsConstants.DefaultFileName,
+            FileName = string.IsNullOrWhiteSpace(fileName) ? PdsConstants.DefaultFileName : fileName,
             Participant = participant
         };
 

--- a/application/CohortManager/src/Functions/DemographicServices/RetrievePDSDemographic/RetrievePDSDemographic.cs
+++ b/application/CohortManager/src/Functions/DemographicServices/RetrievePDSDemographic/RetrievePDSDemographic.cs
@@ -51,7 +51,21 @@ public class RetrievePdsDemographic
         try
         {
             var nhsNumber = req.Query["nhsNumber"];
-            var sourceFileName = req.Query["sourceFileName"]; // optional: original NEMS blob name when available
+            // Optional: original NEMS blob name when available (parse safely without throwing if missing)
+            string? sourceFileName = null;
+            try
+            {
+                // Prefer robust parsing to avoid KeyNotFound for optional params
+                var parsed = Microsoft.AspNetCore.WebUtilities.QueryHelpers.ParseQuery(req.Url.Query);
+                if (parsed.TryGetValue("sourceFileName", out var sv))
+                {
+                    sourceFileName = sv.ToString();
+                }
+            }
+            catch
+            {
+                // Best-effort: leave null if parsing fails
+            }
 
             var bearerToken = await _bearerTokenService.GetBearerToken();
             if (bearerToken == null)

--- a/application/CohortManager/src/Functions/DemographicServices/RetrievePDSDemographic/RetrievePDSDemographic.cs
+++ b/application/CohortManager/src/Functions/DemographicServices/RetrievePDSDemographic/RetrievePDSDemographic.cs
@@ -51,6 +51,7 @@ public class RetrievePdsDemographic
         try
         {
             var nhsNumber = req.Query["nhsNumber"];
+            var sourceFileName = req.Query["sourceFileName"]; // optional: original NEMS blob name when available
 
             var bearerToken = await _bearerTokenService.GetBearerToken();
             if (bearerToken == null)
@@ -74,7 +75,7 @@ public class RetrievePdsDemographic
 
             if (response.StatusCode == HttpStatusCode.NotFound || pdsDemographic.ConfidentialityCode == "R")
             {
-                await _pdsProcessor.ProcessPdsNotFoundResponse(response, nhsNumber);
+                await _pdsProcessor.ProcessPdsNotFoundResponse(response, nhsNumber, sourceFileName);
                 return _createResponse.CreateHttpResponse(HttpStatusCode.NotFound, req, "PDS returned a 404 please database for details");
             }
 

--- a/application/CohortManager/src/Functions/DemographicServices/RetrievePDSDemographic/RetrievePDSDemographic.cs
+++ b/application/CohortManager/src/Functions/DemographicServices/RetrievePDSDemographic/RetrievePDSDemographic.cs
@@ -12,6 +12,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using System.Threading.Tasks;
 using Model;
+using Microsoft.AspNetCore.WebUtilities;
 
 public class RetrievePdsDemographic
 {
@@ -51,20 +52,11 @@ public class RetrievePdsDemographic
         try
         {
             var nhsNumber = req.Query["nhsNumber"];
-            // Optional: original NEMS blob name when available (parse safely without throwing if missing)
             string? sourceFileName = null;
-            try
+            var parsed = QueryHelpers.ParseQuery(req.Url.Query);
+            if (parsed.TryGetValue("sourceFileName", out var sv))
             {
-                // Prefer robust parsing to avoid KeyNotFound for optional params
-                var parsed = Microsoft.AspNetCore.WebUtilities.QueryHelpers.ParseQuery(req.Url.Query);
-                if (parsed.TryGetValue("sourceFileName", out var sv))
-                {
-                    sourceFileName = sv.ToString();
-                }
-            }
-            catch
-            {
-                // Best-effort: leave null if parsing fails
+                sourceFileName = sv.ToString();
             }
 
             var bearerToken = await _bearerTokenService.GetBearerToken();

--- a/tests/UnitTests/DemographicServicesTests/RetrievePDSDemographicTests/RetrievePDSDemographicTests.cs
+++ b/tests/UnitTests/DemographicServicesTests/RetrievePDSDemographicTests/RetrievePDSDemographicTests.cs
@@ -84,7 +84,6 @@ public class RetrievePdsDemographicTests : DatabaseTestBaseSetup<RetrievePdsDemo
         _httpClientFunction.Setup(x => x.GetResponseText(It.IsAny<HttpResponseMessage>()))
             .ReturnsAsync("{}");
 
-        // Build request with nhsNumber only
         SetupRequest("{}");
         SetupRequestWithQueryParams(new Dictionary<string, string>
         {
@@ -122,7 +121,6 @@ public class RetrievePdsDemographicTests : DatabaseTestBaseSetup<RetrievePdsDemo
 
         var fileName = "nems-file-123.xml";
 
-        // Build request with nhsNumber and sourceFileName
         SetupRequest("{}");
         SetupRequestWithQueryParams(new Dictionary<string, string>
         {

--- a/tests/UnitTests/DemographicServicesTests/RetrievePDSDemographicTests/RetrievePDSDemographicTests.cs
+++ b/tests/UnitTests/DemographicServicesTests/RetrievePDSDemographicTests/RetrievePDSDemographicTests.cs
@@ -27,8 +27,8 @@ public class RetrievePdsDemographicTests : DatabaseTestBaseSetup<RetrievePdsDemo
     private static readonly Mock<IPdsProcessor> _mockPdsProcessor = new();
 
 
-    private const string _validNhsNumber = "3112728165";
-    private const long _validNhsNumberLong = 3112728165;
+    private const string _validNhsNumber = "9000000009";
+    private const long _validNhsNumberLong = 9000000009;
 
     public RetrievePdsDemographicTests() : base((conn, logger, transaction, command, response) =>
     new RetrievePdsDemographic(
@@ -42,5 +42,102 @@ public class RetrievePdsDemographicTests : DatabaseTestBaseSetup<RetrievePdsDemo
         ))
     {
         CreateHttpResponseMock();
+        // Provide required config to avoid null access in function
+        var cfg = new RetrievePDSDemographicConfig
+        {
+            RetrievePdsParticipantURL = "http://example.org/pds",
+            DemographicDataServiceURL = "http://example.org/ds",
+            Audience = "aud",
+            KId = "kid",
+            AuthTokenURL = "http://example.org/auth",
+            ParticipantManagementTopic = "topic",
+            ServiceBusConnectionString_client_internal = "Endpoint=sb://test/",
+            UseFakePDSServices = false
+        };
+        _mockConfig.Setup(x => x.Value).Returns(cfg);
+        // Recreate service so it captures configured options Value
+        _service = new RetrievePdsDemographic(
+            _loggerMock.Object,
+            _createResponseMock.Object,
+            _httpClientFunction.Object,
+            _mockFhirPatientDemographicMapper.Object,
+            _mockConfig.Object,
+            _bearerTokenService.Object,
+            _mockPdsProcessor.Object
+        );
+    }
+
+    [TestMethod]
+    public async Task Run_NotFound_WithoutSourceFileName_ForwardsNull()
+    {
+        // Arrange
+        _bearerTokenService.Setup(x => x.GetBearerToken()).ReturnsAsync("token");
+        _mockFhirPatientDemographicMapper.Setup(x => x.ParseFhirJson(It.IsAny<string>()))
+            .Returns(new PdsDemographic { ConfidentialityCode = "R" });
+
+        var okResponse = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("{}")
+        };
+        _httpClientFunction.Setup(x => x.SendPdsGet(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(okResponse);
+        _httpClientFunction.Setup(x => x.GetResponseText(It.IsAny<HttpResponseMessage>()))
+            .ReturnsAsync("{}");
+
+        // Build request with nhsNumber only
+        SetupRequest("{}");
+        SetupRequestWithQueryParams(new Dictionary<string, string>
+        {
+            {"nhsNumber", _validNhsNumber }
+        });
+        _request.Setup(r => r.Url).Returns(new Uri($"http://localhost/api/RetrievePdsDemographic?nhsNumber={_validNhsNumber}"));
+
+        // Act
+        await _service.Run(_request.Object);
+
+        // Assert
+        _mockPdsProcessor.Verify(p => p.ProcessPdsNotFoundResponse(
+            It.IsAny<HttpResponseMessage>(),
+            _validNhsNumber,
+            It.Is<string?>(s => s == null)
+        ), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task Run_NotFound_WithSourceFileName_ForwardsFilename()
+    {
+        // Arrange
+        _bearerTokenService.Setup(x => x.GetBearerToken()).ReturnsAsync("token");
+        _mockFhirPatientDemographicMapper.Setup(x => x.ParseFhirJson(It.IsAny<string>()))
+            .Returns(new PdsDemographic { ConfidentialityCode = "R" });
+
+        var okResponse = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("{}")
+        };
+        _httpClientFunction.Setup(x => x.SendPdsGet(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(okResponse);
+        _httpClientFunction.Setup(x => x.GetResponseText(It.IsAny<HttpResponseMessage>()))
+            .ReturnsAsync("{}");
+
+        var fileName = "nems-file-123.xml";
+
+        // Build request with nhsNumber and sourceFileName
+        SetupRequest("{}");
+        SetupRequestWithQueryParams(new Dictionary<string, string>
+        {
+            {"nhsNumber", _validNhsNumber }
+        });
+        _request.Setup(r => r.Url).Returns(new Uri($"http://localhost/api/RetrievePdsDemographic?nhsNumber={_validNhsNumber}&sourceFileName={Uri.EscapeDataString(fileName)}"));
+
+        // Act
+        await _service.Run(_request.Object);
+
+        // Assert
+        _mockPdsProcessor.Verify(p => p.ProcessPdsNotFoundResponse(
+            It.IsAny<HttpResponseMessage>(),
+            _validNhsNumber,
+            It.Is<string?>(s => s == fileName)
+        ), Times.Once);
     }
 }

--- a/tests/UnitTests/PdsProcessorTests/PdsProcessorTests.cs
+++ b/tests/UnitTests/PdsProcessorTests/PdsProcessorTests.cs
@@ -100,7 +100,7 @@ public class PdsProcessorTests
     [TestMethod]
     public async Task ProcessPdsNotFoundResponse_WithSourceFileName_UsesProvidedFileName()
     {
-        // Arrange invalidated resource 404 error
+        // Arrange
         using var httpResponseMessage = CreatePdsErrorResponse(PdsConstants.InvalidatedResourceCode);
 
         var providedFileName = "nems-file-abc.xml";
@@ -119,7 +119,7 @@ public class PdsProcessorTests
     [TestMethod]
     public async Task ProcessPdsNotFoundResponse_WithoutSourceFileName_FallsBackToDefault()
     {
-        // Arrange invalidated resource 404 error
+        // Arrange
         using var httpResponseMessage = CreatePdsErrorResponse(PdsConstants.InvalidatedResourceCode);
 
         // Act (omit filename)

--- a/tests/UnitTests/PdsProcessorTests/PdsProcessorTests.cs
+++ b/tests/UnitTests/PdsProcessorTests/PdsProcessorTests.cs
@@ -108,7 +108,7 @@ public class PdsProcessorTests
         // Act
         await _pdsProcessor.ProcessPdsNotFoundResponse(httpResponseMessage, nhsNumber, providedFileName);
 
-        // Assert: ensure the queued record carries the provided filename
+        // Assert
         _addBatchToQueue.Verify(x => x.ProcessBatch(
             It.Is<ConcurrentQueue<BasicParticipantCsvRecord>>(q =>
                 q.Count == 1 && q.ToArray()[0].FileName == providedFileName),
@@ -122,10 +122,10 @@ public class PdsProcessorTests
         // Arrange
         using var httpResponseMessage = CreatePdsErrorResponse(PdsConstants.InvalidatedResourceCode);
 
-        // Act (omit filename)
+        // Act
         await _pdsProcessor.ProcessPdsNotFoundResponse(httpResponseMessage, nhsNumber);
 
-        // Assert: ensure the queued record uses default when no filename provided
+        // Assert
         _addBatchToQueue.Verify(x => x.ProcessBatch(
             It.Is<ConcurrentQueue<BasicParticipantCsvRecord>>(q =>
                 q.Count == 1 && q.ToArray()[0].FileName == PdsConstants.DefaultFileName),

--- a/tests/UnitTests/PdsProcessorTests/PdsProcessorTests.cs
+++ b/tests/UnitTests/PdsProcessorTests/PdsProcessorTests.cs
@@ -6,6 +6,9 @@ using DataServices.Client;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Model;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Net.Http;
 using Moq;
 using NHS.CohortManager.DemographicServices;
 
@@ -46,33 +49,37 @@ public class PdsProcessorTests
 
     }
 
-    [TestMethod]
-    public async Task ProcessPdsNotFoundResponse_ProcessesResponse_SendsForDistribution()
+    private static HttpResponseMessage CreatePdsErrorResponse(string code)
     {
         var errorResponse = new PdsErrorResponse()
         {
-            issue = new List<PdsIssue>()
+            issue = new List<PdsIssue>
             {
-                new PdsIssue()
+                new PdsIssue
                 {
-                    code = "",
-                    details = new PdsErrorDetails()
+                    code = string.Empty,
+                    details = new PdsErrorDetails
                     {
-                        coding = new List<PdsCoding>()
+                        coding = new List<PdsCoding>
                         {
-                            new PdsCoding()
-                            {
-                                code = "INVALIDATED_RESOURCE"
-                            }
+                            new PdsCoding { code = code }
                         }
                     }
                 }
             }
         };
 
-        HttpResponseMessage httpResponseMessage = new HttpResponseMessage();
-        httpResponseMessage.Content = new StringContent(JsonSerializer.Serialize(errorResponse));
+        var msg = new HttpResponseMessage
+        {
+            Content = new StringContent(JsonSerializer.Serialize(errorResponse))
+        };
+        return msg;
+    }
 
+    [TestMethod]
+    public async Task ProcessPdsNotFoundResponse_ProcessesResponse_SendsForDistribution()
+    {
+        using var httpResponseMessage = CreatePdsErrorResponse(PdsConstants.InvalidatedResourceCode);
         await _pdsProcessor.ProcessPdsNotFoundResponse(httpResponseMessage, nhsNumber);
 
         _mockLogger.Verify(x => x.Log(It.Is<LogLevel>(l => l == LogLevel.Information),
@@ -91,32 +98,45 @@ public class PdsProcessorTests
     }
 
     [TestMethod]
+    public async Task ProcessPdsNotFoundResponse_WithSourceFileName_UsesProvidedFileName()
+    {
+        // Arrange invalidated resource 404 error
+        using var httpResponseMessage = CreatePdsErrorResponse(PdsConstants.InvalidatedResourceCode);
+
+        var providedFileName = "nems-file-abc.xml";
+
+        // Act
+        await _pdsProcessor.ProcessPdsNotFoundResponse(httpResponseMessage, nhsNumber, providedFileName);
+
+        // Assert: ensure the queued record carries the provided filename
+        _addBatchToQueue.Verify(x => x.ProcessBatch(
+            It.Is<ConcurrentQueue<BasicParticipantCsvRecord>>(q =>
+                q.Count == 1 && q.ToArray()[0].FileName == providedFileName),
+            It.IsAny<string>()),
+            Times.Once);
+    }
+
+    [TestMethod]
+    public async Task ProcessPdsNotFoundResponse_WithoutSourceFileName_FallsBackToDefault()
+    {
+        // Arrange invalidated resource 404 error
+        using var httpResponseMessage = CreatePdsErrorResponse(PdsConstants.InvalidatedResourceCode);
+
+        // Act (omit filename)
+        await _pdsProcessor.ProcessPdsNotFoundResponse(httpResponseMessage, nhsNumber);
+
+        // Assert: ensure the queued record uses default when no filename provided
+        _addBatchToQueue.Verify(x => x.ProcessBatch(
+            It.Is<ConcurrentQueue<BasicParticipantCsvRecord>>(q =>
+                q.Count == 1 && q.ToArray()[0].FileName == PdsConstants.DefaultFileName),
+            It.IsAny<string>()),
+            Times.Once);
+    }
+
+    [TestMethod]
     public async Task ProcessPdsNotFoundResponse_WithNonInvalidatedResource_LogsError()
     {
-        var errorResponse = new PdsErrorResponse()
-        {
-            issue = new List<PdsIssue>()
-            {
-                new PdsIssue()
-                {
-                    code = "",
-                    details = new PdsErrorDetails()
-                    {
-                        coding = new List<PdsCoding>()
-                        {
-                            new PdsCoding()
-                            {
-                                code = ""
-                            }
-                        }
-                    }
-                }
-            }
-        };
-
-        HttpResponseMessage httpResponseMessage = new HttpResponseMessage();
-        httpResponseMessage.Content = new StringContent(JsonSerializer.Serialize(errorResponse));
-
+        using var httpResponseMessage = CreatePdsErrorResponse("");
         await _pdsProcessor.ProcessPdsNotFoundResponse(httpResponseMessage, nhsNumber);
 
         _mockLogger.Verify(x => x.Log(It.Is<LogLevel>(l => l == LogLevel.Information),


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

This change updates the NEMS flow to retain the original blob filename for downstream traceability.

- ProcessNemsUpdate now passes the actual blob filename into BasicParticipantCsvRecord (instead of the constant "NemsMessages").
- RetrievePdsDemographic accepts an optional `sourceFileName` and forwards it when creating a BasicParticipantCsvRecord in the PDS 404/invalidated path; when not provided, the existing default is used.

## Context

Enable traceability from the NEMS inbound blob through to participant processing by carrying the original blob filename. This aligns logs and audit records without altering existing behavior when no filename is available.

### API Changes

- `RetrievePdsDemographic` now accepts an optional query parameter `sourceFileName`. When provided, records created in the 404/invalidated path use this value for `BasicParticipantCsvRecord.FileName`; otherwise, the existing default is used.

### Backward Compatibility

- Callers not providing `sourceFileName` experience no behavior change; defaults are preserved.

## Type of changes

- [x] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [x] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
