### PR TITLE
fix: incorrect language code mapping

### DIFF
--- a/application/CohortManager/src/Functions/Shared/Common/FhirPatientDemographicMapper.cs
+++ b/application/CohortManager/src/Functions/Shared/Common/FhirPatientDemographicMapper.cs
@@ -62,7 +62,7 @@ public class FhirPatientDemographicMapper : IFhirPatientDemographicMapper
                 var patientXml = ExtractPatientXmlFromBundle(xml);
                 if (string.IsNullOrEmpty(patientXml))
                     return string.Empty;
-                
+
                 var parser = new FhirXmlParser();
                 var patient = parser.Parse<Patient>(patientXml);
                 return ExtractNhsNumberFromPatient(patient);
@@ -86,10 +86,10 @@ public class FhirPatientDemographicMapper : IFhirPatientDemographicMapper
     {
         var doc = new XmlDocument();
         doc.LoadXml(bundleXml);
-        
+
         var nsManager = new XmlNamespaceManager(doc.NameTable);
         nsManager.AddNamespace("fhir", "http://hl7.org/fhir");
-        
+
         var patientNode = doc.SelectSingleNode("//fhir:Patient", nsManager);
         return patientNode?.OuterXml ?? string.Empty;
     }
@@ -100,7 +100,7 @@ public class FhirPatientDemographicMapper : IFhirPatientDemographicMapper
         if (patient?.Identifier == null) return patient?.Id ?? string.Empty;
 
         // Look for NHS number identifier
-        var nhsIdentifier = patient.Identifier.FirstOrDefault(id => 
+        var nhsIdentifier = patient.Identifier.FirstOrDefault(id =>
             id.System == "https://fhir.nhs.uk/Id/nhs-number");
 
         return nhsIdentifier?.Value ?? patient.Id ?? string.Empty;
@@ -375,7 +375,7 @@ public class FhirPatientDemographicMapper : IFhirPatientDemographicMapper
             if (languageComponent != null)
             {
                 var languageCoding = (languageComponent.Value as CodeableConcept)?.Coding?.FirstOrDefault();
-                demographic.PreferredLanguage = languageCoding?.Display ?? languageCoding?.Code;
+                demographic.PreferredLanguage = languageCoding?.Code ?? languageCoding?.Display;
             }
 
             if (interpreterComponent != null && interpreterComponent.Value is FhirBoolean interpreterBool && interpreterBool.Value.HasValue)


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

lanauge code was mapping to display name not code 

## Context

pds received records now have the correct language code

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
