### PR TITLE
fix: fxing date formatting

### DIFF
--- a/application/CohortManager/src/Functions/DemographicServices/RetrievePDSDemographic/RetrievePDSDemographic.cs
+++ b/application/CohortManager/src/Functions/DemographicServices/RetrievePDSDemographic/RetrievePDSDemographic.cs
@@ -5,7 +5,6 @@ using System.Net;
 using System.Text.Json;
 using Common;
 using Common.Interfaces;
-using DataServices.Client;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Extensions.Logging;

--- a/application/CohortManager/src/Functions/Shared/Common/FhirPatientDemographicMapper.cs
+++ b/application/CohortManager/src/Functions/Shared/Common/FhirPatientDemographicMapper.cs
@@ -10,6 +10,8 @@ using Model;
 using Model.Enums;
 using System;
 using System.Linq;
+using Azure.Storage.Blobs.Models;
+using System.Globalization;
 
 public class FhirPatientDemographicMapper : IFhirPatientDemographicMapper
 {
@@ -134,6 +136,7 @@ public class FhirPatientDemographicMapper : IFhirPatientDemographicMapper
         MapLanguagePreferences(patient, demographic);
         MapRemovalInformation(patient, demographic);
         MapSecurityMetadata(patient, demographic);
+        MapDates();
 
         return demographic;
     }
@@ -151,6 +154,24 @@ public class FhirPatientDemographicMapper : IFhirPatientDemographicMapper
 
         if (gp.Identifier.Period?.Start != null)
             demographic.PrimaryCareProviderEffectiveFromDate = gp.Identifier.Period.Start.ToString();
+    }
+
+    private static void MapDates(Patient patient, Demographic demographic)
+    {
+        var patientDateOfBirth = DateTime.TryParseExact(patient.BirthDate, "yyyyMMdd", CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime tempDate);
+        if (!patientDateOfBirth)
+        {
+            throw new Exception("there was a problem parsing the date of birth");
+        }
+        demographic.DateOfBirth = tempDate.ToString();
+        demographic.UsualAddressEffectiveFromDate
+        demographic.DateOfDeath
+        demographic.TelephoneNumberEffectiveFromDate
+        demographic.MobileNumberEffectiveFromDate
+        demographic.EmailAddressEffectiveFromDate
+        demographic.RecordInsertDateTime
+        demographic.RecordUpdateDateTime =
+
     }
 
     private static void MapNames(Patient patient, Demographic demographic)
@@ -246,7 +267,7 @@ public class FhirPatientDemographicMapper : IFhirPatientDemographicMapper
         // Map effective date
         if (address.Period?.Start != null)
         {
-            demographic.UsualAddressEffectiveFromDate = address.Period.Start.ToString();
+            demographic.UsualAddressEffectiveFromDate = address.Period.Start;
         }
     }
 
@@ -451,4 +472,15 @@ public class FhirPatientDemographicMapper : IFhirPatientDemographicMapper
 
         demographic.ConfidentialityCode = confidentialityCoding.Code;
     }
+
+    private static string ConvertDateTime(string dateToConvert)
+    {
+        var patientDateOfBirth = DateTime.TryParseExact(dateToConvert, "yyyyMMdd", CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime tempDate);
+        if (!patientDateOfBirth)
+        {
+            throw new Exception("there was a problem parsing the date of birth");
+        }
+        return tempDate.ToString();
+    }
+
 }


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

- now uses the yyyyMMdd when upseting data from the fair API 

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
