### PR TITLE
fix: Set IsStubbed to true by default in local docker compose for NEMS Sub Mgmt

### DIFF
--- a/application/CohortManager/compose.core.yaml
+++ b/application/CohortManager/compose.core.yaml
@@ -289,6 +289,7 @@ services:
         - NemsDefaultEventTypes0=pds-record-change-1
         - NemsBypassServerCertificateValidation=true
         - DtOsDatabaseConnectionString=Server=db,1433;Database=${DB_NAME};User Id=SA;Password=${PASSWORD};TrustServerCertificate=True
+        - IsStubbed=true
       ports:
         - "9081:9081"
 

--- a/application/CohortManager/src/Functions/DemographicServices/ManageNemsSubscription/Program.cs
+++ b/application/CohortManager/src/Functions/DemographicServices/ManageNemsSubscription/Program.cs
@@ -22,10 +22,15 @@ var nemsConfig = config;
 
 X509Certificate2 nemsCertificate;
 
-
-// Load NEMS certificate up-front and inject into DI
-
-nemsCertificate = await nemsConfig.LoadNemsCertificateAsync(logger);
+if (nemsConfig.IsStubbed)
+{
+    logger.LogInformation("ManageNemsSubscription is running in stubbed mode; skipping certificate load.");
+    nemsCertificate = new X509Certificate2();
+}
+else
+{
+    nemsCertificate = await nemsConfig.LoadNemsCertificateAsync(logger);
+}
 
 
 host.ConfigureFunctionsWebApplication();


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

<!-- Describe your changes in detail. -->
Setting IsStubbed to true on the managenemssubscription function in local docker setup - this means no certificates are needed to get it up and running.

## Context

<!-- Why is this change required? What problem does it solve? -->
Local docker based unit tests are failing when the certificate isn't present.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
