### PR TITLE
fix: added Mac fixes for docker + QoL improvements for running automation tests locally

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -24,6 +24,26 @@
       },
     },
     {
+      "label": "Spin up Docker for E2E regression (build + start)",
+      "type": "shell",
+      "osx": {
+        "command": "podman compose down && podman compose -f compose.core.yaml build && podman compose -f compose.cohort-distribution.yaml build && podman compose -f compose.data-services.yaml build && podman compose -f compose.deps.yaml up -d && (podman compose -f compose.deps.yaml up --build db-migration || true) && (podman compose -f compose.deps.yaml rm -f db-migration || true) && podman compose down && podman compose --profile \"service-now\" --profile \"bs-select\" --profile \"non-essential\" up -d"
+      },
+      "windows": {
+        "command": "docker compose down && docker compose -f compose.core.yaml build && docker compose -f compose.cohort-distribution.yaml build && docker compose -f compose.data-services.yaml build && docker compose -f compose.deps.yaml up -d && (docker compose -f compose.deps.yaml up --build db-migration || true) && (docker compose -f compose.deps.yaml rm -f db-migration || true) && docker compose down && docker compose --profile \"service-now\" --profile \"bs-select\" --profile \"non-essential\" up -d",
+        "options": {
+          "shell": { "executable": "wsl.exe" }
+        }
+      },
+      "options": {
+        "cwd": "./application/CohortManager"
+      },
+      "presentation": {
+        "reveal": "always",
+        "panel": "new"
+      }
+    },
+    {
       "label": "Restart application",
       "type": "shell",
       "osx": {
@@ -642,6 +662,58 @@
           "hide": true
         }
       }
+    },
+    {
+      "label": "E2E: Epic1 regression (reuse containers)",
+      "type": "shell",
+      "osx": { "command": "node scripts/health-check.js && npm run test:regression_e2e_epic1" },
+      "windows": { "command": "node scripts/health-check.js && npm run test:regression_e2e_epic1", "options": { "shell": { "executable": "wsl.exe" } } },
+      "options": { "cwd": "./tests/playwright-tests" },
+      "presentation": { "reveal": "always", "panel": "new" }
+    },
+    {
+      "label": "E2E: Epic2 regression (reuse containers)",
+      "type": "shell",
+      "osx": { "command": "node scripts/health-check.js && npm run test:regression_e2e_epic2" },
+      "windows": { "command": "node scripts/health-check.js && npm run test:regression_e2e_epic2", "options": { "shell": { "executable": "wsl.exe" } } },
+      "options": { "cwd": "./tests/playwright-tests" },
+      "presentation": { "reveal": "always", "panel": "new" }
+    },
+    {
+      "label": "E2E: Epic3 regression (reuse containers)",
+      "type": "shell",
+      "osx": { "command": "node scripts/health-check.js && npm run test:regression_e2e_epic3" },
+      "windows": { "command": "node scripts/health-check.js && npm run test:regression_e2e_epic3", "options": { "shell": { "executable": "wsl.exe" } } },
+      "options": { "cwd": "./tests/playwright-tests" },
+      "presentation": { "reveal": "always", "panel": "new" }
+    },
+    {
+      "label": "E2E: Epic4C regression (reuse containers)",
+      "type": "shell",
+      "osx": { "command": "node scripts/health-check.js && npm run test:regression_e2e_epic4c" },
+      "windows": { "command": "node scripts/health-check.js && npm run test:regression_e2e_epic4c", "options": { "shell": { "executable": "wsl.exe" } } },
+      "options": { "cwd": "./tests/playwright-tests" },
+      "presentation": { "reveal": "always", "panel": "new" }
+    },
+    {
+      "label": "E2E: Epic4D regression (reuse containers)",
+      "type": "shell",
+      "osx": { "command": "node scripts/health-check.js && npm run test:regression_e2e_epic4d" },
+      "windows": { "command": "node scripts/health-check.js && npm run test:regression_e2e_epic4d", "options": { "shell": { "executable": "wsl.exe" } } },
+      "options": { "cwd": "./tests/playwright-tests" },
+      "presentation": { "reveal": "always", "panel": "new" }
+    },
+    {
+      "label": "Prune: Podman/Docker build cache",
+      "type": "shell",
+      "osx": {
+        "command": "set +e; echo 'Pruning Podman build cache…'; podman builder prune -a -f; echo 'Podman disk usage:'; podman system df"
+      },
+      "windows": {
+        "command": "set +e && echo Pruning Docker build cache… && docker builder prune -a -f && echo Docker disk usage: && docker system df",
+        "options": { "shell": { "executable": "wsl.exe" } }
+      },
+      "presentation": { "reveal": "always", "panel": "new" }
     }
   ]
 }

--- a/application/CohortManager/compose.cohort-distribution.yaml
+++ b/application/CohortManager/compose.cohort-distribution.yaml
@@ -4,6 +4,7 @@ services:
   distribute-participant:
     container_name: distribute-participant
     image: cohort-manager-distribute-participant
+    platform: "linux/amd64"
     networks: [cohman-network]
     build:
       context: ./src/Functions/
@@ -30,38 +31,44 @@ services:
   retrieve-cohort-distribution-data:
     container_name: retrieve-cohort-distribution-data
     image: cohort-manager-retrieve-cohort-distribution-data
+    platform: "linux/amd64"
     networks: [cohman-network]
     build:
       context: ./src/Functions/
       dockerfile: CohortDistributionServices/RetrieveCohortDistribution/Dockerfile
     profiles: [bs-select]
+    ports:
+      - "7078:7078"
     environment:
       - ASPNETCORE_URLS=http://*:7078
       - DtOsDatabaseConnectionString=Server=db,1433;Database=${DB_NAME};User Id=SA;Password=${PASSWORD};TrustServerCertificate=True
       - ExceptionFunctionURL=http://create-exception:7070/api/CreateException
       - CohortDistributionDataServiceURL=http://cohort-distribution-data-service:7992/api/CohortDistributionDataService/
-      - BsSelectRequestAuditDataService=http://bs-select-request-audit-data-service:7956/api/BsSelectRequestAuditDataService/
+      - BsSelectRequestAuditDataService=http://bs-request-audit-data-service:7956/api/BsSelectRequestAuditDataService/
       - AcceptableLatencyThresholdMs=500
-      - CohortDistributionDataServiceURL=http://localhost:7992/api/CohortDistributionDataService/
 
   retrieve-cohort-request-audit:
     container_name: retrieve-cohort-request-audit
     image: cohort-manager-retrieve-cohort-request-audit
+    platform: "linux/amd64"
     networks: [cohman-network]
     build:
       context: ./src/Functions/
       dockerfile: CohortDistributionServices/RetrieveCohortRequestAudit/Dockerfile
     profiles: [bs-select]
+    ports:
+      - "7086:7086"
     environment:
       - ASPNETCORE_URLS=http://*:7086
       - DtOsDatabaseConnectionString=Server=db,1433;Database=${DB_NAME};User Id=SA;Password=${PASSWORD};TrustServerCertificate=True
       - CohortDistributionDataServiceURL=http://cohort-distribution-data-service:7992/api/CohortDistributionDataService/
-      - BsSelectRequestAuditDataService=http://bs-select-request-audit-data-service:7956/api/BsSelectRequestAuditDataService/
+      - BsSelectRequestAuditDataService=http://bs-request-audit-data-service:7956/api/BsSelectRequestAuditDataService/
       - ExceptionFunctionURL=http://create-exception:7070/api/CreateException
 
   transform-data-service:
     container_name: transform-data-service
     image: cohort-manager-transform-data-service
+    platform: "linux/amd64"
     networks: [cohman-network]
     build:
       context: ./src/Functions/
@@ -79,6 +86,7 @@ services:
   remove-validation-exception-data:
     container_name: remove-validation-exception-data
     image: cohort-manager-remove-validation-exception-data
+    platform: "linux/amd64"
     networks: [cohman-network]
     build:
       context: ./src/Functions/

--- a/application/CohortManager/compose.core.yaml
+++ b/application/CohortManager/compose.core.yaml
@@ -5,6 +5,7 @@ services:
   retrieve-mesh-file:
     container_name: retrieve-mesh-file
     image: cohort-manager-retrieve-mesh-file
+    platform: "linux/amd64"
     networks: [cohman-network]
     build:
       context: ./src/Functions/
@@ -24,6 +25,7 @@ services:
   nems-mesh-retrieval:
     container_name: nems-mesh-retrieval
     image: cohort-manager-nems-mesh-retrieval
+    platform: "linux/amd64"
     networks: [cohman-network]
     build:
       context: ./src/Functions/
@@ -46,6 +48,7 @@ services:
   process-nems-update:
     container_name: process-nems-update
     image: cohort-manager-process-nems-update
+    platform: "linux/amd64"
     networks: [cohman-network]
     build:
       context: ./src/Functions/
@@ -66,10 +69,13 @@ services:
   receive-caas-file:
     container_name: receive-caas-file
     image: cohort-manager-receive-caas-file
+    platform: "linux/amd64"
     networks: [cohman-network]
     build:
       context: ./src/Functions/
       dockerfile: CaasIntegration/receiveCaasFile/Dockerfile
+    ports:
+      - "7060:7060"
     environment:
       - AzureWebJobsStorage=${AZURITE_CONNECTION_STRING}
       - caasfolder_STORAGE=${AZURITE_CONNECTION_STRING}
@@ -93,6 +99,7 @@ services:
   manage-participant:
     container_name: manage-participant
     image: cohort-manager-manage-participant
+    platform: "linux/amd64"
     networks: [cohman-network]
     build:
       context: ./src/Functions/
@@ -109,6 +116,7 @@ services:
   manage-servicenow-participant:
     container_name: manage-servicenow-participant
     image: cohort-manager-manage-servicenow-participant
+    platform: "linux/amd64"
     networks: [cohman-network]
     build:
       context: ./src/Functions/
@@ -129,6 +137,7 @@ services:
   update-blocked-flag:
     container_name: update-blocked-flag
     image: cohort-manager-update-blocked-flag
+    platform: "linux/amd64"
     networks: [cohman-network]
     build:
       context: ./src/Functions/
@@ -144,11 +153,12 @@ services:
       - ExceptionFunctionURL=http://create-exception:7070/api/CreateException
       - ManageNemsSubscriptionUnsubscribeURL=http://manage-nems-subscription:9081/api/Unsubscribe
       - ManageNemsSubscriptionSubscribeURL=http://manage-nems-subscription:9081/api/Subscribe
-      - RetrievePdsDemographicURL=http://etrieve-pds-demographic:8082/api/RetrievePdsDemographic
+      - RetrievePdsDemographicURL=http://retrieve-pds-demographic:8082/api/RetrievePdsDemographic
 
   delete-participant:
     container_name: delete-participant
     image: cohort-manager-delete-participant
+    platform: "linux/amd64"
     networks: [cohman-network]
     ports:
     - "7087:7087"
@@ -167,6 +177,7 @@ services:
   create-exception:
     container_name: create-exception
     image: cohort-manager-create-exception
+    platform: "linux/amd64"
     networks: [cohman-network]
     build:
       context: ./src/Functions/
@@ -181,6 +192,7 @@ services:
   update-exception:
     container_name: update-exception
     image: cohort-manager-update-exception
+    platform: "linux/amd64"
     networks: [cohman-network]
     build:
       context: ./src/Functions/
@@ -194,6 +206,7 @@ services:
   get-validation-exceptions:
     container_name: get-validation-exceptions
     image: cohort-manager-get-validation-exceptions
+    platform: "linux/amd64"
     networks: [cohman-network]
     build:
       context: ./src/Functions/
@@ -211,6 +224,7 @@ services:
   static-validation:
     container_name: static-validation
     image: cohort-manager-static-validation
+    platform: "linux/amd64"
     networks: [cohman-network]
     build:
       context: ./src/Functions/
@@ -223,6 +237,7 @@ services:
   lookup-validation:
     container_name: lookup-validation
     image: cohort-manager-lookup-validation
+    platform: "linux/amd64"
     networks: [cohman-network]
     build:
       context: ./src/Functions/
@@ -242,6 +257,7 @@ services:
   retrieve-pds-demographic:
     container_name: retrieve-pds-demographic
     image: cohort-manager-retrieve-pds-demographic
+    platform: "linux/amd64"
     networks: [cohman-network]
     build:
       context: ./src/Functions/
@@ -266,6 +282,7 @@ services:
   manage-nems-subscription:
       container_name: manage-nems-subscription
       image: cohort-manager-manage-nems-subscription
+      platform: "linux/amd64"
       networks: [cohman-network]
       profiles: [nems]
       build:
@@ -295,6 +312,7 @@ services:
   durable-demographic-function:
     container_name: durable-demographic-function
     image: cohort-manager-durable-demographic-function
+    platform: "linux/amd64"
     networks: [cohman-network]
     build:
       context: ./src/Functions/
@@ -312,6 +330,7 @@ services:
   servicenow-message-handler:
     container_name: servicenow-message-handler
     image: cohort-manager-servicenow-message-handler
+    platform: "linux/amd64"
     networks: [cohman-network]
     build:
       context: ./src/Functions/
@@ -334,6 +353,7 @@ services:
   servicenow-cohort-lookup:
     container_name: servicenow-cohort-lookup
     image: cohort-manager-servicenow-cohort-lookup
+    platform: "linux/amd64"
     networks: [cohman-network]
     build:
       context: ./src/Functions/
@@ -351,6 +371,7 @@ services:
     build:
       context: ./src/Web
       dockerfile: Dockerfile
+    platform: "linux/amd64"
     restart: always
     profiles: [ui]
     ports:

--- a/application/CohortManager/compose.data-services.yaml
+++ b/application/CohortManager/compose.data-services.yaml
@@ -4,6 +4,7 @@ services:
   exception-management-data-service:
     container_name: exception-management-data-service
     image: cohort-manager-exception-management-data-service
+    platform: "linux/amd64"
     ports:
       - 7911:7911
     networks: [cohman-network]
@@ -18,19 +19,23 @@ services:
   bs-request-audit-data-service:
     container_name: bs-request-audit-data-service
     image: cohort-manager-bs-request-audit-data-service
+    platform: "linux/amd64"
     networks: [cohman-network]
     build:
       context: ./src/Functions/
       dockerfile: screeningDataServices/BsSelectRequestAudit/Dockerfile
     profiles: [bs-select]
+    ports:
+      - 7956:7956
     environment:
-      - ASPNETCORE_URLS=http://*:7989
+      - ASPNETCORE_URLS=http://*:7956
       - DtOsDatabaseConnectionString=Server=db,1433;Database=${DB_NAME};User Id=SA;Password=${PASSWORD};TrustServerCertificate=True
       - AcceptableLatencyThresholdMs=500
 
   screening-lkp-data-service:
     container_name: screening-lkp-data-service
     image: cohort-manager-screening-lkp-data-service
+    platform: "linux/amd64"
     networks: [cohman-network]
     build:
       context: ./src/Functions/
@@ -43,6 +48,7 @@ services:
   gene-code-lkp-data-service:
     container_name: gene-code-lkp-data-service
     image: cohort-manager-gene-code-lkp-data-service
+    platform: "linux/amd64"
     networks: [cohman-network]
     profiles: [not-implemented]
     build:
@@ -56,6 +62,7 @@ services:
   higher-risk-referral-reason-lkp-data-service:
     container_name: higher-risk-referral-reason-lkp-data-service
     image: cohort-manager-higher-risk-referral-reason-lkp-data-service
+    platform: "linux/amd64"
     networks: [cohman-network]
     build:
       context: ./src/Functions/
@@ -69,6 +76,7 @@ services:
   participant-demographic-data-service:
     container_name: participant-demographic-data-service
     image: cohort-manager-participant-demographic-data-service
+    platform: "linux/amd64"
     ports:
       - 7993:7993
     networks: [cohman-network]
@@ -83,6 +91,7 @@ services:
   participant-management-data-service:
     container_name: participant-management-data-service
     image: cohort-manager-participant-management-data-service
+    platform: "linux/amd64"
     ports:
       - 7994:7994
     networks: [cohman-network]
@@ -97,6 +106,7 @@ services:
   cohort-distribution-data-service:
     container_name: cohort-distribution-data-service
     image: cohort-manager-cohort-distribution-data-service
+    platform: "linux/amd64"
     ports:
       - 7992:7992
     networks: [cohman-network]
@@ -111,6 +121,7 @@ services:
   nems-subscription-data-service:
     container_name: nems-subscription-data-service
     image: cohort-manager-nems-subscription-data-service
+    platform: "linux/amd64"
     networks: [cohman-network]
     profiles: [nems]
     build:
@@ -124,6 +135,7 @@ services:
   reference-data-service:
     container_name: reference-data-service
     image: cohort-manager-reference-data-service
+    platform: "linux/amd64"
     networks: [cohman-network]
     build:
       context: ./src/Functions/
@@ -136,6 +148,7 @@ services:
   servicenow-cases-data-service:
      container_name: servicenow-cases-data-service
      image: cohort-manager-servicenow-cases-data-service
+     platform: "linux/amd64"
      networks: [cohman-network]
      profiles: [service-now]
      build:

--- a/application/CohortManager/src/Functions/CaasIntegration/RetrieveMeshFile/Dockerfile
+++ b/application/CohortManager/src/Functions/CaasIntegration/RetrieveMeshFile/Dockerfile
@@ -17,12 +17,11 @@ FROM base AS function
 COPY ./CaasIntegration/RetrieveMeshFile /src/dotnet-function-app
 WORKDIR /src/dotnet-function-app
 
-RUN --mount=type=cache,target=/root/.nuget/packages \
-    dotnet publish *.csproj --output /home/site/wwwroot
-
+RUN dotnet restore
+RUN dotnet publish *.csproj --output /home/site/wwwroot --no-restore
 # To enable ssh & remote debugging on app service change the base image to the one below
 # FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0-appservice
-FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0
+FROM --platform=linux/amd64 mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     AzureFunctionsJobHost__Logging__Console__IsEnabled=true
 

--- a/application/CohortManager/src/Functions/CaasIntegration/receiveCaasFile/Dockerfile
+++ b/application/CohortManager/src/Functions/CaasIntegration/receiveCaasFile/Dockerfile
@@ -17,12 +17,11 @@ FROM base AS function
 COPY ./CaasIntegration/receiveCaasFile /src/dotnet-function-app
 WORKDIR /src/dotnet-function-app
 
-RUN --mount=type=cache,target=/root/.nuget/packages \
-    dotnet publish *.csproj --output /home/site/wwwroot
-
+RUN dotnet restore
+RUN dotnet publish *.csproj --output /home/site/wwwroot --no-restore
 # To enable ssh & remote debugging on app service change the base image to the one below
 # FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0-appservice
-FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0
+FROM --platform=linux/amd64 mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     AzureFunctionsJobHost__Logging__Console__IsEnabled=true
 

--- a/application/CohortManager/src/Functions/CohortDistributionServices/DistributeParticipant/Dockerfile
+++ b/application/CohortManager/src/Functions/CohortDistributionServices/DistributeParticipant/Dockerfile
@@ -17,12 +17,11 @@ FROM base AS function
 COPY ./CohortDistributionServices/DistributeParticipant /src/dotnet-function-app
 WORKDIR /src/dotnet-function-app
 
-RUN --mount=type=cache,target=/root/.nuget/packages \
-    dotnet publish *.csproj --output /home/site/wwwroot
-
+RUN dotnet restore
+RUN dotnet publish *.csproj --output /home/site/wwwroot --no-restore
 # To enable ssh & remote debugging on app service change the base image to the one below
 # FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0-appservice
-FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0
+FROM --platform=linux/amd64 mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     AzureFunctionsJobHost__Logging__Console__IsEnabled=true
 

--- a/application/CohortManager/src/Functions/CohortDistributionServices/RetrieveCohortDistribution/Dockerfile
+++ b/application/CohortManager/src/Functions/CohortDistributionServices/RetrieveCohortDistribution/Dockerfile
@@ -17,12 +17,11 @@ FROM base AS function
 COPY ./CohortDistributionServices/RetrieveCohortDistribution /src/dotnet-function-app
 WORKDIR /src/dotnet-function-app
 
-RUN --mount=type=cache,target=/root/.nuget/packages \
-    dotnet publish *.csproj --output /home/site/wwwroot
-
+RUN dotnet restore
+RUN dotnet publish *.csproj --output /home/site/wwwroot --no-restore
 # To enable ssh & remote debugging on app service change the base image to the one below
 # FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0-appservice
-FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0
+FROM --platform=linux/amd64 mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     AzureFunctionsJobHost__Logging__Console__IsEnabled=true
 

--- a/application/CohortManager/src/Functions/CohortDistributionServices/RetrieveCohortRequestAudit/Dockerfile
+++ b/application/CohortManager/src/Functions/CohortDistributionServices/RetrieveCohortRequestAudit/Dockerfile
@@ -19,12 +19,11 @@ FROM base AS function
 COPY ./CohortDistributionServices/RetrieveCohortRequestAudit /src/dotnet-function-app
 WORKDIR /src/dotnet-function-app
 
-RUN --mount=type=cache,target=/root/.nuget/packages \
-    dotnet publish *.csproj --output /home/site/wwwroot
-
+RUN dotnet restore
+RUN dotnet publish *.csproj --output /home/site/wwwroot --no-restore
 # To enable ssh & remote debugging on app service change the base image to the one below
 # FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0-appservice
-FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0
+FROM --platform=linux/amd64 mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     AzureFunctionsJobHost__Logging__Console__IsEnabled=true
 

--- a/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/Dockerfile
+++ b/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/Dockerfile
@@ -17,12 +17,11 @@ FROM base AS function
 COPY ./CohortDistributionServices/TransformDataService /src/dotnet-function-app
 WORKDIR /src/dotnet-function-app
 
-RUN --mount=type=cache,target=/root/.nuget/packages \
-    dotnet publish *.csproj --output /home/site/wwwroot
-
+RUN dotnet restore
+RUN dotnet publish *.csproj --output /home/site/wwwroot --no-restore
 # To enable ssh & remote debugging on app service change the base image to the one below
 # FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0-appservice
-FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0
+FROM --platform=linux/amd64 mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     AzureFunctionsJobHost__Logging__Console__IsEnabled=true
 

--- a/application/CohortManager/src/Functions/DemographicServices/DemographicDurableFunction/Dockerfile
+++ b/application/CohortManager/src/Functions/DemographicServices/DemographicDurableFunction/Dockerfile
@@ -17,12 +17,11 @@ FROM base AS function
 COPY ./DemographicServices/DemographicDurableFunction /src/dotnet-function-app
 WORKDIR /src/dotnet-function-app
 
-RUN --mount=type=cache,target=/root/.nuget/packages \
-    dotnet publish *.csproj --output /home/site/wwwroot
-
+RUN dotnet restore
+RUN dotnet publish *.csproj --output /home/site/wwwroot --no-restore
 # To enable ssh & remote debugging on app service change the base image to the one below
 # FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0-appservice
-FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0
+FROM --platform=linux/amd64 mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     AzureFunctionsJobHost__Logging__Console__IsEnabled=true
 

--- a/application/CohortManager/src/Functions/DemographicServices/ManageNemsSubscription/Dockerfile
+++ b/application/CohortManager/src/Functions/DemographicServices/ManageNemsSubscription/Dockerfile
@@ -17,12 +17,11 @@ FROM base AS function
 COPY ./DemographicServices/ManageNemsSubscription  /src/dotnet-function-app
 WORKDIR /src/dotnet-function-app
 
-RUN --mount=type=cache,target=/root/.nuget/packages \
-    dotnet publish *.csproj --output /home/site/wwwroot
-
+RUN dotnet restore
+RUN dotnet publish *.csproj --output /home/site/wwwroot --no-restore
 # To enable ssh & remote debugging on app service change the base image to the one below
 # FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0-appservice
-FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0
+FROM --platform=linux/amd64 mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     AzureFunctionsJobHost__Logging__Console__IsEnabled=true
 

--- a/application/CohortManager/src/Functions/DemographicServices/RetrievePDSDemographic/Dockerfile
+++ b/application/CohortManager/src/Functions/DemographicServices/RetrievePDSDemographic/Dockerfile
@@ -17,12 +17,11 @@ FROM base AS function
 COPY ./DemographicServices/RetrievePDSDemographic  /src/dotnet-function-app
 WORKDIR /src/dotnet-function-app
 
-RUN --mount=type=cache,target=/root/.nuget/packages \
-    dotnet publish *.csproj --output /home/site/wwwroot
-
+RUN dotnet restore
+RUN dotnet publish *.csproj --output /home/site/wwwroot --no-restore
 # To enable ssh & remote debugging on app service change the base image to the one below
 # FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0-appservice
-FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0
+FROM --platform=linux/amd64 mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     AzureFunctionsJobHost__Logging__Console__IsEnabled=true
 

--- a/application/CohortManager/src/Functions/ExceptionHandling/CreateException/Dockerfile
+++ b/application/CohortManager/src/Functions/ExceptionHandling/CreateException/Dockerfile
@@ -17,12 +17,11 @@ FROM base AS function
 COPY ./ExceptionHandling/CreateException /src/dotnet-function-app
 WORKDIR /src/dotnet-function-app
 
-RUN --mount=type=cache,target=/root/.nuget/packages \
-    dotnet publish *.csproj --output /home/site/wwwroot
-
+RUN dotnet restore
+RUN dotnet publish *.csproj --output /home/site/wwwroot --no-restore
 # To enable ssh & remote debugging on app service change the base image to the one below
 # FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0-appservice
-FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0
+FROM --platform=linux/amd64 mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     AzureFunctionsJobHost__Logging__Console__IsEnabled=true
 

--- a/application/CohortManager/src/Functions/ExceptionHandling/UpdateException/Dockerfile
+++ b/application/CohortManager/src/Functions/ExceptionHandling/UpdateException/Dockerfile
@@ -17,12 +17,11 @@ FROM base AS function
 COPY ./ExceptionHandling/UpdateException /src/dotnet-function-app
 WORKDIR /src/dotnet-function-app
 
-RUN --mount=type=cache,target=/root/.nuget/packages \
-    dotnet publish *.csproj --output /home/site/wwwroot
-
+RUN dotnet restore
+RUN dotnet publish *.csproj --output /home/site/wwwroot --no-restore
 # To enable ssh & remote debugging on app service change the base image to the one below
 # FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0-appservice
-FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0
+FROM --platform=linux/amd64 mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0
 
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     AzureFunctionsJobHost__Logging__Console__IsEnabled=true

--- a/application/CohortManager/src/Functions/NemsSubscriptionService/NemsMeshRetrieval/Dockerfile
+++ b/application/CohortManager/src/Functions/NemsSubscriptionService/NemsMeshRetrieval/Dockerfile
@@ -17,12 +17,11 @@ FROM base AS function
 COPY ./NemsSubscriptionService/NemsMeshRetrieval /src/dotnet-function-app
 WORKDIR /src/dotnet-function-app
 
-RUN --mount=type=cache,target=/root/.nuget/packages \
-    dotnet publish *.csproj --output /home/site/wwwroot
-
+RUN dotnet restore
+RUN dotnet publish *.csproj --output /home/site/wwwroot --no-restore
 # To enable ssh & remote debugging on app service change the base image to the one below
 # FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0-appservice
-FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0
+FROM --platform=linux/amd64 mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     AzureFunctionsJobHost__Logging__Console__IsEnabled=true
 

--- a/application/CohortManager/src/Functions/NemsSubscriptionService/ProcessNemsUpdate/Dockerfile
+++ b/application/CohortManager/src/Functions/NemsSubscriptionService/ProcessNemsUpdate/Dockerfile
@@ -22,7 +22,7 @@ RUN --mount=type=cache,target=/root/.nuget/packages \
 
 # To enable ssh & remote debugging on app service change the base image to the one below
 # FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0-appservice
-FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0
+FROM --platform=linux/amd64 mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     AzureFunctionsJobHost__Logging__Console__IsEnabled=true
 

--- a/application/CohortManager/src/Functions/ParticipantManagementServices/DeleteParticipant/Dockerfile
+++ b/application/CohortManager/src/Functions/ParticipantManagementServices/DeleteParticipant/Dockerfile
@@ -17,12 +17,11 @@ FROM base AS function
 COPY ./ParticipantManagementServices/DeleteParticipant /src/dotnet-function-app
 WORKDIR /src/dotnet-function-app
 
-RUN --mount=type=cache,target=/root/.nuget/packages \
-    dotnet publish *.csproj --output /home/site/wwwroot
-
+RUN dotnet restore
+RUN dotnet publish *.csproj --output /home/site/wwwroot --no-restore
 # To enable ssh & remote debugging on app service change the base image to the one below
 # FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0-appservice
-FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0
+FROM --platform=linux/amd64 mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     AzureFunctionsJobHost__Logging__Console__IsEnabled=true
 

--- a/application/CohortManager/src/Functions/ParticipantManagementServices/ManageParticipant/Dockerfile
+++ b/application/CohortManager/src/Functions/ParticipantManagementServices/ManageParticipant/Dockerfile
@@ -15,12 +15,11 @@ FROM base AS function
 COPY ./ParticipantManagementServices/ManageParticipant /src/dotnet-function-app
 WORKDIR /src/dotnet-function-app
 
-RUN --mount=type=cache,target=/root/.nuget/packages \
-    dotnet publish *.csproj --output /home/site/wwwroot
-
+RUN dotnet restore
+RUN dotnet publish *.csproj --output /home/site/wwwroot --no-restore
 # To enable ssh & remote debugging on app service change the base image to the one below
 # FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0-appservice
-FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0
+FROM --platform=linux/amd64 mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     AzureFunctionsJobHost__Logging__Console__IsEnabled=true
 

--- a/application/CohortManager/src/Functions/ParticipantManagementServices/ManageServiceNowParticipant/Dockerfile
+++ b/application/CohortManager/src/Functions/ParticipantManagementServices/ManageServiceNowParticipant/Dockerfile
@@ -17,12 +17,11 @@ FROM base AS function
 COPY ./ParticipantManagementServices/ManageServiceNowParticipant /src/dotnet-function-app
 WORKDIR /src/dotnet-function-app
 
-RUN --mount=type=cache,target=/root/.nuget/packages \
-    dotnet publish *.csproj --output /home/site/wwwroot
-
+RUN dotnet restore
+RUN dotnet publish *.csproj --output /home/site/wwwroot --no-restore
 # To enable ssh & remote debugging on app service change the base image to the one below
 # FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0-appservice
-FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0
+FROM --platform=linux/amd64 mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     AzureFunctionsJobHost__Logging__Console__IsEnabled=true
 

--- a/application/CohortManager/src/Functions/ParticipantManagementServices/UpdateBlockedFlag/Dockerfile
+++ b/application/CohortManager/src/Functions/ParticipantManagementServices/UpdateBlockedFlag/Dockerfile
@@ -16,12 +16,11 @@ FROM base AS function
 COPY ./ParticipantManagementServices/UpdateBlockedFlag /src/dotnet-function-app
 WORKDIR /src/dotnet-function-app
 
-RUN --mount=type=cache,target=/root/.nuget/packages \
-    dotnet publish *.csproj --output /home/site/wwwroot
-
+RUN dotnet restore
+RUN dotnet publish *.csproj --output /home/site/wwwroot --no-restore
 # To enable ssh & remote debugging on app service change the base image to the one below
 # FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0-appservice
-FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0
+FROM --platform=linux/amd64 mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     AzureFunctionsJobHost__Logging__Console__IsEnabled=true
 

--- a/application/CohortManager/src/Functions/ScreeningValidationService/LookupValidation/Dockerfile
+++ b/application/CohortManager/src/Functions/ScreeningValidationService/LookupValidation/Dockerfile
@@ -17,12 +17,11 @@ FROM base AS function
 COPY ./ScreeningValidationService/LookupValidation /src/dotnet-function-app
 WORKDIR /src/dotnet-function-app
 
-RUN --mount=type=cache,target=/root/.nuget/packages \
-    dotnet publish *.csproj --output /home/site/wwwroot
-
+RUN dotnet restore
+RUN dotnet publish *.csproj --output /home/site/wwwroot --no-restore
 # To enable ssh & remote debugging on app service change the base image to the one below
 # FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0-appservice
-FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0
+FROM --platform=linux/amd64 mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     AzureFunctionsJobHost__Logging__Console__IsEnabled=true
 

--- a/application/CohortManager/src/Functions/ScreeningValidationService/RemoveValidationException/Dockerfile
+++ b/application/CohortManager/src/Functions/ScreeningValidationService/RemoveValidationException/Dockerfile
@@ -17,12 +17,11 @@ FROM base AS function
 COPY ./ScreeningValidationService/RemoveValidationException /src/dotnet-function-app
 WORKDIR /src/dotnet-function-app
 
-RUN --mount=type=cache,target=/root/.nuget/packages \
-    dotnet publish *.csproj --output /home/site/wwwroot
-
+RUN dotnet restore
+RUN dotnet publish *.csproj --output /home/site/wwwroot --no-restore
 # To enable ssh & remote debugging on app service change the base image to the one below
 # FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0-appservice
-FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0
+FROM --platform=linux/amd64 mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     AzureFunctionsJobHost__Logging__Console__IsEnabled=true
 

--- a/application/CohortManager/src/Functions/ScreeningValidationService/StaticValidation/Dockerfile
+++ b/application/CohortManager/src/Functions/ScreeningValidationService/StaticValidation/Dockerfile
@@ -17,12 +17,11 @@ FROM base AS function
 COPY ./ScreeningValidationService/StaticValidation /src/dotnet-function-app
 WORKDIR /src/dotnet-function-app
 
-RUN --mount=type=cache,target=/root/.nuget/packages \
-    dotnet publish *.csproj --output /home/site/wwwroot
-
+RUN dotnet restore
+RUN dotnet publish *.csproj --output /home/site/wwwroot --no-restore
 # To enable ssh & remote debugging on app service change the base image to the one below
 # FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0-appservice
-FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0
+FROM --platform=linux/amd64 mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     AzureFunctionsJobHost__Logging__Console__IsEnabled=true
 

--- a/application/CohortManager/src/Functions/ServiceNowIntegration/ServiceNowCohortLookup/Dockerfile
+++ b/application/CohortManager/src/Functions/ServiceNowIntegration/ServiceNowCohortLookup/Dockerfile
@@ -17,12 +17,11 @@ FROM base AS function
 COPY ./ServiceNowIntegration/ServiceNowCohortLookup  /src/dotnet-function-app
 WORKDIR /src/dotnet-function-app
 
-RUN --mount=type=cache,target=/root/.nuget/packages \
-    dotnet publish *.csproj --output /home/site/wwwroot
-
+RUN dotnet restore
+RUN dotnet publish *.csproj --output /home/site/wwwroot --no-restore
 # To enable ssh & remote debugging on app service change the base image to the one below
 # FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0-appservice
-FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0
+FROM --platform=linux/amd64 mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     AzureFunctionsJobHost__Logging__Console__IsEnabled=true
 

--- a/application/CohortManager/src/Functions/ServiceNowIntegration/ServiceNowMessageHandler/Dockerfile
+++ b/application/CohortManager/src/Functions/ServiceNowIntegration/ServiceNowMessageHandler/Dockerfile
@@ -17,12 +17,11 @@ FROM base AS function
 COPY ./ServiceNowIntegration/ServiceNowMessageHandler  /src/dotnet-function-app
 WORKDIR /src/dotnet-function-app
 
-RUN --mount=type=cache,target=/root/.nuget/packages \
-    dotnet publish *.csproj --output /home/site/wwwroot
-
+RUN dotnet restore
+RUN dotnet publish *.csproj --output /home/site/wwwroot --no-restore
 # To enable ssh & remote debugging on app service change the base image to the one below
 # FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0-appservice
-FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0
+FROM --platform=linux/amd64 mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     AzureFunctionsJobHost__Logging__Console__IsEnabled=true
 

--- a/application/CohortManager/src/Functions/screeningDataServices/BsSelectRequestAudit/Dockerfile
+++ b/application/CohortManager/src/Functions/screeningDataServices/BsSelectRequestAudit/Dockerfile
@@ -17,12 +17,11 @@ FROM base AS function
 COPY ./screeningDataServices/BsSelectRequestAudit /src/dotnet-function-app
 WORKDIR /src/dotnet-function-app
 
-RUN --mount=type=cache,target=/root/.nuget/packages \
-    dotnet publish *.csproj --output /home/site/wwwroot
-
+RUN dotnet restore
+RUN dotnet publish *.csproj --output /home/site/wwwroot --no-restore
 # To enable ssh & remote debugging on app service change the base image to the one below
 # FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0-appservice
-FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0
+FROM --platform=linux/amd64 mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     AzureFunctionsJobHost__Logging__Console__IsEnabled=true
 

--- a/application/CohortManager/src/Functions/screeningDataServices/CohortDistributionDataService/Dockerfile
+++ b/application/CohortManager/src/Functions/screeningDataServices/CohortDistributionDataService/Dockerfile
@@ -17,12 +17,11 @@ FROM base AS function
 COPY ./screeningDataServices/CohortDistributionDataService /src/dotnet-function-app
 WORKDIR /src/dotnet-function-app
 
-RUN --mount=type=cache,target=/root/.nuget/packages \
-    dotnet publish *.csproj --output /home/site/wwwroot
-
+RUN dotnet restore
+RUN dotnet publish *.csproj --output /home/site/wwwroot --no-restore
 # To enable ssh & remote debugging on app service change the base image to the one below
 # FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0-appservice
-FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0
+FROM --platform=linux/amd64 mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     AzureFunctionsJobHost__Logging__Console__IsEnabled=true
 

--- a/application/CohortManager/src/Functions/screeningDataServices/ExceptionManagementDataService/Dockerfile
+++ b/application/CohortManager/src/Functions/screeningDataServices/ExceptionManagementDataService/Dockerfile
@@ -17,12 +17,11 @@ FROM base AS function
 COPY ./screeningDataServices/ExceptionManagementDataService /src/dotnet-function-app
 WORKDIR /src/dotnet-function-app
 
-RUN --mount=type=cache,target=/root/.nuget/packages \
-    dotnet publish *.csproj --output /home/site/wwwroot
-
+RUN dotnet restore
+RUN dotnet publish *.csproj --output /home/site/wwwroot --no-restore
 # To enable ssh & remote debugging on app service change the base image to the one below
 # FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0-appservice
-FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0
+FROM --platform=linux/amd64 mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     AzureFunctionsJobHost__Logging__Console__IsEnabled=true
 

--- a/application/CohortManager/src/Functions/screeningDataServices/GeneCodeLkpDataService/Dockerfile
+++ b/application/CohortManager/src/Functions/screeningDataServices/GeneCodeLkpDataService/Dockerfile
@@ -17,12 +17,11 @@ FROM base AS function
 COPY ./screeningDataServices/GeneCodeLkpDataService /src/dotnet-function-app
 WORKDIR /src/dotnet-function-app
 
-RUN --mount=type=cache,target=/root/.nuget/packages \
-    dotnet publish *.csproj --output /home/site/wwwroot
-
+RUN dotnet restore
+RUN dotnet publish *.csproj --output /home/site/wwwroot --no-restore
 # To enable ssh & remote debugging on app service change the base image to the one below
 # FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0-appservice
-FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0
+FROM --platform=linux/amd64 mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     AzureFunctionsJobHost__Logging__Console__IsEnabled=true
 

--- a/application/CohortManager/src/Functions/screeningDataServices/GetValidationExceptions/Dockerfile
+++ b/application/CohortManager/src/Functions/screeningDataServices/GetValidationExceptions/Dockerfile
@@ -17,12 +17,11 @@ FROM base AS function
 COPY ./screeningDataServices/GetValidationExceptions /src/dotnet-function-app
 WORKDIR /src/dotnet-function-app
 
-RUN --mount=type=cache,target=/root/.nuget/packages \
-    dotnet publish *.csproj --output /home/site/wwwroot
-
+RUN dotnet restore
+RUN dotnet publish *.csproj --output /home/site/wwwroot --no-restore
 # To enable ssh & remote debugging on app service change the base image to the one below
 # FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0-appservice
-FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0
+FROM --platform=linux/amd64 mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     AzureFunctionsJobHost__Logging__Console__IsEnabled=true
 

--- a/application/CohortManager/src/Functions/screeningDataServices/HigherRiskReferralReasonLkpDataService/Dockerfile
+++ b/application/CohortManager/src/Functions/screeningDataServices/HigherRiskReferralReasonLkpDataService/Dockerfile
@@ -17,12 +17,11 @@ FROM base AS function
 COPY ./screeningDataServices/HigherRiskReferralReasonLkpDataService /src/dotnet-function-app
 WORKDIR /src/dotnet-function-app
 
-RUN --mount=type=cache,target=/root/.nuget/packages \
-    dotnet publish *.csproj --output /home/site/wwwroot
-
+RUN dotnet restore
+RUN dotnet publish *.csproj --output /home/site/wwwroot --no-restore
 # To enable ssh & remote debugging on app service change the base image to the one below
 # FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0-appservice
-FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0
+FROM --platform=linux/amd64 mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     AzureFunctionsJobHost__Logging__Console__IsEnabled=true
 

--- a/application/CohortManager/src/Functions/screeningDataServices/NemsSubscriptionDataService/Dockerfile
+++ b/application/CohortManager/src/Functions/screeningDataServices/NemsSubscriptionDataService/Dockerfile
@@ -21,7 +21,7 @@ RUN dotnet publish ./*.csproj --output /home/site/wwwroot
 
 # To enable ssh & remote debugging on app service change the base image to the one below
 # FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0-appservice
-FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0
+FROM --platform=linux/amd64 mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     AzureFunctionsJobHost__Logging__Console__IsEnabled=true
 

--- a/application/CohortManager/src/Functions/screeningDataServices/ParticipantDemographicDataService/Dockerfile
+++ b/application/CohortManager/src/Functions/screeningDataServices/ParticipantDemographicDataService/Dockerfile
@@ -17,12 +17,11 @@ FROM base AS function
 COPY ./screeningDataServices/ParticipantDemographicDataService /src/dotnet-function-app
 WORKDIR /src/dotnet-function-app
 
-RUN --mount=type=cache,target=/root/.nuget/packages \
-    dotnet publish *.csproj --output /home/site/wwwroot
-
+RUN dotnet restore
+RUN dotnet publish *.csproj --output /home/site/wwwroot --no-restore
 # To enable ssh & remote debugging on app service change the base image to the one below
 # FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0-appservice
-FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0
+FROM --platform=linux/amd64 mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     AzureFunctionsJobHost__Logging__Console__IsEnabled=true
 

--- a/application/CohortManager/src/Functions/screeningDataServices/ParticipantManagementDataService/Dockerfile
+++ b/application/CohortManager/src/Functions/screeningDataServices/ParticipantManagementDataService/Dockerfile
@@ -17,12 +17,11 @@ FROM base AS function
 COPY ./screeningDataServices/ParticipantManagementDataService /src/dotnet-function-app
 WORKDIR /src/dotnet-function-app
 
-RUN --mount=type=cache,target=/root/.nuget/packages \
-    dotnet publish *.csproj --output /home/site/wwwroot
-
+RUN dotnet restore
+RUN dotnet publish *.csproj --output /home/site/wwwroot --no-restore
 # To enable ssh & remote debugging on app service change the base image to the one below
 # FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0-appservice
-FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0
+FROM --platform=linux/amd64 mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     AzureFunctionsJobHost__Logging__Console__IsEnabled=true
 

--- a/application/CohortManager/src/Functions/screeningDataServices/ReferenceDataService/Dockerfile
+++ b/application/CohortManager/src/Functions/screeningDataServices/ReferenceDataService/Dockerfile
@@ -17,12 +17,11 @@ FROM base AS function
 COPY ./screeningDataServices/ReferenceDataService /src/dotnet-function-app
 WORKDIR /src/dotnet-function-app
 
-RUN --mount=type=cache,target=/root/.nuget/packages \
-    dotnet publish *.csproj --output /home/site/wwwroot
-
+RUN dotnet restore
+RUN dotnet publish *.csproj --output /home/site/wwwroot --no-restore
 # To enable ssh & remote debugging on app service change the base image to the one below
 # FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0-appservice
-FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0
+FROM --platform=linux/amd64 mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     AzureFunctionsJobHost__Logging__Console__IsEnabled=true
 

--- a/application/CohortManager/src/Functions/screeningDataServices/ScreeningLkpDataService/Dockerfile
+++ b/application/CohortManager/src/Functions/screeningDataServices/ScreeningLkpDataService/Dockerfile
@@ -17,12 +17,11 @@ FROM base AS function
 COPY ./screeningDataServices/ScreeningLkpDataService /src/dotnet-function-app
 WORKDIR /src/dotnet-function-app
 
-RUN --mount=type=cache,target=/root/.nuget/packages \
-    dotnet publish *.csproj --output /home/site/wwwroot
-
+RUN dotnet restore
+RUN dotnet publish *.csproj --output /home/site/wwwroot --no-restore
 # To enable ssh & remote debugging on app service change the base image to the one below
 # FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0-appservice
-FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0
+FROM --platform=linux/amd64 mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     AzureFunctionsJobHost__Logging__Console__IsEnabled=true
 

--- a/application/CohortManager/src/Functions/screeningDataServices/ServiceNowCasesDataService/Dockerfile
+++ b/application/CohortManager/src/Functions/screeningDataServices/ServiceNowCasesDataService/Dockerfile
@@ -21,7 +21,7 @@ RUN dotnet publish ./*.csproj --output /home/site/wwwroot
 
 # To enable ssh & remote debugging on app service change the base image to the one below
 # FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0-appservice
-FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0
+FROM --platform=linux/amd64 mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     AzureFunctionsJobHost__Logging__Console__IsEnabled=true
 

--- a/tests/playwright-tests/package.json
+++ b/tests/playwright-tests/package.json
@@ -15,7 +15,8 @@
     "test:regression_e2e_epic4d": "cross-env TEST_TYPE=RegressionEpic4d npx playwright test --project=dev --config=src/config/playwright.config.ts --grep=@epic4d-",
     "test": "cross-env TEST_TYPE=SMOKE npx playwright test --project=dev --config=src/config/playwright.config.ts --grep=\"@smoke @e2e\"",
     "test:validation-exceptions": "cross-env TEST_TYPE=VALIDATION npx playwright test tests/api/bsselect/validationExceptions/ --project=dev --config=src/config/playwright.config.ts",
-    "test:service_now": "npx playwright test --project=dev --config=src/config/playwright.config.ts --grep=\"@service_now\""
+    "test:service_now": "npx playwright test --project=dev --config=src/config/playwright.config.ts --grep=\"@service_now\"",
+    "e2e:health": "node scripts/health-check.js"
   },
   "keywords": [],
   "author": "",

--- a/tests/playwright-tests/scripts/health-check.js
+++ b/tests/playwright-tests/scripts/health-check.js
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+/* Simple health check for core endpoints used in E2E runs */
+const { URL } = require('node:url');
+
+function log(msg) { console.log(`[health] ${msg}`); }
+
+async function waitHttp(targets, maxAttempts=5, intervalMs=3000) {
+  function httpStatus(u) { return new Promise(resolve => {
+    const h = new URL(u);
+    const mod = h.protocol === 'https:' ? require('https') : require('http');
+    const req = mod.request({ hostname:h.hostname, port:h.port, path:h.pathname || '/', method:'GET', timeout:2000 }, res => {
+      const code = res.statusCode || 0; res.resume(); resolve(code);
+    });
+    req.on('timeout', () => { req.destroy(new Error('timeout')); });
+    req.on('error', () => resolve(0));
+    req.end();
+  }); }
+  // Map ports to likely container names to help the user
+  const portToContainer = {
+    '7994': 'participant-management-data-service',
+    '7993': 'participant-demographic-data-service',
+    '7992': 'cohort-distribution-data-service',
+    '7078': 'retrieve-cohort-distribution-data',
+    '7086': 'retrieve-cohort-request-audit',
+    '8082': 'retrieve-pds-demographic',
+    '9092': 'servicenow-message-handler'
+  };
+
+  for (const t of targets) {
+    let attempt = 0;
+    while (true) {
+      attempt++;
+      const code = await httpStatus(t);
+      if ((code >= 200 && code < 400) || code === 400 || code === 405) {
+        log(`Ready (HTTP ${code}): ${t}`);
+        break;
+      }
+      if (attempt >= maxAttempts) {
+        try {
+          const u = new URL(t);
+          const port = String(u.port || (u.protocol === 'https:' ? 443 : 80));
+          const name = portToContainer[port] || `service on port ${port}`;
+          console.error(`[health] Timeout waiting for ${t}.`);
+          console.error(`[health] This likely means container '${name}' is not running.`);
+          console.error(`[health] Start containers via VS Code task "Spin up Docker for E2E regression (build + start)" or run compose profiles for service-now, bs-select, and non-essential.`);
+        } catch {}
+        throw new Error(`Timeout waiting for ${t}`);
+      }
+      log(`Waiting on ${t} (${attempt}/${maxAttempts})...`);
+      await new Promise(r=>setTimeout(r, intervalMs));
+    }
+  }
+}
+
+(async () => {
+  const targets = [
+    'http://localhost:7994/api/ParticipantManagementDataService',
+    'http://localhost:7993/api/ParticipantDemographicDataService',
+    'http://localhost:7992/api/CohortDistributionDataService',
+    'http://localhost:7078/api/RetrieveCohortDistributionData',
+    'http://localhost:7086/api/RetrieveCohortRequestAudit',
+    'http://localhost:8082/api/health',
+    'http://localhost:9092/api/health'
+  ];
+  await waitHttp(targets);
+  log('All targets healthy');
+})().catch(err => { console.error(err.message || err); process.exit(1); });


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

<!-- Describe your changes in detail. -->
This PR pins all Azure Functions to amd64 images in Dockerfiles and docker compose yml files. Also new VS Code tasks are added for spinning up a test framework, and running automated tests against these containers.

## Context

<!-- Why is this change required? What problem does it solve? -->
As the Arm64 image of Azure Functions has become unavailable the docker setup has stopped working for Apple Silicon based Macs. This PR pins the containers to amd64, which forces the apple virtualisation to use Rosetta (an on-the-fly architecture migration).

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
