### PR TITLE
fix: PDS not found bug fix

### DIFF
--- a/application/CohortManager/src/Functions/DemographicServices/RetrievePDSDemographic/MockedPDSData/patient-not-found.json
+++ b/application/CohortManager/src/Functions/DemographicServices/RetrievePDSDemographic/MockedPDSData/patient-not-found.json
@@ -1,0 +1,19 @@
+{
+  "issue": [
+    {
+      "code": "not-found",
+      "details": {
+        "coding": [
+          {
+            "code": "RESOURCE_NOT_FOUND",
+            "display": "Resource not found",
+            "system": "https://fhir.nhs.uk/R4/CodeSystem/Spine-ErrorOrWarningCode",
+            "version": "1"
+          }
+        ]
+      },
+      "severity": "information"
+    }
+  ],
+  "resourceType": "OperationOutcome"
+}

--- a/application/CohortManager/src/Functions/DemographicServices/RetrievePDSDemographic/RetrievePDSDemographic.cs
+++ b/application/CohortManager/src/Functions/DemographicServices/RetrievePDSDemographic/RetrievePDSDemographic.cs
@@ -75,10 +75,17 @@ public class RetrievePdsDemographic
             var response = await _httpClientFunction.SendPdsGet(url, bearerToken);
             string jsonResponse = "";
 
+            if (response.StatusCode == HttpStatusCode.NotFound)
+            {
+                await _pdsProcessor.ProcessPdsNotFoundResponse(response, nhsNumber, sourceFileName);
+                return _createResponse.CreateHttpResponse(HttpStatusCode.NotFound, req, "PDS returned a 404 please database for details");
+            }
+
             jsonResponse = await _httpClientFunction.GetResponseText(response);
+
             var pdsDemographic = _fhirPatientDemographicMapper.ParseFhirJson(jsonResponse);
 
-            if (response.StatusCode == HttpStatusCode.NotFound || pdsDemographic.ConfidentialityCode == "R")
+            if (pdsDemographic.ConfidentialityCode == "R")
             {
                 await _pdsProcessor.ProcessPdsNotFoundResponse(response, nhsNumber, sourceFileName);
                 return _createResponse.CreateHttpResponse(HttpStatusCode.NotFound, req, "PDS returned a 404 please database for details");

--- a/application/CohortManager/src/Functions/DemographicServices/RetrievePDSDemographic/RetrievePDSDemographic.cs
+++ b/application/CohortManager/src/Functions/DemographicServices/RetrievePDSDemographic/RetrievePDSDemographic.cs
@@ -75,13 +75,13 @@ public class RetrievePdsDemographic
             var response = await _httpClientFunction.SendPdsGet(url, bearerToken);
             string jsonResponse = "";
 
+            jsonResponse = await _httpClientFunction.GetResponseText(response);
+
             if (response.StatusCode == HttpStatusCode.NotFound)
             {
                 await _pdsProcessor.ProcessPdsNotFoundResponse(response, nhsNumber, sourceFileName);
                 return _createResponse.CreateHttpResponse(HttpStatusCode.NotFound, req, "PDS returned a 404 please database for details");
             }
-
-            jsonResponse = await _httpClientFunction.GetResponseText(response);
 
             var pdsDemographic = _fhirPatientDemographicMapper.ParseFhirJson(jsonResponse);
 

--- a/application/CohortManager/src/Functions/Shared/Common/PdsHttpClientMock.cs
+++ b/application/CohortManager/src/Functions/Shared/Common/PdsHttpClientMock.cs
@@ -42,7 +42,8 @@ public class PdsHttpClientMock : HttpClientFunction
 
         if (patient == null)
         {
-            return HttpStubUtilities.CreateFakeHttpResponse(url, "NotFound", HttpStatusCode.NotFound);
+            var notFoundResponseBody = await File.ReadAllTextAsync("MockedPDSData/patient-not-found.json");
+            return HttpStubUtilities.CreateFakeHttpResponse(url, notFoundResponseBody, HttpStatusCode.NotFound);
         }
         return HttpStubUtilities.CreateFakeHttpResponse(url, patient);
 

--- a/application/CohortManager/src/Functions/Shared/Common/PdsHttpClientMock.cs
+++ b/application/CohortManager/src/Functions/Shared/Common/PdsHttpClientMock.cs
@@ -50,12 +50,13 @@ public class PdsHttpClientMock : HttpClientFunction
 
     }
 
-    private static async Task<string?> GetPatientMockObject(string? nhsNumber = null)
+    private async Task<string?> GetPatientMockObject(string? nhsNumber = null)
     {
 
         string path = nhsNumber is null ? "MockedPDSData/complete-patient.json" : $"MockedPDSData/complete-patient-{nhsNumber}.json";
         if (!File.Exists(path))
         {
+            _logger.LogWarning("Mocked PDS Data file couldn't be found");
             return null;
         }
         return await File.ReadAllTextAsync(path);

--- a/application/CohortManager/src/Functions/Shared/Common/Utilities/HTTPStubUtilities.cs
+++ b/application/CohortManager/src/Functions/Shared/Common/Utilities/HTTPStubUtilities.cs
@@ -20,7 +20,7 @@ public static class HttpStubUtilities
         }
         HttpResponseData.Headers.Location = location;
         HttpResponseData.Content = new StringContent(content);
-        HttpResponseData.StatusCode = HttpStatusCode.OK;
+        HttpResponseData.StatusCode = httpStatusCode;
         return HttpResponseData;
     }
 


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

- Adding participant not found response to PDS stub.
- Bug fix in Retrieve PDS Demographic where it tried to deserialise json to the wrong type for invalid records.

## Context

When a participant couldn't be found in the mocked (or real) PDS endpoint. 
The function would return a 500 error rather than the correct 404

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
