### PR TITLE
fix: keep old referral flag in participant management

### DIFF
--- a/application/CohortManager/src/Functions/ParticipantManagementServices/ManageParticipant/ManageParticipant.cs
+++ b/application/CohortManager/src/Functions/ParticipantManagementServices/ManageParticipant/ManageParticipant.cs
@@ -43,7 +43,7 @@ public class ManageParticipant
         Participant participant = participantRecord.Participant;
         try
         {
-            _logger.LogInformation("Recieved manage participant request");
+            _logger.LogInformation("Received manage participant request");
             bool nhsNumberValid = ValidationHelper.ValidateNHSNumber(participant.NhsNumber);
             if (!nhsNumberValid)
             {
@@ -72,11 +72,12 @@ public class ManageParticipant
             }
             else
             {
-                _logger.LogInformation("Existing participant managment record found, updating record {ParticipantId}", databaseParticipant.ParticipantId);
+                _logger.LogInformation("Existing participant management record found, updating record {ParticipantId}", databaseParticipant.ParticipantId);
                 var participantManagement = participant.ToParticipantManagement();
                 participantManagement.ParticipantId = databaseParticipant.ParticipantId;
                 participantManagement.RecordUpdateDateTime = DateTime.UtcNow;
                 participantManagement.RecordInsertDateTime = databaseParticipant.RecordInsertDateTime;
+                participantManagement.ReferralFlag = databaseParticipant.ReferralFlag;
 
                 dataServiceResponse = await _participantManagementClient.Update(participantManagement);
             }

--- a/tests/UnitTests/ParticipantManagementServicesTests/ManageParticipantTests/ManageParticipantTests.cs
+++ b/tests/UnitTests/ParticipantManagementServicesTests/ManageParticipantTests/ManageParticipantTests.cs
@@ -87,7 +87,8 @@ public class ManageParticipantTests
                 PreferredLanguage = "English",
                 IsInterpreterRequired = "0",
                 RecordType = Actions.Amended,
-                ScreeningId = "1"
+                ScreeningId = "1",
+                ReferralFlag = "0"
             }
         };
 
@@ -202,5 +203,27 @@ public class ManageParticipantTests
                 It.IsAny<Participant>(),
                 It.IsAny<string>(),
                 ""), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task Run_DatabaseAndRequestReferralFlagsDifferent_UseDatabaseFlag()
+    {
+        // Arrange
+        ParticipantManagement dbParticipant = new()
+        {
+            NHSNumber = 9444567877,
+            ReferralFlag = 1
+        };
+
+        _participantManagementClientMock
+            .Setup(x => x.GetSingleByFilter(It.IsAny<Expression<Func<ParticipantManagement, bool>>>()))
+            .ReturnsAsync(dbParticipant);
+
+        // Act
+        await _sut.Run(JsonSerializer.Serialize(_request));
+
+        // Assert
+        _participantManagementClientMock
+            .Verify(x => x.Update(It.Is<ParticipantManagement>(x => x.ReferralFlag == 1)), Times.Once);
     }
 }


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description
updated manage participant to use the existing referral flag value for amend records instead of updating in

<!-- Describe your changes in detail. -->

## Context
[DTOSS-10701](https://nhsd-jira.digital.nhs.uk/browse/DTOSS-10701)

The referral flag is hardcoded in manage service now participant and receive caas file, now that we are getting amends for self-referrals through caas, we need to make sure the referral flag stays the same, otherwise it would be overwritten to false when we get an amend for a self-referred participant

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
