### PR TITLE
fix: Medifact bug fix (backslash and pipe) plus added some unit tests for CheckEmailCharacters method

### DIFF
--- a/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/TransformString.cs
+++ b/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/TransformString.cs
@@ -108,6 +108,10 @@ public class TransformString
         var transformedEmail = (string?)rulesList.Where(result => result.IsSuccess)
                                         .Select(result => result.ActionResult.Output)
                                         .FirstOrDefault();
+        if (transformedEmail != emailAddress)
+        {
+            ParticipantUpdated = true;
+        }
         return transformedEmail;
     }        
 

--- a/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/TransformString.cs
+++ b/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/TransformString.cs
@@ -101,18 +101,28 @@ public class TransformString
         }
         return stringBuilder.ToString();
     }
-
+    
     private async Task<string?> CheckEmailCharacters(string emailAddress)
     {
+        string? transformedEmail = emailAddress;
         var rulesList = await _ruleEngine.ExecuteAllRulesAsync("71.InvalidEmailCharacter", emailAddress);
-        var transformedEmail = (string?)rulesList.Where(result => result.IsSuccess)
-                                        .Select(result => result.ActionResult.Output)
-                                        .FirstOrDefault();
+
+        // Only modify transformedEmail if a rule was successful
+        var successfulResult = rulesList.FirstOrDefault(result => result.IsSuccess);
+        if (successfulResult != null)
+        {
+            transformedEmail = (string?)successfulResult.ActionResult.Output;
+        }
+
+        Console.WriteLine("transformed:" + transformedEmail + " original: " + emailAddress);
+
         if (transformedEmail != emailAddress)
         {
             ParticipantUpdated = true;
         }
+
         return transformedEmail;
-    }        
+    }
+
 
 }

--- a/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/TransformString.cs
+++ b/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/TransformString.cs
@@ -66,7 +66,7 @@ public class TransformString
             ParticipantUpdated = true;
             // Special characters that need to be handled separately
             if (stringField.Contains(@"\E\") || stringField.Contains(@"\T\"))
-                throw new ArgumentException("Participant contains illegal characters");
+                throw new ArgumentException("$Participant contains illegal characters");
 
             // The & character is the only illegal character that is transformed to a string instead of a char
             if (stringField.Contains('&'))
@@ -79,7 +79,7 @@ public class TransformString
             // Check to see if there are any unhandled invalid chars
             if (!Regex.IsMatch(transformedField, allowedCharacters, RegexOptions.None, matchTimeout))
 
-                throw new ArgumentException($"Participant contains illegal characters");
+                throw new ArgumentException("Participant contains illegal characters");
 
             return transformedField;
         }

--- a/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/TransformString.cs
+++ b/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/TransformString.cs
@@ -66,7 +66,7 @@ public class TransformString
             ParticipantUpdated = true;
             // Special characters that need to be handled separately
             if (stringField.Contains(@"\E\") || stringField.Contains(@"\T\"))
-                throw new ArgumentException($"Participant contains illegal characters");
+                throw new ArgumentException("Participant contains illegal characters");
 
             // The & character is the only illegal character that is transformed to a string instead of a char
             if (stringField.Contains('&'))

--- a/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/TransformString.cs
+++ b/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/TransformString.cs
@@ -102,26 +102,6 @@ public class TransformString
         return stringBuilder.ToString();
     }
 
-    private async Task<string?> EmailCharacters(string emailAddress)
-    {
-        HashSet<char> invalidCharacters = ['\\', '*', '£', '`', '~', '|'];
-        bool invalidFlag = false;
-
-        foreach (char character in emailAddress)
-        {
-            if (invalidCharacters.Contains(character))
-            {
-                invalidFlag = true;
-            }
-        }
-        if (invalidFlag)
-        {
-            ParticipantUpdated = true;
-            return null; //Return null if invalid characters exist
-        }
-        return emailAddress; // Return the original email if no invalid characters are found
-    }
-
     private async Task<string?> CheckEmailCharacters(string emailAddress)
     {
         var rulesList = await _ruleEngine.ExecuteAllRulesAsync("71.InvalidEmailCharacter", emailAddress);

--- a/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/TransformString.cs
+++ b/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/TransformString.cs
@@ -53,7 +53,7 @@ public class TransformString
 
     private async Task<string> CheckParticipantCharactersAsync(string stringField)
     {
-        string allowedCharacters = @"^[a-zA-Z0-9\s.,\-()'+:?!¬*]+$";
+        string allowedCharacters = @"^[a-zA-Z0-9\s.,\-()'+:?!¬￢*]+$";
         TimeSpan matchTimeout = TimeSpan.FromSeconds(2); // Adjust timeout as needed
 
         // Skip if the field is null or doesn't have any invalid chars
@@ -104,7 +104,7 @@ public class TransformString
 
     private async Task<string?> CheckEmailCharacters(string emailAddress)
     {
-        HashSet<char> invalidCharacters = ['\u005c', '*', '\u00a3', '`', '~', '|'];
+        HashSet<char> invalidCharacters = ['\\', '*', '£', '`', '~', '|'];
         bool invalidFlag = false;
 
         foreach (char character in emailAddress)

--- a/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/TransformString.cs
+++ b/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/TransformString.cs
@@ -79,7 +79,7 @@ public class TransformString
             // Check to see if there are any unhandled invalid chars
             if (!Regex.IsMatch(transformedField, allowedCharacters, RegexOptions.None, matchTimeout))
 
-                throw new ArgumentException(transformedField.ToString());
+                throw new ArgumentException($"Participant contains illegal characters");
 
             return transformedField;
         }
@@ -101,7 +101,7 @@ public class TransformString
         }
         return stringBuilder.ToString();
     }
-    
+
     private async Task<string?> CheckEmailCharacters(string emailAddress)
     {
         string? transformedEmail = emailAddress;
@@ -113,8 +113,6 @@ public class TransformString
         {
             transformedEmail = (string?)successfulResult.ActionResult.Output;
         }
-
-        Console.WriteLine("transformed:" + transformedEmail + " original: " + emailAddress);
 
         if (transformedEmail != emailAddress)
         {

--- a/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/TransformString.cs
+++ b/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/TransformString.cs
@@ -78,7 +78,7 @@ public class TransformString
 
             // Check to see if there are any unhandled invalid chars
             if (!Regex.IsMatch(transformedField, allowedCharacters, RegexOptions.None, matchTimeout))
-                
+
                 throw new ArgumentException(transformedField.ToString());
 
             return transformedField;
@@ -102,7 +102,7 @@ public class TransformString
         return stringBuilder.ToString();
     }
 
-    private async Task<string?> CheckEmailCharacters(string emailAddress)
+    private async Task<string?> EmailCharacters(string emailAddress)
     {
         HashSet<char> invalidCharacters = ['\\', '*', '£', '`', '~', '|'];
         bool invalidFlag = false;
@@ -121,5 +121,14 @@ public class TransformString
         }
         return emailAddress; // Return the original email if no invalid characters are found
     }
+
+    private async Task<string?> CheckEmailCharacters(string emailAddress)
+    {
+        var rulesList = await _ruleEngine.ExecuteAllRulesAsync("72.InvalidEmailCharacter", emailAddress);
+        var transformedEmail = (string?)rulesList.Where(result => result.IsSuccess)
+                                        .Select(result => result.ActionResult.Output)
+                                        .FirstOrDefault() ?? emailAddress;
+        return transformedEmail;
+    }        
 
 }

--- a/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/TransformString.cs
+++ b/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/TransformString.cs
@@ -66,7 +66,7 @@ public class TransformString
             ParticipantUpdated = true;
             // Special characters that need to be handled separately
             if (stringField.Contains(@"\E\") || stringField.Contains(@"\T\"))
-                throw new ArgumentException("$Participant contains illegal characters");
+                throw new ArgumentException($"Participant contains illegal characters");
 
             // The & character is the only illegal character that is transformed to a string instead of a char
             if (stringField.Contains('&'))

--- a/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/TransformString.cs
+++ b/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/TransformString.cs
@@ -124,10 +124,10 @@ public class TransformString
 
     private async Task<string?> CheckEmailCharacters(string emailAddress)
     {
-        var rulesList = await _ruleEngine.ExecuteAllRulesAsync("72.InvalidEmailCharacter", emailAddress);
+        var rulesList = await _ruleEngine.ExecuteAllRulesAsync("71.InvalidEmailCharacter", emailAddress);
         var transformedEmail = (string?)rulesList.Where(result => result.IsSuccess)
                                         .Select(result => result.ActionResult.Output)
-                                        .FirstOrDefault() ?? emailAddress;
+                                        .FirstOrDefault();
         return transformedEmail;
     }        
 

--- a/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/characterRules.json
+++ b/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/characterRules.json
@@ -253,18 +253,6 @@
             }
           }
         }
-      },
-      {
-        "RuleName": "Ampersand",
-        "Expression": "input1 == 38",
-        "Actions": {
-          "OnSuccess": {
-            "Name": "OutputExpression",
-            "Context": {
-              "Expression": "' and '"
-            }
-          }
-        }
       }
     ]
   }

--- a/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/characterRules.json
+++ b/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/characterRules.json
@@ -255,5 +255,82 @@
         }
       }
     ]
+  },
+  {
+    "WorkflowName": "72.InvalidEmailCharacter",
+    "Rules": [
+      {
+        "RuleName": "EmailContainsBackslash",
+        "Expression": "input1.Contains('\\')",
+        "Actions": {
+          "OnSuccess": {
+            "Name": "OutputExpression",
+            "Context": {
+              "Expression": "null"
+            }
+          }
+        }
+      },
+      {
+        "RuleName": "EmailContainsAsterisk",
+        "Expression": "input1.Contains('*')",
+        "Actions": {
+          "OnSuccess": {
+            "Name": "OutputExpression",
+            "Context": {
+              "Expression": "null"
+            }
+          }
+        }
+      },
+      {
+        "RuleName": "EmailContainsPound",
+        "Expression": "input1.Contains('£')",
+        "Actions": {
+          "OnSuccess": {
+            "Name": "OutputExpression",
+            "Context": {
+              "Expression": "null"
+            }
+          }
+        }
+      },
+      {
+        "RuleName": "EmailContainsGrave",
+        "Expression": "input1.Contains('`')",
+        "Actions": {
+          "OnSuccess": {
+            "Name": "OutputExpression",
+            "Context": {
+              "Expression": "null"
+            }
+          }
+        }
+      },
+      {
+        "RuleName": "EmailContainsTilde",
+        "Expression": "input1.Contains('~')",
+        "Actions": {
+          "OnSuccess": {
+            "Name": "OutputExpression",
+            "Context": {
+              "Expression": "null"
+            }
+          }
+        }
+      },
+      {
+        "RuleName": "EmailContainsPipe",
+        "Expression": "input1.Contains('|');",
+        "Actions": {
+          "OnSuccess": {
+            "Name": "OutputExpression",
+            "Context": {
+              "Expression": "null"
+            }
+          }
+        }
+      }
+    ]
   }
 ]

--- a/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/characterRules.json
+++ b/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/characterRules.json
@@ -261,7 +261,7 @@
     "Rules": [
       {
         "RuleName": "EmailContainsBackslash",
-        "Expression": "input1.Contains('\\')",
+        "Expression": "input1.Contains('\u005c')",
         "Actions": {
           "OnSuccess": {
             "Name": "OutputExpression",

--- a/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/characterRules.json
+++ b/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/characterRules.json
@@ -261,7 +261,7 @@
     "Rules": [
       {
         "RuleName": "EmailContainsBackslash",
-        "Expression": "input1.Contains('\u005c')",
+        "Expression": "input1.Contains('\\\\')",
         "Actions": {
           "OnSuccess": {
             "Name": "OutputExpression",
@@ -321,7 +321,7 @@
       },
       {
         "RuleName": "EmailContainsPipe",
-        "Expression": "input1.Contains('|');",
+        "Expression": "input1.Contains('|')",
         "Actions": {
           "OnSuccess": {
             "Name": "OutputExpression",

--- a/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/characterRules.json
+++ b/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/characterRules.json
@@ -257,7 +257,7 @@
     ]
   },
   {
-    "WorkflowName": "72.InvalidEmailCharacter",
+    "WorkflowName": "71.InvalidEmailCharacter",
     "Rules": [
       {
         "RuleName": "EmailContainsBackslash",


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description
a rogue ; was causing the pipe rule to fail. The backslash rule was being escaped when turned to json.

added test coverage to TransformString.cs
<!-- Describe your changes in detail. -->

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [X] I have followed the code style of the project
- [X] I have added tests to cover my changes
- [X] I have updated the documentation accordingly
- [X] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [X] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
