### PR TITLE
fix: DTOSS-10762 CD Pipeline conditions improvement

### DIFF
--- a/.azuredevops/templates/cd-infrastructure-core-common.yaml
+++ b/.azuredevops/templates/cd-infrastructure-core-common.yaml
@@ -44,7 +44,10 @@ stages:
             serviceConnection: ${{ parameters.serviceConnection }}
 
 - stage: terraform_deploy
-  displayName: ${{ if eq(parameters.terraformActions, 'Apply') }} Terraform Deploy ${{ else }} Terraform Plan
+  ${{ if eq(parameters.terraformActions, 'Apply') }}:
+    displayName: Terraform Deploy
+  ${{ else }}:
+    displayName: Terraform Plan
   condition: in(dependencies.re_tag_stage.result, 'Succeeded', 'Skipped')
   variables:
     tfVarsFile: ${{ parameters.tfVarsFile }}


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

- CD pipeline improvement: don't launch db_changes_stage or restart_functions_stage unless Terraform Apply or the ACR re-tagging ran successfully. Prevents unexpected restarts when simply running a Terraform Plan.
- Other conditional logic simplifications.
- For clarity, added conditional displayname for the terraform_deploy stage, so that it's labelled `Terraform Plan` if no apply is selected when initiating the pipeline.

## Testing

Tested in branch:
https://dev.azure.com/nhse-dtos/dtos-cohort-manager/_build/results?buildId=26639&view=results

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
