### PR TITLE
fix: use the correct query param for raised/not raised

### DIFF
--- a/application/CohortManager/src/Web/app/api/GetValidationExceptions/route.ts
+++ b/application/CohortManager/src/Web/app/api/GetValidationExceptions/route.ts
@@ -45,8 +45,6 @@ function addExceptionDetails<T extends { ExceptionId: number }>(items: T[]) {
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const exceptionId = searchParams.get("exceptionId");
-  const raisedOnly = searchParams.get("raisedOnly");
-  const notRaisedOnly = searchParams.get("notRaisedOnly");
   const sortBy = searchParams.get("sortBy");
   const sortOrder = searchParams.get("sortOrder");
   const exceptionStatus = searchParams.get("exceptionStatus");
@@ -107,28 +105,6 @@ export async function GET(request: Request) {
       isRaised ? "ServiceNowCreatedDate" : "DateCreated"
     );
 
-    const response = createExceptionListResponse(
-      addExceptionDetails(sortedItems)
-    );
-    return NextResponse.json(response, { status: 200 });
-  }
-
-  if (notRaisedOnly) {
-    const notRaisedExceptions = mockDataStore.getNotRaisedExceptions();
-    const sortedItems = sortExceptions([...notRaisedExceptions], sortBy);
-    const response = createExceptionListResponse(
-      addExceptionDetails(sortedItems)
-    );
-    return NextResponse.json(response, { status: 200 });
-  }
-
-  if (raisedOnly) {
-    const raisedExceptions = mockDataStore.getRaisedExceptions();
-    const sortedItems = sortExceptions(
-      [...raisedExceptions],
-      sortBy,
-      "ServiceNowCreatedDate"
-    );
     const response = createExceptionListResponse(
       addExceptionDetails(sortedItems)
     );

--- a/application/CohortManager/src/Web/app/lib/fetchExceptions.ts
+++ b/application/CohortManager/src/Web/app/lib/fetchExceptions.ts
@@ -13,7 +13,7 @@ export async function fetchExceptions(exceptionId?: number) {
 }
 
 export async function fetchExceptionsNotRaised() {
-  const apiUrl = `${process.env.EXCEPTIONS_API_URL}/api/GetValidationExceptions?notRaisedOnly=true`;
+  const apiUrl = `${process.env.EXCEPTIONS_API_URL}/api/GetValidationExceptions?exceptionStatus=2`;
 
   const response = await fetch(apiUrl);
   if (!response.ok) {
@@ -23,7 +23,7 @@ export async function fetchExceptionsNotRaised() {
 }
 
 export async function fetchExceptionsRaised() {
-  const apiUrl = `${process.env.EXCEPTIONS_API_URL}/api/GetValidationExceptions?raisedOnly=true`;
+  const apiUrl = `${process.env.EXCEPTIONS_API_URL}/api/GetValidationExceptions?exceptionStatus=1`;
 
   const response = await fetch(apiUrl);
   if (!response.ok) {
@@ -33,7 +33,7 @@ export async function fetchExceptionsRaised() {
 }
 
 export async function fetchExceptionsNotRaisedSorted(sortBy: 0 | 1) {
-  const apiUrl = `${process.env.EXCEPTIONS_API_URL}/api/GetValidationExceptions?notRaisedOnly=true&sortBy=${sortBy}`;
+  const apiUrl = `${process.env.EXCEPTIONS_API_URL}/api/GetValidationExceptions?exceptionStatus=2&sortBy=${sortBy}`;
 
   const response = await fetch(apiUrl);
   if (!response.ok) {
@@ -43,7 +43,7 @@ export async function fetchExceptionsNotRaisedSorted(sortBy: 0 | 1) {
 }
 
 export async function fetchExceptionsRaisedSorted(sortBy: 0 | 1) {
-  const apiUrl = `${process.env.EXCEPTIONS_API_URL}/api/GetValidationExceptions?raisedOnly=true&sortBy=${sortBy}`;
+  const apiUrl = `${process.env.EXCEPTIONS_API_URL}/api/GetValidationExceptions?exceptionStatus=1&sortBy=${sortBy}`;
 
   const response = await fetch(apiUrl);
   if (!response.ok) {


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

fix: use the correct query param for raised/not raised

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
