### PR TITLE
fix: use the correct query param sortOrder and UpdateExceptionServiceNowId endpoint

### DIFF
--- a/application/CohortManager/src/Web/app/api/GetValidationExceptions/route.ts
+++ b/application/CohortManager/src/Web/app/api/GetValidationExceptions/route.ts
@@ -3,14 +3,18 @@ import mockDataStore from "@/app/data/mockDataStore";
 
 function sortExceptions<
   T extends { DateCreated: string; ServiceNowCreatedDate?: string }
->(items: T[], sortBy: string | null, dateField: keyof T = "DateCreated"): T[] {
-  if (sortBy === "1") {
+>(
+  items: T[],
+  sortOrder: string | null,
+  dateField: keyof T = "DateCreated"
+): T[] {
+  if (sortOrder === "1") {
     return items.sort(
       (a, b) =>
         new Date(a[dateField] as string).getTime() -
         new Date(b[dateField] as string).getTime()
     );
-  } else if (sortBy === "0") {
+  } else if (sortOrder === "0") {
     return items.sort(
       (a, b) =>
         new Date(b[dateField] as string).getTime() -
@@ -45,7 +49,6 @@ function addExceptionDetails<T extends { ExceptionId: number }>(items: T[]) {
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const exceptionId = searchParams.get("exceptionId");
-  const sortBy = searchParams.get("sortBy");
   const sortOrder = searchParams.get("sortOrder");
   const exceptionStatus = searchParams.get("exceptionStatus");
   const isReport = searchParams.get("isReport");
@@ -69,7 +72,7 @@ export async function GET(request: Request) {
 
   // Handle list requests - get fresh data from store
   if (exceptionStatus !== null) {
-    const usingSort = sortBy ?? sortOrder; // accept either param name
+    const usingSort = sortOrder ?? sortOrder; // accept either param name
     const isRaised = exceptionStatus === "1";
     const allItems = isRaised
       ? mockDataStore.getRaisedExceptions()

--- a/application/CohortManager/src/Web/app/components/sortExceptionsForm.tsx
+++ b/application/CohortManager/src/Web/app/components/sortExceptionsForm.tsx
@@ -1,5 +1,5 @@
 interface SortExceptionsFormProps {
-  readonly sortBy: number;
+  readonly sortOrder: number;
   readonly options: readonly {
     readonly value: string;
     readonly label: string;
@@ -9,7 +9,7 @@ interface SortExceptionsFormProps {
 }
 
 export default function SortExceptionsForm({
-  sortBy,
+  sortOrder,
   options,
   hiddenText = "exceptions",
   testId,
@@ -24,8 +24,8 @@ export default function SortExceptionsForm({
           <select
             className="nhsuk-select"
             id="sort-exceptions"
-            name="sortBy"
-            defaultValue={String(sortBy)}
+            name="sortOrder"
+            defaultValue={String(sortOrder)}
             data-testid={testId}
           >
             {options.map((option) => (

--- a/application/CohortManager/src/Web/app/exceptions/[filter]/page.tsx
+++ b/application/CohortManager/src/Web/app/exceptions/[filter]/page.tsx
@@ -17,7 +17,7 @@ export const metadata: Metadata = {
 export default async function Page({
   searchParams,
 }: {
-  readonly searchParams?: Promise<{ readonly sortBy?: string }>;
+  readonly searchParams?: Promise<{ readonly sortOrder?: string }>;
 }) {
   const session = await auth();
   const isCohortManager = await canAccessCohortManager(session);
@@ -28,7 +28,7 @@ export default async function Page({
 
   const breadcrumbItems = [{ label: "Home", url: "/" }];
   const resolvedSearchParams = searchParams ? await searchParams : {};
-  const sortBy = resolvedSearchParams.sortBy === "1" ? 1 : 0;
+  const sortOrder = resolvedSearchParams.sortOrder === "1" ? 1 : 0;
 
   const sortOptions = [
     {
@@ -42,7 +42,7 @@ export default async function Page({
   ];
 
   try {
-    const exceptions = await fetchExceptionsRaisedSorted(sortBy);
+    const exceptions = await fetchExceptionsRaisedSorted(sortOrder);
 
     const exceptionDetails: ExceptionDetails[] = exceptions.Items.map(
       (exception: {
@@ -81,7 +81,7 @@ export default async function Page({
 
               <div className="app-form-results-container">
                 <SortExceptionsForm
-                  sortBy={sortBy}
+                  sortOrder={sortOrder}
                   options={sortOptions}
                   hiddenText="raised exceptions"
                   testId="sort-raised-exceptions"

--- a/application/CohortManager/src/Web/app/exceptions/page.tsx
+++ b/application/CohortManager/src/Web/app/exceptions/page.tsx
@@ -17,7 +17,7 @@ export const metadata: Metadata = {
 export default async function Page({
   searchParams,
 }: {
-  readonly searchParams?: Promise<{ readonly sortBy?: string }>;
+  readonly searchParams?: Promise<{ readonly sortOrder?: string }>;
 }) {
   const session = await auth();
   const isCohortManager = await canAccessCohortManager(session);
@@ -28,7 +28,7 @@ export default async function Page({
 
   const breadcrumbItems = [{ label: "Home", url: "/" }];
   const resolvedSearchParams = searchParams ? await searchParams : {};
-  const sortBy = resolvedSearchParams.sortBy === "1" ? 1 : 0;
+  const sortOrder = resolvedSearchParams.sortOrder === "1" ? 1 : 0;
 
   const sortOptions = [
     {
@@ -42,7 +42,7 @@ export default async function Page({
   ];
 
   try {
-    const exceptions = await fetchExceptionsNotRaisedSorted(sortBy);
+    const exceptions = await fetchExceptionsNotRaisedSorted(sortOrder);
 
     const exceptionDetails: ExceptionDetails[] = exceptions.Items.map(
       (exception: {
@@ -81,7 +81,7 @@ export default async function Page({
 
               <div className="app-form-results-container">
                 <SortExceptionsForm
-                  sortBy={sortBy}
+                  sortOrder={sortOrder}
                   options={sortOptions}
                   hiddenText="not raised exceptions"
                   testId="sort-not-raised-exceptions"

--- a/application/CohortManager/src/Web/app/lib/fetchExceptions.ts
+++ b/application/CohortManager/src/Web/app/lib/fetchExceptions.ts
@@ -6,6 +6,11 @@ export async function fetchExceptions(exceptionId?: number) {
     : `${process.env.EXCEPTIONS_API_URL}/api/GetValidationExceptions`;
 
   const response = await fetch(apiUrl);
+
+  if (response.status === 204) {
+    return [];
+  }
+
   if (!response.ok) {
     throw new Error(`Error fetching data: ${response.statusText}`);
   }
@@ -16,6 +21,11 @@ export async function fetchExceptionsNotRaised() {
   const apiUrl = `${process.env.EXCEPTIONS_API_URL}/api/GetValidationExceptions?exceptionStatus=2`;
 
   const response = await fetch(apiUrl);
+
+  if (response.status === 204) {
+    return [];
+  }
+
   if (!response.ok) {
     throw new Error(`Error fetching data: ${response.statusText}`);
   }
@@ -26,26 +36,41 @@ export async function fetchExceptionsRaised() {
   const apiUrl = `${process.env.EXCEPTIONS_API_URL}/api/GetValidationExceptions?exceptionStatus=1`;
 
   const response = await fetch(apiUrl);
+
+  if (response.status === 204) {
+    return [];
+  }
+
   if (!response.ok) {
     throw new Error(`Error fetching data: ${response.statusText}`);
   }
   return response.json();
 }
 
-export async function fetchExceptionsNotRaisedSorted(sortBy: 0 | 1) {
-  const apiUrl = `${process.env.EXCEPTIONS_API_URL}/api/GetValidationExceptions?exceptionStatus=2&sortBy=${sortBy}`;
+export async function fetchExceptionsNotRaisedSorted(sortOrder: 0 | 1) {
+  const apiUrl = `${process.env.EXCEPTIONS_API_URL}/api/GetValidationExceptions?exceptionStatus=2&sortOrder=${sortOrder}`;
 
   const response = await fetch(apiUrl);
+
+  if (response.status === 204) {
+    return [];
+  }
+
   if (!response.ok) {
     throw new Error(`Error fetching data: ${response.statusText}`);
   }
   return response.json();
 }
 
-export async function fetchExceptionsRaisedSorted(sortBy: 0 | 1) {
-  const apiUrl = `${process.env.EXCEPTIONS_API_URL}/api/GetValidationExceptions?exceptionStatus=1&sortBy=${sortBy}`;
+export async function fetchExceptionsRaisedSorted(sortOrder: 0 | 1) {
+  const apiUrl = `${process.env.EXCEPTIONS_API_URL}/api/GetValidationExceptions?exceptionStatus=1&sortOrder=${sortOrder}`;
 
   const response = await fetch(apiUrl);
+
+  if (response.status === 204) {
+    return [];
+  }
+
   if (!response.ok) {
     throw new Error(`Error fetching data: ${response.statusText}`);
   }

--- a/application/CohortManager/src/Web/app/lib/fetchReports.ts
+++ b/application/CohortManager/src/Web/app/lib/fetchReports.ts
@@ -4,10 +4,16 @@ export async function fetchReports(exceptionCategory: number, date: string) {
   const apiUrl = `${process.env.EXCEPTIONS_API_URL}/api/GetValidationExceptions?exceptionStatus=1&sortOrder=1&exceptionCategory=${exceptionCategory}&isReport=1&reportDate=${date}`;
 
   const response = await fetch(apiUrl);
+
+  if (response.status === 204) {
+    return [];
+  }
+
   if (!response.ok) {
     throw new Error(
       `Error fetching data for reports: ${response.status} ${response.statusText} from ${apiUrl}`
     );
   }
+
   return response.json();
 }

--- a/application/CohortManager/src/Web/app/lib/updateExceptions.ts
+++ b/application/CohortManager/src/Web/app/lib/updateExceptions.ts
@@ -28,7 +28,7 @@ export async function updateExceptions(
     redirect(errorUrl);
   }
 
-  const apiUrl = `${process.env.EXCEPTIONS_API_URL}/api/UpdateException`;
+  const apiUrl = `${process.env.EXCEPTIONS_API_URL}/api/UpdateExceptionServiceNowId`;
 
   const response = await fetch(apiUrl, {
     method: "PUT",


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

This PR uses the correct query param `sortOrder` instead of `sortBy` for the sorting of the Exceptions in the API and renames it through the UI for consistency. It also uses the correct API endpoint for `UpdateExceptionServiceNowId`

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
