### PR TITLE
test: Fixed validateServiceNowRequestWithMockServer in playwright tests by adding a wait

### DIFF
--- a/tests/playwright-tests/src/tests/runner/runner-workflow-manual-add.spec.ts
+++ b/tests/playwright-tests/src/tests/runner/runner-workflow-manual-add.spec.ts
@@ -25,6 +25,7 @@ test.beforeAll(async () => {
   apiContext = await playwrightRequest.newContext();
   console.log(`Running ${TEST_TYPE} tests with scenario tags: ${scopedTestScenario}`);
   await cleanupDatabaseFromAPI(apiContext, addData.nhsNumbers);
+  await cleanupWireMock(apiContext);
 
   const dateMap = generateDynamicDateMap();
   const updatedParticipantRecords = replaceDynamicDatesInJson(addData.inputParticipantRecords, dateMap);
@@ -36,7 +37,6 @@ test.beforeAll(async () => {
 });
 
 test.afterAll(async () => {
-  await cleanupWireMock(apiContext);
   await apiContext.dispose();
 });
 

--- a/tests/playwright-tests/src/tests/steps/steps.ts
+++ b/tests/playwright-tests/src/tests/steps/steps.ts
@@ -53,6 +53,9 @@ export async function validateSqlDatabaseFromAPI(request: APIRequestContext, val
 export async function validateServiceNowRequestWithMockServer(request: APIRequestContext, validations: ServiceNowRequestValidations[]) {
   const wireMockUrl = getWireMockUrl();
 
+  // Wait for 5 seconds
+  await new Promise((resolve) => setTimeout(resolve, 5000));
+
   var response = await request.get(wireMockUrl);
   var body = await response.json() as WireMockResponse;
 


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

- Added a 5 second wait
- Moved WireMock cleanup to run before tests to align with database cleanup

## Context

Playwright tests were failing because they would run before the test records were fully processed.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
