### PR TITLE
refactor: PageSize and LastResultId removed from PaginationResult Model, tests updated

### DIFF
--- a/application/CohortManager/src/Functions/Shared/Common/Pagination/PaginationResult.cs
+++ b/application/CohortManager/src/Functions/Shared/Common/Pagination/PaginationResult.cs
@@ -6,9 +6,7 @@ public class PaginationResult<T>
     public bool IsFirstPage { get; set; }
     public bool HasNextPage { get; set; }
     public bool HasPreviousPage { get; set; }
-    public int? LastResultId { get; set; }
     public int TotalItems { get; set; }
     public int TotalPages { get; set; }
     public int CurrentPage { get; set; }
-    public int PageSize { get; set; }
 }

--- a/application/CohortManager/src/Functions/Shared/Common/Pagination/PaginationService.cs
+++ b/application/CohortManager/src/Functions/Shared/Common/Pagination/PaginationService.cs
@@ -31,11 +31,9 @@ public class PaginationService<T> : IPaginationService<T>
             IsFirstPage = page == 1,
             HasNextPage = page < totalPages,
             HasPreviousPage = page > 1,
-            LastResultId = null, // Not used in page-based pagination
             TotalItems = totalItems,
             TotalPages = totalPages,
             CurrentPage = page,
-            PageSize = pageSize
         };
     }
 

--- a/tests/UnitTests/ScreeningDataServicesTests/ValidationExceptionDataTests/GetValidationExceptionTests/GetValidationExceptionsTests.cs
+++ b/tests/UnitTests/ScreeningDataServicesTests/ValidationExceptionDataTests/GetValidationExceptionTests/GetValidationExceptionsTests.cs
@@ -137,7 +137,6 @@ public class GetValidationExceptionsTests
             CurrentPage = 1,
             TotalItems = 3,
             TotalPages = 1,
-            PageSize = 10
         };
 
         var expectedHeaders = new Dictionary<string, string> { { "X-Total-Count", "3" } };
@@ -175,7 +174,6 @@ public class GetValidationExceptionsTests
             CurrentPage = 1,
             TotalItems = reportExceptions.Count,
             TotalPages = 1,
-            PageSize = 10
         };
 
         var expectedHeaders = new Dictionary<string, string> { { "X-Total-Count", "2" } };
@@ -237,7 +235,6 @@ public class GetValidationExceptionsTests
             CurrentPage = 1,
             TotalItems = allReportExceptions.Count,
             TotalPages = 1,
-            PageSize = 10
         };
 
         var expectedHeaders = new Dictionary<string, string> { { "X-Total-Count", allReportExceptions.Count.ToString() } };
@@ -280,7 +277,6 @@ public class GetValidationExceptionsTests
             CurrentPage = 1,
             TotalItems = todaysReportExceptions.Count,
             TotalPages = 1,
-            PageSize = 10
         };
 
         var expectedHeaders = new Dictionary<string, string> { { "X-Total-Count", todaysReportExceptions.Count.ToString() } };
@@ -343,7 +339,6 @@ public class GetValidationExceptionsTests
             CurrentPage = 1,
             TotalItems = boExceptions.Count,
             TotalPages = 1,
-            PageSize = 10
         };
 
         var expectedHeaders = new Dictionary<string, string> { { "X-Total-Count", boExceptions.Count.ToString() } };
@@ -394,7 +389,6 @@ public class GetValidationExceptionsTests
             CurrentPage = pageNumber,
             TotalItems = filteredAndSortedExceptions.Count,
             TotalPages = 2,
-            PageSize = 1
         };
 
         var expectedHeaders = new Dictionary<string, string>
@@ -487,7 +481,6 @@ public class GetValidationExceptionsTests
             CurrentPage = 1,
             TotalItems = 0,
             TotalPages = 0,
-            PageSize = 10
         };
 
         var expectedHeaders = new Dictionary<string, string> { { "X-Total-Count", "0" } };
@@ -553,7 +546,6 @@ public class GetValidationExceptionsTests
             CurrentPage = 1,
             TotalItems = 2,
             TotalPages = 1,
-            PageSize = 10
         };
 
         var expectedHeaders = new Dictionary<string, string> { { "X-Total-Count", "2" } };
@@ -594,7 +586,6 @@ public class GetValidationExceptionsTests
             CurrentPage = 1,
             TotalItems = sortedExceptions.Count,
             TotalPages = 1,
-            PageSize = 10
         };
 
         var expectedHeaders = new Dictionary<string, string> { { "X-Total-Count", sortedExceptions.Count.ToString() } };
@@ -635,7 +626,6 @@ public class GetValidationExceptionsTests
             CurrentPage = pageNumber,
             TotalItems = _exceptionList.Count,
             TotalPages = 3,
-            PageSize = 2
         };
 
         var expectedHeaders = new Dictionary<string, string> {
@@ -681,7 +671,7 @@ public class GetValidationExceptionsTests
             CurrentPage = 1,
             TotalItems = _exceptionList.Count,
             TotalPages = 1,
-            PageSize = 10
+
         };
 
         var expectedHeaders = new Dictionary<string, string> { { "X-Total-Count", _exceptionList.Count.ToString() } };
@@ -720,7 +710,7 @@ public class GetValidationExceptionsTests
             CurrentPage = 1,
             TotalItems = _exceptionList.Count,
             TotalPages = 1,
-            PageSize = 10
+
         };
 
         var expectedHeaders = new Dictionary<string, string> { { "X-Total-Count", _exceptionList.Count.ToString() } };
@@ -780,7 +770,7 @@ public class GetValidationExceptionsTests
             CurrentPage = 1,
             TotalItems = reportExceptions.Count,
             TotalPages = 1,
-            PageSize = 10
+
         };
 
         var expectedHeaders = new Dictionary<string, string> { { "X-Total-Count", reportExceptions.Count.ToString() } };


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

PageSize and LastResultId removed from PaginationResult Model, tests updated

## Context

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [x] I have added tests to cover my changes
- [x] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
