### PR TITLE
Fix: dtoss 10638 moving rules to right workflow

### DIFF
--- a/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/transformRules.json
+++ b/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/transformRules.json
@@ -3,6 +3,99 @@
     "WorkflowName": "Routine",
     "Rules": [
       {
+        "RuleName": "8a.Transform.NoTransformButError",
+        "LocalParams": [
+          {
+            "Name": "DMSInSMU",
+            "Expression": "participant.CurrentPosting == \"DMS\" && excludedSMUList.Contains(participant.PrimaryCareProvider)"
+          },
+          {
+            "Name": "WelshCurrentPosting",
+            "Expression": "dbLookup.RetrievePostingCategory(participant.CurrentPosting) == \"WALES\""
+          },
+          {
+            "Name": "NoTransformationRequired",
+            "Expression": "existingParticipant.PrimaryCareProvider == null && existingParticipant.ReasonForRemoval == \"ORR\""
+          }
+        ],
+        "Expression": "participant.RecordType == Actions.Amended && (DMSInSMU || WelshCurrentPosting) && NoTransformationRequired",
+        "Actions": {
+          "OnSuccess": {
+            "Name": "TransformAction",
+            "Context": {
+              "transformFields": [
+                {
+                  "isExpression": false,
+                  "field": "PrimaryCareProvider",
+                  "value": null
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  },
+  {
+    "WorkflowName": "Common",
+    "Rules": [
+      {
+        "RuleName": "60.Other.SupersededNhsNumber",
+        "Expression": "participant.RecordType == Actions.Amended && !string.IsNullOrEmpty(participant.SupersededByNhsNumber)",
+        "Actions": {
+          "OnSuccess": {
+            "Name": "TransformAction",
+            "Context": {
+              "transformFields": [
+                {
+                  "field": "PrimaryCareProvider",
+                  "value": "",
+                  "isExpression": false
+                },
+                {
+                  "field": "ReasonForRemoval",
+                  "value": "ORR",
+                  "isExpression": false
+                },
+                {
+                  "field": "ReasonForRemovalEffectiveFromDate",
+                  "value": "DateTime.UtcNow.Date.ToString(\"yyyyMMdd\")",
+                  "isExpression": true
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "RuleName": "00.Other.InvalidFlag.TrueAndNoPrimaryCareProvider",
+        "Expression": "(!string.IsNullOrEmpty(participant.PrimaryCareProvider) && participant.InvalidFlag  == \"1\") OR participant.RecordType == Actions.Removed",
+        "Actions": {
+          "OnSuccess": {
+            "Name": "TransformAction",
+            "Context": {
+              "transformFields": [
+                {
+                  "field": "PrimaryCareProvider",
+                  "value": "",
+                  "isExpression": false
+                },
+                {
+                  "field": "ReasonForRemoval",
+                  "value": "ORR",
+                  "isExpression": false
+                },
+                {
+                  "field": "ReasonForRemovalEffectiveFromDate",
+                  "value": "DateTime.UtcNow.Date.ToString(\"yyyyMMdd\")",
+                  "isExpression": true
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
         "RuleName": "8.Transform.UpdatedRecordExcludedAndDMS",
         "LocalParams": [
           {
@@ -37,99 +130,6 @@
                 {
                   "field": "ReasonForRemovalEffectiveFromDate",
                   "value": "DateTime.Today.ToString(\"yyyyMMdd\")",
-                  "isExpression": true
-                }
-              ]
-            }
-          }
-        }
-      },
-      {
-        "RuleName": "8a.Transform.NoTransformButError",
-        "LocalParams": [
-          {
-            "Name": "DMSInSMU",
-            "Expression": "participant.CurrentPosting == \"DMS\" && excludedSMUList.Contains(participant.PrimaryCareProvider)"
-          },
-          {
-            "Name": "WelshCurrentPosting",
-            "Expression": "dbLookup.RetrievePostingCategory(participant.CurrentPosting) == \"WALES\""
-          },
-          {
-            "Name": "NoTransformationRequired",
-            "Expression": "existingParticipant.PrimaryCareProvider == null && existingParticipant.ReasonForRemoval == \"ORR\""
-          }
-        ],
-        "Expression": "participant.RecordType == Actions.Amended && (DMSInSMU || WelshCurrentPosting) && NoTransformationRequired",
-        "Actions": {
-          "OnSuccess": {
-            "Name": "TransformAction",
-            "Context": {
-              "transformFields": [
-                {
-                  "isExpression": false,
-                  "field": "PrimaryCareProvider",
-                  "value": null
-                }
-              ]
-            }
-          }
-        }
-      },
-      {
-        "RuleName": "60.Other.SupersededNhsNumber",
-        "Expression": "participant.RecordType == Actions.Amended && !string.IsNullOrEmpty(participant.SupersededByNhsNumber)",
-        "Actions": {
-          "OnSuccess": {
-            "Name": "TransformAction",
-            "Context": {
-              "transformFields": [
-                {
-                  "field": "PrimaryCareProvider",
-                  "value": "",
-                  "isExpression": false
-                },
-                {
-                  "field": "ReasonForRemoval",
-                  "value": "ORR",
-                  "isExpression": false
-                },
-                {
-                  "field": "ReasonForRemovalEffectiveFromDate",
-                  "value": "DateTime.UtcNow.Date.ToString(\"yyyyMMdd\")",
-                  "isExpression": true
-                }
-              ]
-            }
-          }
-        }
-      }
-    ]
-  },
-  {
-    "WorkflowName": "Common",
-    "Rules": [
-      {
-        "RuleName": "00.Other.InvalidFlag.TrueAndNoPrimaryCareProvider",
-        "Expression": "(!string.IsNullOrEmpty(participant.PrimaryCareProvider) && participant.InvalidFlag  == \"1\") OR participant.RecordType == Actions.Removed",
-        "Actions": {
-          "OnSuccess": {
-            "Name": "TransformAction",
-            "Context": {
-              "transformFields": [
-                {
-                  "field": "PrimaryCareProvider",
-                  "value": "",
-                  "isExpression": false
-                },
-                {
-                  "field": "ReasonForRemoval",
-                  "value": "ORR",
-                  "isExpression": false
-                },
-                {
-                  "field": "ReasonForRemovalEffectiveFromDate",
-                  "value": "DateTime.UtcNow.Date.ToString(\"yyyyMMdd\")",
                   "isExpression": true
                 }
               ]

--- a/application/CohortManager/src/Functions/ScreeningValidationService/StaticValidation/Breast_Screening_staticRules.json
+++ b/application/CohortManager/src/Functions/ScreeningValidationService/StaticValidation/Breast_Screening_staticRules.json
@@ -25,28 +25,6 @@
             }
           }
         }
-      },
-      {
-        "RuleName": "53.CurrentPostingAndPrimaryCareProvider.NBO.NonFatal",
-        "LocalParams": [
-          {
-            "Name": "currentPosting",
-            "Expression": "participant.CurrentPosting"
-          },
-          {
-            "Name": "primaryCareProvider",
-            "Expression": "participant.PrimaryCareProvider"
-          }
-        ],
-        "Expression": "!(string.IsNullOrEmpty(currentPosting) AND !string.IsNullOrEmpty(primaryCareProvider))",
-        "Actions": {
-          "OnFailure": {
-            "Name": "OutputExpression",
-            "Context": {
-              "Expression": "\"Current posting and Primary Care provider contain incompatible values\""
-            }
-          }
-        }
       }
     ]
   },
@@ -147,6 +125,28 @@
   {
     "WorkflowName": "AMENDED",
     "Rules": [
+      {
+        "RuleName": "53.CurrentPostingAndPrimaryCareProvider.NBO.NonFatal",
+        "LocalParams": [
+          {
+            "Name": "currentPosting",
+            "Expression": "participant.CurrentPosting"
+          },
+          {
+            "Name": "primaryCareProvider",
+            "Expression": "participant.PrimaryCareProvider"
+          }
+        ],
+        "Expression": "!(string.IsNullOrEmpty(currentPosting) AND !string.IsNullOrEmpty(primaryCareProvider))",
+        "Actions": {
+          "OnFailure": {
+            "Name": "OutputExpression",
+            "Context": {
+              "Expression": "\"Current posting and Primary Care provider contain incompatible values\""
+            }
+          }
+        }
+      },
       {
         "RuleName": "66.DeathStatus.NBO.NonFatal",
         "LocalParams": [

--- a/tests/UnitTests/ScreeningValidationServiceTests/StaticValidation/StaticValidationTests.cs
+++ b/tests/UnitTests/ScreeningValidationServiceTests/StaticValidation/StaticValidationTests.cs
@@ -620,6 +620,8 @@ public class StaticValidationTests
         // Arrange
         _participantCsvRecord.Participant.CurrentPosting = currentPosting;
         _participantCsvRecord.Participant.PrimaryCareProvider = primaryCareProvider;
+        _participantCsvRecord.Participant.RecordType = Actions.Amended;
+
         var json = JsonSerializer.Serialize(_participantCsvRecord);
         SetUpRequestBody(json);
 


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

https://nhsd-jira.digital.nhs.uk/browse/DTOSS-10638

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
