### PR TITLE
fix: Change Slack Alert filter to main branch

### DIFF
--- a/.azuredevops/templates/cd-infrastructure-core-common.yaml
+++ b/.azuredevops/templates/cd-infrastructure-core-common.yaml
@@ -127,7 +127,7 @@ stages:
   condition: |
     and(
       always(),
-      eq(variables['Build.SourceBranch'], 'refs/heads/feat/dtoss-10921-slack-generic-messaging'),
+      eq(variables['Build.SourceBranch'], 'refs/heads/main'),
       ne('${{ parameters.slackWebHook }}', '')
     )
   pool:


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Fix filter so that Slack Alerts are sent on pipeline runs on the main branch, not the original dev branch.

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
