### PR TITLE
fix: added idempotent check to ManageCaasSubscription Subscribe endpoint

### DIFF
--- a/application/CohortManager/src/Functions/DemographicServices/ManageCaasSubscription/ManageCaasSubscription.cs
+++ b/application/CohortManager/src/Functions/DemographicServices/ManageCaasSubscription/ManageCaasSubscription.cs
@@ -70,7 +70,7 @@ public class ManageCaasSubscription
             var existing = await _nemsSubscriptionAccessor.GetSingle(i => i.NhsNumber == nhsNo);
             if (existing != null && !string.IsNullOrWhiteSpace(existing.SubscriptionId))
             {
-                _logger.LogInformation("CAAS Subscribe called for NHS {Nhs} but existing subscription found {SubId}; returning existing.", nhsNo, existing.SubscriptionId);
+                _logger.LogInformation("CAAS Subscribe called but existing subscription found {SubId}; returning existing.", existing.SubscriptionId);
                 return await _createResponse.CreateHttpResponseWithBodyAsync(HttpStatusCode.OK, req, $"Already subscribed. Subscription ID: {existing.SubscriptionId}");
             }
 
@@ -118,9 +118,8 @@ public class ManageCaasSubscription
             _logger.LogError(ex, "Error sending CAAS subscribe request");
             try
             {
-                string? rawNhs = req.Query["nhsNumber"];
-                var nhsForLog = ValidationHelper.ValidateNHSNumber(rawNhs!) ? rawNhs! : string.Empty;
-                await _exceptionHandler.CreateSystemExceptionLogFromNhsNumber(ex, nhsForLog, nameof(ManageCaasSubscription), "", string.Empty);
+                // Do not log NHS numbers
+                await _exceptionHandler.CreateSystemExceptionLogFromNhsNumber(ex, string.Empty, nameof(ManageCaasSubscription), "", string.Empty);
             }
             catch
             {
@@ -183,9 +182,8 @@ public class ManageCaasSubscription
             _logger.LogError(ex, "Error checking subscription status");
             try
             {
-                string? rawNhs = req.Query["nhsNumber"];
-                var nhsForLog = ValidationHelper.ValidateNHSNumber(rawNhs!) ? rawNhs! : string.Empty;
-                await _exceptionHandler.CreateSystemExceptionLogFromNhsNumber(ex, nhsForLog, nameof(ManageCaasSubscription), "", string.Empty);
+                // Do not log NHS numbers
+                await _exceptionHandler.CreateSystemExceptionLogFromNhsNumber(ex, string.Empty, nameof(ManageCaasSubscription), "", string.Empty);
             }
             catch
             {

--- a/application/CohortManager/src/Functions/DemographicServices/ManageCaasSubscription/ManageCaasSubscription.cs
+++ b/application/CohortManager/src/Functions/DemographicServices/ManageCaasSubscription/ManageCaasSubscription.cs
@@ -118,8 +118,9 @@ public class ManageCaasSubscription
             _logger.LogError(ex, "Error sending CAAS subscribe request");
             try
             {
-                // Do not log NHS numbers
-                await _exceptionHandler.CreateSystemExceptionLogFromNhsNumber(ex, string.Empty, nameof(ManageCaasSubscription), "", string.Empty);
+                string? rawNhs = req.Query["nhsNumber"];
+                var nhsForLog = ValidationHelper.ValidateNHSNumber(rawNhs!) ? rawNhs! : string.Empty;
+                await _exceptionHandler.CreateSystemExceptionLogFromNhsNumber(ex, nhsForLog, nameof(ManageCaasSubscription), "", string.Empty);
             }
             catch
             {
@@ -182,8 +183,9 @@ public class ManageCaasSubscription
             _logger.LogError(ex, "Error checking subscription status");
             try
             {
-                // Do not log NHS numbers
-                await _exceptionHandler.CreateSystemExceptionLogFromNhsNumber(ex, string.Empty, nameof(ManageCaasSubscription), "", string.Empty);
+                string? rawNhs = req.Query["nhsNumber"];
+                var nhsForLog = ValidationHelper.ValidateNHSNumber(rawNhs!) ? rawNhs! : string.Empty;
+                await _exceptionHandler.CreateSystemExceptionLogFromNhsNumber(ex, nhsForLog, nameof(ManageCaasSubscription), "", string.Empty);
             }
             catch
             {

--- a/application/CohortManager/src/Functions/DemographicServices/ManageCaasSubscription/ManageCaasSubscription.cs
+++ b/application/CohortManager/src/Functions/DemographicServices/ManageCaasSubscription/ManageCaasSubscription.cs
@@ -70,8 +70,12 @@ public class ManageCaasSubscription
             var existing = await _nemsSubscriptionAccessor.GetSingle(i => i.NhsNumber == nhsNo);
             if (existing != null && !string.IsNullOrWhiteSpace(existing.SubscriptionId))
             {
-                _logger.LogInformation("CAAS Subscribe called but existing subscription found {SubId}; returning existing.", existing.SubscriptionId);
-                return await _createResponse.CreateHttpResponseWithBodyAsync(HttpStatusCode.OK, req, $"Already subscribed. Subscription ID: {existing.SubscriptionId}");
+                var src = existing.SubscriptionSource?.ToString() ?? "";
+                _logger.LogInformation("CAAS Subscribe: existing subscription {SubId}, source {Source}; returning existing.", existing.SubscriptionId, string.IsNullOrWhiteSpace(src) ? "Unknown" : src);
+                var message = string.IsNullOrWhiteSpace(src)
+                    ? $"Already subscribed. Subscription ID: {existing.SubscriptionId}"
+                    : $"Already subscribed. Subscription ID: {existing.SubscriptionId}. Source: {src}";
+                return await _createResponse.CreateHttpResponseWithBodyAsync(HttpStatusCode.OK, req, message);
             }
 
             var toMailbox = _config.CaasToMailbox!;

--- a/application/CohortManager/src/Functions/DemographicServices/ManageCaasSubscription/ManageCaasSubscription.cs
+++ b/application/CohortManager/src/Functions/DemographicServices/ManageCaasSubscription/ManageCaasSubscription.cs
@@ -13,6 +13,7 @@ using DataServices.Core;
 using Model;
 using NHS.CohortManager.DemographicServices;
 using Common.Interfaces;
+using System.Linq;
 
 /// <summary>
 /// Azure Functions endpoints for managing CaaS subscriptions via MESH and data services.
@@ -48,6 +49,18 @@ public class ManageCaasSubscription
         _exceptionHandler = exceptionHandler;
     }
 
+    private async Task<NemsSubscription?> GetLatestSubscriptionAsync(long nhsNumber)
+    {
+        var records = await _nemsSubscriptionAccessor.GetRange(i => i.NhsNumber == nhsNumber);
+        if (records == null || records.Count == 0)
+        {
+            return null;
+        }
+        return records
+            .OrderByDescending(r => r.RecordInsertDateTime ?? DateTime.MinValue)
+            .FirstOrDefault();
+    }
+
 
     /// <summary>
     /// Creates a new CaaS subscription for the given NHS number and persists a record.
@@ -66,6 +79,14 @@ public class ManageCaasSubscription
             }
 
             var nhsNo = long.Parse(nhsNumber!);
+
+            var existing = await GetLatestSubscriptionAsync(nhsNo);
+            if (existing != null && !string.IsNullOrWhiteSpace(existing.SubscriptionId))
+            {
+                _logger.LogInformation("CAAS Subscribe called for NHS {Nhs} but existing subscription found {SubId}; returning existing.", nhsNo, existing.SubscriptionId);
+                return await _createResponse.CreateHttpResponseWithBodyAsync(HttpStatusCode.OK, req, $"Already subscribed. Subscription ID: {existing.SubscriptionId}");
+            }
+
             var toMailbox = _config.CaasToMailbox!;
             var fromMailbox = _config.CaasFromMailbox!;
             var messageId = await _meshSendCaasSubscribe.SendSubscriptionRequest(nhsNo, toMailbox, fromMailbox);
@@ -160,7 +181,8 @@ public class ManageCaasSubscription
                 return await _createResponse.CreateHttpResponseWithBodyAsync(HttpStatusCode.BadRequest, req, "NHS number is required and must be valid format.");
             }
 
-            var record = await _nemsSubscriptionAccessor.GetSingle(i => i.NhsNumber == long.Parse(nhsNumber!));
+            var nhs = long.Parse(nhsNumber!);
+            var record = await GetLatestSubscriptionAsync(nhs);
             string? subscriptionId = record?.SubscriptionId;
 
             if (string.IsNullOrEmpty(subscriptionId))

--- a/tests/UnitTests/DemographicServicesTests/ManageCaasSubscriptionTests/ManageCaasSubscriptionTests.cs
+++ b/tests/UnitTests/DemographicServicesTests/ManageCaasSubscriptionTests/ManageCaasSubscriptionTests.cs
@@ -205,6 +205,9 @@ public class ManageCaasSubscriptionTests
     [TestMethod]
     public async Task Subscribe_MeshCalled_WithConfigMailboxes()
     {
+        _nemsAccessor
+            .Setup(a => a.GetSingle(It.IsAny<System.Linq.Expressions.Expression<Func<NemsSubscription, bool>>>() ))
+            .ReturnsAsync((NemsSubscription?)null);
         _nemsAccessor.Setup(a => a.InsertSingle(It.IsAny<NemsSubscription>())).ReturnsAsync(true);
         var req = _setupRequest.Setup(null, new NameValueCollection { { "nhsNumber", "9000000009" } }, HttpMethod.Post);
         var res = await _sut.Subscribe(req.Object);
@@ -216,6 +219,9 @@ public class ManageCaasSubscriptionTests
     [TestMethod]
     public async Task Subscribe_MeshThrows_ReturnsInternalServerError()
     {
+        _nemsAccessor
+            .Setup(a => a.GetSingle(It.IsAny<System.Linq.Expressions.Expression<Func<NemsSubscription, bool>>>() ))
+            .ReturnsAsync((NemsSubscription?)null);
         _mesh
             .Setup(m => m.SendSubscriptionRequest(It.IsAny<long>(), It.IsAny<string>(), It.IsAny<string>()))
             .ThrowsAsync(new Exception("mesh-down"));
@@ -229,6 +235,9 @@ public class ManageCaasSubscriptionTests
     [TestMethod]
     public async Task Subscribe_DBInsertFails_ReturnsInternalServerError()
     {
+        _nemsAccessor
+            .Setup(a => a.GetSingle(It.IsAny<System.Linq.Expressions.Expression<Func<NemsSubscription, bool>>>() ))
+            .ReturnsAsync((NemsSubscription?)null);
         _nemsAccessor.Setup(a => a.InsertSingle(It.IsAny<NemsSubscription>())).ReturnsAsync(false);
         var req = _setupRequest.Setup(null, new NameValueCollection { { "nhsNumber", "9000000009" } }, HttpMethod.Post);
         var res = await _sut.Subscribe(req.Object);
@@ -260,6 +269,9 @@ public class ManageCaasSubscriptionTests
         );
 
         var req = _setupRequest.Setup(null, new NameValueCollection { { "nhsNumber", "9000000009" } }, HttpMethod.Post);
+        _nemsAccessor
+            .Setup(a => a.GetSingle(It.IsAny<System.Linq.Expressions.Expression<Func<NemsSubscription, bool>>>() ))
+            .ReturnsAsync((NemsSubscription?)null);
         var res = await sut.Subscribe(req.Object);
         Assert.AreEqual(HttpStatusCode.OK, res.StatusCode);
         _logger.Verify(l => l.Log(
@@ -294,6 +306,9 @@ public class ManageCaasSubscriptionTests
         );
 
         var req = _setupRequest.Setup(null, new NameValueCollection { { "nhsNumber", "9000000009" } }, HttpMethod.Post);
+        _nemsAccessor
+            .Setup(a => a.GetSingle(It.IsAny<System.Linq.Expressions.Expression<Func<NemsSubscription, bool>>>() ))
+            .ReturnsAsync((NemsSubscription?)null);
         var res = await sut.Subscribe(req.Object);
         Assert.AreEqual(HttpStatusCode.OK, res.StatusCode);
         _logger.Verify(l => l.Log(
@@ -321,6 +336,9 @@ public class ManageCaasSubscriptionTests
     [TestMethod]
     public async Task Subscribe_MeshReturnsNull_ReturnsInternalServerError()
     {
+        _nemsAccessor
+            .Setup(a => a.GetSingle(It.IsAny<System.Linq.Expressions.Expression<Func<NemsSubscription, bool>>>() ))
+            .ReturnsAsync((NemsSubscription?)null);
         _mesh
             .Setup(m => m.SendSubscriptionRequest(It.IsAny<long>(), It.IsAny<string>(), It.IsAny<string>()))
             .ReturnsAsync((string?)null);


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

<!-- Describe your changes in detail. -->

added idempotent check to ManageCaasSubscription Subscribe endpoint

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
