### PR TITLE
fix: deploy wiremock container app into existing CAE

### DIFF
--- a/infrastructure/tf-core/environments/development.tfvars
+++ b/infrastructure/tf-core/environments/development.tfvars
@@ -56,13 +56,6 @@ regions = {
         service_delegation_name    = "Microsoft.App/environments"
         service_delegation_actions = ["Microsoft.Network/virtualNetworks/subnets/join/action"]
       }
-      container-app-default = {
-        cidr_newbits               = 7
-        cidr_offset                = 7
-        delegation_name            = "Microsoft.App/environments"
-        service_delegation_name    = "Microsoft.App/environments"
-        service_delegation_actions = ["Microsoft.Network/virtualNetworks/subnets/join/action"]
-      }
     }
   }
 }
@@ -244,9 +237,6 @@ container_app_environments = {
     db-management = {
       zone_redundancy_enabled = false
     }
-    default = {
-      zone_redundancy_enabled = false
-    }
   }
 }
 
@@ -266,7 +256,7 @@ container_app_jobs = {
 container_apps = {
   apps = {
     wiremock = {
-      container_app_environment_key = "default"
+      container_app_environment_key = "db-management"
       docker_image                  = "cohort-manager-wiremock"
       container_registry_use_mi     = true
       add_user_assigned_identity    = false


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

The current version of our CAE module does not support more than one CAE resource to be deployed.
There is a conflict due to `ManagedEnvironmentInfrastructureResourceGroupConflict` issue, as setting the value of `infrastructure_resource_group_name` with `"${var.resource_group_name}-cae-infra"`:

<img width="692" height="353" alt="image" src="https://github.com/user-attachments/assets/f819ca32-76ce-4852-b588-c7e8a33063b2" />

This results in the same value for `infrastructure_resource_group_name` across all CAE instances in the environment.

In the long run the module needs to be fixed, but in order to be able to deploy the Wiremock, it's going to be deployed into an existing CAE - `cae-dev-uks-cohman-db-management `.

The fix for the CAE module will contain a breaking change that will require a change across other projects, and will be planned out right after the Wiremock is up and running.

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [X] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [X] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [X] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
