### PR TITLE
fix: fix the sort order params

### DIFF
--- a/application/CohortManager/src/Web/app/api/GetValidationExceptions/route.ts
+++ b/application/CohortManager/src/Web/app/api/GetValidationExceptions/route.ts
@@ -4,13 +4,15 @@ import mockDataStore from "@/app/data/mockDataStore";
 function sortExceptions<
   T extends { DateCreated: string; ServiceNowCreatedDate?: string }
 >(items: T[], sortBy: string | null, dateField: keyof T = "DateCreated"): T[] {
-  if (sortBy === "1") {
+  if (sortBy === "0") {
+    // Ascending: oldest first
     return items.sort(
       (a, b) =>
         new Date(a[dateField] as string).getTime() -
         new Date(b[dateField] as string).getTime()
     );
-  } else if (sortBy === "0") {
+  } else if (sortBy === "1") {
+    // Descending: newest first
     return items.sort(
       (a, b) =>
         new Date(b[dateField] as string).getTime() -

--- a/application/CohortManager/src/Web/app/exceptions/[filter]/page.tsx
+++ b/application/CohortManager/src/Web/app/exceptions/[filter]/page.tsx
@@ -39,7 +39,7 @@ export default async function Page({
 
   const breadcrumbItems = [{ label: "Home", url: "/" }];
   const resolvedSearchParams = searchParams ? await searchParams : {};
-  const sortBy = resolvedSearchParams.sortBy === "1" ? 1 : 0;
+  const sortBy = resolvedSearchParams.sortBy === "0" ? 0 : 1;
   const currentPage = Math.max(
     1,
     parseInt(resolvedSearchParams.page || "1", 10)
@@ -47,11 +47,11 @@ export default async function Page({
 
   const sortOptions = [
     {
-      value: "0",
+      value: "1",
       label: "Status last updated (most recent first)",
     },
     {
-      value: "1",
+      value: "0",
       label: "Status last updated (oldest first)",
     },
   ];

--- a/application/CohortManager/src/Web/app/exceptions/page.tsx
+++ b/application/CohortManager/src/Web/app/exceptions/page.tsx
@@ -49,7 +49,7 @@ export default async function Page({
 
   const breadcrumbItems = [{ label: "Home", url: "/" }];
   const resolvedSearchParams = searchParams ? await searchParams : {};
-  const sortBy = resolvedSearchParams.sortBy === "1" ? 1 : 0;
+  const sortBy = resolvedSearchParams.sortBy === "0" ? 0 : 1;
   const currentPage = Math.max(
     1,
     parseInt(resolvedSearchParams.page || "1", 10)
@@ -57,11 +57,11 @@ export default async function Page({
 
   const sortOptions = [
     {
-      value: "0",
+      value: "1",
       label: "Date exception created (newest first)",
     },
     {
-      value: "1",
+      value: "0",
       label: "Date exception created (oldest first)",
     },
   ];

--- a/application/CohortManager/src/Web/tests/features/notRaisedExceptions.feature
+++ b/application/CohortManager/src/Web/tests/features/notRaisedExceptions.feature
@@ -11,7 +11,7 @@ Feature: Not raised exceptions page
   Scenario: Table shows 10 "Not raised" exceptions with expected columns
     Then the table "exceptions-table" has 10 rows
     And every row in the table "exceptions-table" has status "Not raised"
-    And the first row in the table "exceptions-table" has exception ID "2073"
+    And the first row in the table "exceptions-table" has exception ID "2028"
 
     Scenario: Sort the not raised exceptions table by "Date exception created (oldest first)"
       Given I should see the heading "Not raised breast screening exceptions"
@@ -23,7 +23,7 @@ Feature: Not raised exceptions page
       Given I should see the heading "Not raised breast screening exceptions"
       When I sort the table by "Date exception created (newest first)"
       Then the table "exceptions-table" has 10 rows
-      And the first row in the table "exceptions-table" has exception ID "2073"
+      And the first row in the table "exceptions-table" has exception ID "2028"
 
   Scenario: Breadcrumb back to homepage
     Then I see the link "Home"

--- a/application/CohortManager/src/Web/tests/features/raisedExceptions.feature
+++ b/application/CohortManager/src/Web/tests/features/raisedExceptions.feature
@@ -14,7 +14,7 @@ Feature: Raised exceptions page
       Then I see text containing "Showing 1 to 10" in the element "raised-exception-count"
       And the table "exceptions-table" has 10 rows
       And every row in the table "exceptions-table" has status "Raised"
-      And the first row in the table "exceptions-table" has exception ID "3001"
+      And the first row in the table "exceptions-table" has exception ID "4001"
 
     Scenario: Sort the raised exceptions table by "Status last updated (oldest first)"
       Given I should see the heading "Raised breast screening exceptions"
@@ -26,7 +26,7 @@ Feature: Raised exceptions page
       Given I should see the heading "Raised breast screening exceptions"
       When I sort the table by "Status last updated (most recent first)"
       Then the table "exceptions-table" has 10 rows
-      And the first row in the table "exceptions-table" has exception ID "3001"
+  And the first row in the table "exceptions-table" has exception ID "4001"
 
     Scenario: Check for breadcrumb navigation back to homepage
       When I go to the page "/exceptions"


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Fixes the sort order parameters by correcting the mapping between sort option values and their corresponding sort behaviors across the exception handling system.

- Swapped the sort option values so "0" represents oldest first (ascending) and "1" represents newest first (descending)
- Updated the sort logic in the API route to match the corrected value mappings
- Updated test expectations to reflect the new sort order behavior


## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [x] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
