### PR TITLE
fix: Removed NHS Number from log statement

### DIFF
--- a/application/CohortManager/src/Functions/ParticipantManagementServices/ManageServiceNowParticipant/ManageServiceNowParticipantFunction.cs
+++ b/application/CohortManager/src/Functions/ParticipantManagementServices/ManageServiceNowParticipant/ManageServiceNowParticipantFunction.cs
@@ -180,7 +180,7 @@ public class ManageServiceNowParticipantFunction
 
         if (isVhrParticipant)
         {
-            _logger.LogInformation("Participant with NHS Number: {NhsNumber} set as High Risk", serviceNowParticipant.NhsNumber);
+            _logger.LogInformation("Participant set as High Risk");
         }
 
         return await _participantManagementClient.Add(participantToAdd);

--- a/tests/UnitTests/ParticipantManagementServicesTests/ManageServiceNowParticipantTests/ManageServiceNowParticipantFunctionTests.cs
+++ b/tests/UnitTests/ParticipantManagementServicesTests/ManageServiceNowParticipantTests/ManageServiceNowParticipantFunctionTests.cs
@@ -537,7 +537,7 @@ public class ManageServiceNowParticipantFunctionTests
         _queueClientMock.VerifyNoOtherCalls();
 
         _loggerMock.VerifyLogger(LogLevel.Information, "Participant not in participant management table, adding new record");
-        _loggerMock.VerifyLogger(LogLevel.Information, $"Participant with NHS Number: {vhrParticipant.NhsNumber} set as High Risk");
+        _loggerMock.VerifyLogger(LogLevel.Information, $"Participant set as High Risk");
     }
 
     [TestMethod]


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Removed NHS Number from log statement

## Context

Shouldn't be logging NHS Numbers

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
