### PR TITLE
fix: always set record insert time to now

### DIFF
--- a/application/CohortManager/src/Functions/CohortDistributionServices/DistributeParticipant/DistributeParticipantActivities.cs
+++ b/application/CohortManager/src/Functions/CohortDistributionServices/DistributeParticipant/DistributeParticipantActivities.cs
@@ -113,11 +113,7 @@ public class DistributeParticipantActivities
         transformedParticipant.Extracted = Convert.ToInt32(_config.IsExtractedToBSSelect).ToString();
         var newRecord = transformedParticipant.ToCohortDistribution();
 
-        if (newRecord.RecordInsertDateTime is null)
-        {
-            newRecord.RecordInsertDateTime = DateTime.UtcNow;
-        }
-        newRecord.RecordUpdateDateTime = DateTime.UtcNow;
+        newRecord.RecordUpdateDateTime = newRecord.RecordInsertDateTime = DateTime.UtcNow;
         var isAdded = await _cohortDistributionClient.Add(newRecord);
 
         _logger.LogInformation("sent participant to cohort distribution data service");

--- a/application/CohortManager/src/Functions/CohortDistributionServices/DistributeParticipant/ValidateParticipant.cs
+++ b/application/CohortManager/src/Functions/CohortDistributionServices/DistributeParticipant/ValidateParticipant.cs
@@ -96,7 +96,6 @@ public class ValidateParticipant
             // Transformation
             _logger.LogInformation("Transforming participant");
             var transformedParticipant = await context.CallActivityAsync<CohortDistributionParticipant?>(nameof(TransformParticipant), validationRecord);
-            transformedParticipant.RecordInsertDateTime = previousRecord.RecordInsertDateTime;
 
             return transformedParticipant;
         }


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

<!-- Describe your changes in detail. -->

## Context
[DTOSS-11011](https://nhsd-jira.digital.nhs.uk/browse/DTOSS-11011)
previously the insert time was set to when the first record was inserted for a participant but it needs to be set on a per record basis

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
