### PR TITLE
fix: Fixes for handling PDS INVALIDATED_RESOURCE code and S flagged patients

### DIFF
--- a/application/CohortManager/src/Functions/DemographicServices/RetrievePDSDemographic/IPdsProcessor.cs
+++ b/application/CohortManager/src/Functions/DemographicServices/RetrievePDSDemographic/IPdsProcessor.cs
@@ -6,6 +6,5 @@ using Model;
 public interface IPdsProcessor
 {
     Task ProcessPdsNotFoundResponse(HttpResponseMessage pdsResponse, string nhsNumber, string? sourceFileName = null);
-    Task ProcessRecord(Participant participant, string? fileName = null);
     Task<bool> UpsertDemographicRecordFromPDS(ParticipantDemographic participantDemographic);
 }

--- a/application/CohortManager/src/Functions/DemographicServices/RetrievePDSDemographic/PdsProcessor.cs
+++ b/application/CohortManager/src/Functions/DemographicServices/RetrievePDSDemographic/PdsProcessor.cs
@@ -65,8 +65,6 @@ public class PdsProcessor : IPdsProcessor
         participant.RecordType = Actions.Removed;
 
         await ProcessRecord(participant, sourceFileName);
-
-        return;
     }
 
     /// <summary>

--- a/application/CohortManager/src/Functions/DemographicServices/RetrievePDSDemographic/PdsProcessor.cs
+++ b/application/CohortManager/src/Functions/DemographicServices/RetrievePDSDemographic/PdsProcessor.cs
@@ -54,7 +54,6 @@ public class PdsProcessor : IPdsProcessor
 
         _logger.LogInformation("NotFound response contains INVALIDATED_RESOURCE code");
 
-        // Reason for removal for date should be today and the reason for removal ORR
         var pdsDemographic = new PdsDemographic()
         {
             NhsNumber = nhsNumber,


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

- When NotFound response contains an INVALIDATED_RESOURCE code, a message to remove the participant is only sent if the request is part of a NEMS update.
- Removed call to ProcessPdsNotFoundResponse for participants with ConfidentialityCode == "R"

## Context

[DTOSS-10995](https://nhsd-jira.digital.nhs.uk/browse/DTOSS-10995)

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [x] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
