### PR TITLE
fix: now still sends update record to durable function even if record does not currently exist in demographic table

### DIFF
--- a/application/CohortManager/src/Functions/CaasIntegration/receiveCaasFile/ProcessFileClasses/ProcessCaasFile.cs
+++ b/application/CohortManager/src/Functions/CaasIntegration/receiveCaasFile/ProcessFileClasses/ProcessCaasFile.cs
@@ -133,7 +133,8 @@ public class ProcessCaasFile : IProcessCaasFile
             case Actions.Amended:
                 if (!await UpdateOldDemographicRecord(basicParticipantCsvRecord, fileName))
                 {
-                    await CreateError(participant, fileName, "old record did not exist or there was a problem when getting the old record form the database");
+                    currentBatch.DemographicData.Enqueue(participant.ToParticipantDemographic());
+                    currentBatch.UpdateRecords.Enqueue(basicParticipantCsvRecord);
                     break;
                 }
                 currentBatch.UpdateRecords.Enqueue(basicParticipantCsvRecord);
@@ -192,7 +193,7 @@ public class ProcessCaasFile : IProcessCaasFile
             }
 
             _logger.LogError("updating old Demographic record was not successful");
-            return updated;
+            throw new InvalidOperationException("updating old Demographic record was not successful");
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
… does not exist in database

<!-- markdownlint-disable-next-line first-line-heading -->
## Description



## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
