### PR TITLE
fix: [DTOSS-11025] add retries to grype installation to avoid errors when running in parallel

### DIFF
--- a/.github/workflows/stage-3-build-images.yaml
+++ b/.github/workflows/stage-3-build-images.yaml
@@ -181,7 +181,21 @@ jobs:
           echo "VULNERABILITIES_REPOSITORY_REPORT=$VULNERABILITIES_REPOSITORY_REPORT" >> $GITHUB_ENV
           bash -x ${GITHUB_WORKSPACE}/templates/scripts/reports/scan-vulnerabilities.sh
 
-          curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sudo sh -s -- -b /usr/local/bin
+          run: |
+            retries=5
+            delay=10
+            count=0
+            until [ $count -ge $retries ]
+            do
+              curl -sSfL https://get.anchore.io/grype | sudo sh -s -- -b /usr/local/bin && break
+              count=$((count+1))
+              echo "Retry $count/$retries exited with failure, retrying in $delay seconds..."
+              sleep $delay
+            done
+            if [ $count -eq $retries ]; then
+              echo "Failed to install grype after $retries attempts."
+              exit 1
+            fi
 
           SCAN_RESULTS=$(grype "${PROJECT_NAME}-${function}:latest" --scope all-layers)
           # ANSI color codes


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Currently the image building process fails with an error while trying to download grype with the GitHub matrix running in parallel (a single thread work fine).
To avoid this, we're adding a loop with 5 retries, and a 10 second cooldown period. 
At the same time, we're updating the grype instalation method to the one that's official based on the [grype's repository](https://github.com/anchore/grype) docummentation.

Old method:

`curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sudo sh -s -- -b /usr/local/bin`

New method:
```
run: |
  retries=5
  delay=10
  count=0
  until [ $count -ge $retries ]
  do
    curl -sSfL https://get.anchore.io/grype | sudo sh -s -- -b /usr/local/bin && break
    count=$((count+1))
    echo "Retry $count/$retries exited with failure, retrying in $delay seconds..."
    sleep $delay
  done
  if [ $count -eq $retries ]; then
    echo "Failed to install grype after $retries attempts."
    exit 1
  fi
```

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [X] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [X] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
