### PR TITLE
fix: unbound CaaS send workflow config

### DIFF
--- a/application/CohortManager/src/Functions/DemographicServices/ManageCaasSubscription/Program.cs
+++ b/application/CohortManager/src/Functions/DemographicServices/ManageCaasSubscription/Program.cs
@@ -10,6 +10,7 @@ using DataServices.Core;
 var hostBuilder = new HostBuilder()
     .ConfigureFunctionsWebApplication()
     .AddConfiguration<ManageCaasSubscriptionConfig>(out ManageCaasSubscriptionConfig? config)
+    .AddConfiguration<MeshSendCaasSubscribeConfig>()
     .AddMeshMailboxes(new MeshConfig
     {
         MeshApiBaseUrl = config!.CaasSubscriptionMeshApiBaseUrl,


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Fixes a bug where the config for sending subscription requests to Caas wasnt bound. 
Causing items to be sent without a mesh workflow ID

## Context

Workflow ID was not binding.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
