### PR TITLE
feat: change parquet schema for caas subscribe

### DIFF
--- a/application/CohortManager/src/Functions/Shared/Common/Mesh/MeshSendCaasSubscribe.cs
+++ b/application/CohortManager/src/Functions/Shared/Common/Mesh/MeshSendCaasSubscribe.cs
@@ -59,16 +59,16 @@ public class MeshSendCaasSubscribe : IMeshSendCaasSubscribe
     {
         var columns = new Column[]
         {
-            new Column<long>("nhs_number"),
+            new Column<string>("nhs_number"),
         };
-        long[] nhsNumberList = { nhsNumber };
+        string[] nhsNumberList = { nhsNumber.ToString() };
 
         using var stream = new MemoryStream();
         using var writer = new ManagedOutputStream(stream);
         using (var file = new ParquetFileWriter(writer, columns))
         {
             using var rowGroup = file.AppendRowGroup();
-            using (var nhsNumberColumn = rowGroup.NextColumn().LogicalWriter<long>())
+            using (var nhsNumberColumn = rowGroup.NextColumn().LogicalWriter<string>())
             {
                 nhsNumberColumn.WriteBatch(nhsNumberList);
             }

--- a/tests/integration-tests/MeshCaaSSubscribeIntegrationTests/ParquetAsserts.cs
+++ b/tests/integration-tests/MeshCaaSSubscribeIntegrationTests/ParquetAsserts.cs
@@ -6,7 +6,7 @@ using ParquetSharp;
 using ParquetSharp.IO;
 public static class ParquetAsserts
 {
-    public static void ContainsExpectedNhsNumber(byte[] parquetBytes, long expectedNhsNumber)
+    public static void ContainsExpectedNhsNumber(byte[] parquetBytes, string expectedNhsNumber)
     {
         using var stream = new MemoryStream(parquetBytes);
         using var reader = new ManagedRandomAccessFile(stream);
@@ -20,7 +20,7 @@ public static class ParquetAsserts
         var columnCount = rowGroup.MetaData.NumColumns;
         Assert.AreEqual(1, columnCount, "Expected exactly 1 column.");
 
-        using var columnReader = rowGroup.Column(0).LogicalReader<long>();
+        using var columnReader = rowGroup.Column(0).LogicalReader<string>();
         var values = columnReader.ReadAll(checked((int)rowGroup.MetaData.NumRows));
 
         Assert.AreEqual(1, values.Length, "Expected exactly 1 row.");

--- a/tests/integration-tests/MeshCaaSSubscribeIntegrationTests/SendCaasSubscribeTests.cs
+++ b/tests/integration-tests/MeshCaaSSubscribeIntegrationTests/SendCaasSubscribeTests.cs
@@ -76,7 +76,7 @@ public sealed class SendCaasSubscribeTests
         // assert
         Assert.IsNotNull(messageId);
 
-        // act - validate message recieved
+        // act - validate message received
         var getMessagesResult = await _meshInboxService.GetMessagesAsync(toMailbox);
 
         // assert - File is in mesh
@@ -86,7 +86,7 @@ public sealed class SendCaasSubscribeTests
         var message = await _meshInboxService.GetMessageByIdAsync(toMailbox, messageId);
 
         // asset - ensure message contains expected parquet file
-        ParquetAsserts.ContainsExpectedNhsNumber(message.Response.FileAttachment.Content, nhsNumber);
+        ParquetAsserts.ContainsExpectedNhsNumber(message.Response.FileAttachment.Content, nhsNumber.ToString());
 
     }
 }


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

<!-- Describe your changes in detail. -->

CaaS team requested that we send the NHS number in the CaaS Subscribe file to string not long

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [x] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
