### PR TITLE
feat: caas multiple subscribe requests

### DIFF
--- a/application/CohortManager/src/Functions/DemographicServices/ManageCaasSubscription/ManageCaasSubscription.cs
+++ b/application/CohortManager/src/Functions/DemographicServices/ManageCaasSubscription/ManageCaasSubscription.cs
@@ -184,8 +184,6 @@ public class ManageCaasSubscription
             nhsNumberLongSet.RemoveWhere(existingNhsNumbers.Contains);
             failedNhsNumbers.UnionWith(removedNhsNumbers.Select(x => x.ToString()));
 
-
-
             var toMailbox = _config.CaasToMailbox!;
             var fromMailbox = _config.CaasFromMailbox!;
             var messageId = await _meshSendCaasSubscribe.SendSubscriptionRequest(nhsNumberLongSet.ToArray(), toMailbox, fromMailbox);

--- a/application/CohortManager/src/Functions/Shared/Common/Mesh/IMeshSendCaasSubscribe.cs
+++ b/application/CohortManager/src/Functions/Shared/Common/Mesh/IMeshSendCaasSubscribe.cs
@@ -13,4 +13,12 @@ public interface IMeshSendCaasSubscribe
     /// <param name="fromMailbox">Source MESH mailbox ID.</param>
     /// <returns>The MESH message ID on success; otherwise null.</returns>
     Task<string?> SendSubscriptionRequest(long nhsNumber, string toMailbox, string fromMailbox);
+    /// <summary>
+    /// Sends a CAAS subscription request for the given list of NHS numbers.
+    /// </summary>
+    /// <param name="nhsNumber">list of NHS numbers to be sent.</param>
+    /// <param name="toMailbox">Destination MESH mailbox ID.</param>
+    /// <param name="fromMailbox">Source MESH mailbox ID.</param>
+    /// <returns>The MESH message ID on success; otherwise null.</returns>
+    Task<string?> SendSubscriptionRequest(long[] nhsNumbers, string toMailbox, string fromMailbox);
 }

--- a/application/CohortManager/src/Functions/Shared/Common/Mesh/MeshSendCaasSubscribe.cs
+++ b/application/CohortManager/src/Functions/Shared/Common/Mesh/MeshSendCaasSubscribe.cs
@@ -91,7 +91,7 @@ public class MeshSendCaasSubscribe : IMeshSendCaasSubscribe
             using var rowGroup = file.AppendRowGroup();
             using (var nhsNumberColumn = rowGroup.NextColumn().LogicalWriter<string>())
             {
-                nhsNumberColumn.WriteBatch(nhsNumber);
+                nhsNumberColumn.WriteBatch(nhsNumberList);
             }
         }
 

--- a/application/CohortManager/src/Functions/Shared/Common/Mesh/MeshSendCaasSubscribe.cs
+++ b/application/CohortManager/src/Functions/Shared/Common/Mesh/MeshSendCaasSubscribe.cs
@@ -1,8 +1,10 @@
 namespace Common;
 
 using System.Threading.Tasks;
+using Azure.Messaging.EventGrid.SystemEvents;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Microsoft.Identity.Client;
 using NHS.MESH.Client.Contracts.Services;
 using NHS.MESH.Client.Models;
 using ParquetSharp;
@@ -34,7 +36,18 @@ public class MeshSendCaasSubscribe : IMeshSendCaasSubscribe
     {
 
         var content = CreateParquetFile(nhsNumber);
+        return await SendMeshMessage(content, fromMailbox, toMailbox);
+    }
 
+    public async Task<string?> SendSubscriptionRequest(long[] nhsNumbers, string toMailbox, string fromMailbox)
+    {
+
+        var content = CreateParquetFile(nhsNumbers);
+        return await SendMeshMessage(content, fromMailbox, toMailbox);
+    }
+
+    private async Task<string?> SendMeshMessage(byte[] content, string fromMailbox, string toMailbox)
+    {
         FileAttachment file = new FileAttachment
         {
             FileName = "CaaSSubscribe.parquet",
@@ -57,12 +70,18 @@ public class MeshSendCaasSubscribe : IMeshSendCaasSubscribe
 
     private static byte[] CreateParquetFile(long nhsNumber)
     {
+
+        long[] nhsNumberList = { nhsNumber };
+
+        return CreateParquetFile(nhsNumberList);
+    }
+
+    private static byte[] CreateParquetFile(long[] nhsNumber)
+    {
         var columns = new Column[]
         {
             new Column<long>("nhs_number"),
         };
-        long[] nhsNumberList = { nhsNumber };
-
         using var stream = new MemoryStream();
         using var writer = new ManagedOutputStream(stream);
         using (var file = new ParquetFileWriter(writer, columns))
@@ -70,11 +89,10 @@ public class MeshSendCaasSubscribe : IMeshSendCaasSubscribe
             using var rowGroup = file.AppendRowGroup();
             using (var nhsNumberColumn = rowGroup.NextColumn().LogicalWriter<long>())
             {
-                nhsNumberColumn.WriteBatch(nhsNumberList);
+                nhsNumberColumn.WriteBatch(nhsNumber);
             }
         }
 
         return stream.ToArray();
-
     }
 }

--- a/application/CohortManager/src/Functions/Shared/Common/Mesh/MeshSendCaasSubscribeStub.cs
+++ b/application/CohortManager/src/Functions/Shared/Common/Mesh/MeshSendCaasSubscribeStub.cs
@@ -9,4 +9,10 @@ public class MeshSendCaasSubscribeStub : IMeshSendCaasSubscribe
         await Task.CompletedTask;
         return $"STUB_{Guid.NewGuid():N}";
     }
+
+    public async Task<string?> SendSubscriptionRequest(long[] nhsNumbers, string toMailbox, string fromMailbox)
+    {
+        await Task.CompletedTask;
+        return $"STUB_{Guid.NewGuid():N}";
+    }
 }


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Adds another endpoint to create a subscription request to caas with multiple NHS NUmbers

## Context

easier cutover for creating mutliple subscriptions

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
