### PR TITLE
fix: participant management insert date

### DIFF
--- a/application/CohortManager/src/Functions/Shared/Model/Participant.cs
+++ b/application/CohortManager/src/Functions/Shared/Model/Participant.cs
@@ -198,8 +198,8 @@ public class Participant
             ExceptionFlag = MappingUtilities.ParseStringFlag(ExceptionFlag ?? "0"),
             BlockedFlag = MappingUtilities.ParseStringFlag(BlockedFlag ?? "0"),
             ReferralFlag = existingRecord.ReferralFlag,
-            RecordInsertDateTime = MappingUtilities.ParseDates(RecordInsertDateTime),
-            RecordUpdateDateTime = existingRecord.RecordInsertDateTime,
+            RecordInsertDateTime = existingRecord.RecordInsertDateTime,
+            RecordUpdateDateTime = existingRecord.RecordUpdateDateTime,
             IsHigherRisk = existingRecord.IsHigherRisk
         };
 


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description
fixes insert time to be set to the previous record's insert time instead of the new record's (null) insert time

<!-- Describe your changes in detail. -->

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
