### PR TITLE
fix: use the correct portal form title for rule 66

### DIFF
--- a/application/CohortManager/src/Web/app/components/participantInformationPanel.tsx
+++ b/application/CohortManager/src/Web/app/components/participantInformationPanel.tsx
@@ -172,10 +172,10 @@ export default function ParticipantInformationPanel({
             <div className="nhsuk-summary-list__row">
               <dt className="nhsuk-summary-list__key">More detail</dt>
               <dd className="nhsuk-summary-list__value">
-                <p>
-                  {exceptionDetails.moreDetails ||
-                    exceptionDetails.shortDescription}
-                </p>
+                <p>{exceptionDetails.shortDescription}</p>
+                {exceptionDetails.moreDetails && (
+                  <p>{exceptionDetails.moreDetails}</p>
+                )}
                 {exceptionDetails.reportingId && (
                   <p>
                     Cohort Manager rule (to be included for reporting):{" "}

--- a/application/CohortManager/src/Web/app/lib/ruleMapping.ts
+++ b/application/CohortManager/src/Web/app/lib/ruleMapping.ts
@@ -102,6 +102,7 @@ export const ruleIdMappings: Record<number, RuleMapping> = {
     moreDetails:
       "To update a record with a formal death status, ensure that the reason for removal field contains a compatible death-related value.",
     reportingId: "CMR20",
+    portalFormTitle: "Formal death",
   },
   69: {
     ruleDescription: "NHS number’s invalid flag is set to true.",


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

https://nhsd-jira.digital.nhs.uk/browse/DTOSS-11097

<img width="1720" height="1634" alt="screencapture-localhost-3000-exceptions-2025-10-02-14_59_49" src="https://github.com/user-attachments/assets/6341d440-ab9a-400e-b9a6-2dc622fa5fdb" />

<img width="1720" height="2024" alt="screencapture-localhost-3000-participant-information-2027-2025-10-02-15_00_35" src="https://github.com/user-attachments/assets/5f4244a8-e09c-4774-8524-8d687b75096a" />

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
