### PR TITLE
feat: DTOSS-12464 & DTOSS-12468 dummy gp rules

### DIFF
--- a/application/CohortManager/src/Functions/CohortDistributionServices/DistributeParticipant/DistributeParticipant.cs
+++ b/application/CohortManager/src/Functions/CohortDistributionServices/DistributeParticipant/DistributeParticipant.cs
@@ -69,6 +69,13 @@ public class DistributeParticipant
     public async Task DistributeParticipantOrchestrator([OrchestrationTrigger] TaskOrchestrationContext context)
     {
         var participantRecord = context.GetInput<BasicParticipantCsvRecord>();
+
+        if (participantRecord is null)
+        {
+            _logger.LogError("Orchestration was started with null input");
+            return;
+        }
+
         try
         {
             // Retrieve participant data
@@ -87,16 +94,17 @@ public class DistributeParticipant
                 return;
             }
 
-            ValidationRecord validationRecord = new() { FileName = participantRecord.FileName, Participant = participantData };
+            ValidationRecord validationRecord = new() { FileName = participantRecord.FileName, Participant = participantData, ReasonForAdding = participantRecord.ReasonForAdding };
 
             var serviceNowParticipant = participantRecord?.Participant.ReferralFlag == "1";
+
             if (serviceNowParticipant && !string.IsNullOrEmpty(participantRecord?.Participant.PrimaryCareProvider))
             {
                 validationRecord.Participant.PrimaryCareProvider = participantRecord.Participant.PrimaryCareProvider;
             }
 
             // Allocate service provider
-            validationRecord.ServiceProvider = await context.CallActivityAsync<string>(nameof(Activities.AllocateServiceProvider), participantRecord.Participant);
+            validationRecord.ServiceProvider = await context.CallActivityAsync<string>(nameof(Activities.AllocateServiceProvider), validationRecord.Participant);
 
             // Validation & Transformation
             var transformedParticipant = await context.CallSubOrchestratorAsync<CohortDistributionParticipant?>(nameof(ValidateParticipant.ValidationOrchestrator), validationRecord);

--- a/application/CohortManager/src/Functions/CohortDistributionServices/DistributeParticipant/ValidateParticipant.cs
+++ b/application/CohortManager/src/Functions/CohortDistributionServices/DistributeParticipant/ValidateParticipant.cs
@@ -221,7 +221,8 @@ public class ValidateParticipant
             FileName = validationRecord.FileName,
             // TODO: is this used?
             ServiceProvider = validationRecord.ServiceProvider,
-            ExistingParticipant = validationRecord.PreviousParticipantRecord.ToCohortDistribution()
+            ExistingParticipant = validationRecord.PreviousParticipantRecord.ToCohortDistribution(),
+            ReasonForAdding = validationRecord.ReasonForAdding
         };
 
         var json = JsonSerializer.Serialize(transformDataRequestBody);

--- a/application/CohortManager/src/Functions/CohortDistributionServices/DistributeParticipant/ValidateParticipant.cs
+++ b/application/CohortManager/src/Functions/CohortDistributionServices/DistributeParticipant/ValidateParticipant.cs
@@ -154,7 +154,8 @@ public class ValidateParticipant
         var request = new ParticipantCsvRecord
         {
             Participant = new Participant(validationRecord.Participant),
-            FileName = validationRecord.FileName
+            FileName = validationRecord.FileName,
+            ReasonForAdding = validationRecord.ReasonForAdding
         };
 
         var json = JsonSerializer.Serialize(request);
@@ -185,7 +186,9 @@ public class ValidateParticipant
         {
             NewParticipant = new Participant(validationRecord.Participant),
             ExistingParticipant = new Participant(validationRecord.PreviousParticipantRecord),
-            FileName = validationRecord.FileName
+            FileName = validationRecord.FileName,
+            ReasonForAdding = validationRecord.ReasonForAdding
+
         };
 
         var json = JsonSerializer.Serialize(request);

--- a/application/CohortManager/src/Functions/CohortDistributionServices/DistributeParticipant/ValidationRecord.cs
+++ b/application/CohortManager/src/Functions/CohortDistributionServices/DistributeParticipant/ValidationRecord.cs
@@ -1,6 +1,7 @@
 namespace NHS.CohortManager.CohortDistributionServices;
 
 using Model;
+using Model.Enums;
 
 public class ValidationRecord
 {
@@ -8,4 +9,5 @@ public class ValidationRecord
     public required CohortDistributionParticipant Participant { get; set; }
     public CohortDistributionParticipant? PreviousParticipantRecord { get; set; }
     public string ServiceProvider { get; set; }
+    public ReasonForAdding? ReasonForAdding { get; set; } = null;
 }

--- a/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/ITransformDataLookupFacade.cs
+++ b/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/ITransformDataLookupFacade.cs
@@ -10,4 +10,5 @@ public interface ITransformDataLookupFacade
     public bool ValidateLanguageCode(string languageCode);
     public Task<HashSet<string>> GetCachedExcludedSMUValues();
     string RetrievePostingCategory(string currentPosting);
+    bool CheckIfPrimaryCareProviderExists(string primaryCareProvider);
 }

--- a/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/TransformDataLookupFacade.cs
+++ b/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/TransformDataLookupFacade.cs
@@ -126,4 +126,18 @@ public class TransformDataLookupFacade : ITransformDataLookupFacade
         var result = _currentPostingClient.GetSingle(currentPosting).Result;
         return result.PostingCategory;
     }
+
+
+    /// <summary>
+    /// Used in rule 36 in the lookup rules, and rule 54 in the cohort rules.
+    /// Validates the participants primary care provider (GP practice code)
+    /// </summary>
+    /// <param name="primaryCareProvider">The participant's primary care provider.</param>
+    /// <returns>bool, whether or not the GP practice code exists in the DB.<returns>
+    public bool CheckIfPrimaryCareProviderExists(string primaryCareProvider)
+    {
+        _logger.LogInformation("Checking Primary Care Provider {PrimaryCareProvider} Exists", primaryCareProvider);
+        var result = _bsSelectGPPracticeClient.GetSingle(primaryCareProvider).Result;
+        return result != null;
+    }
 }

--- a/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/TransformDataLookupFacade.cs
+++ b/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/TransformDataLookupFacade.cs
@@ -133,7 +133,7 @@ public class TransformDataLookupFacade : ITransformDataLookupFacade
     /// Validates the participants primary care provider (GP practice code)
     /// </summary>
     /// <param name="primaryCareProvider">The participant's primary care provider.</param>
-    /// <returns>bool, whether or not the GP practice code exists in the DB.<returns>
+    /// <returns>bool, whether or not the GP practice code exists in the DB.</returns>
     public bool CheckIfPrimaryCareProviderExists(string primaryCareProvider)
     {
         _logger.LogInformation("Checking Primary Care Provider {PrimaryCareProvider} Exists", primaryCareProvider);

--- a/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/TransformDataService.cs
+++ b/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/TransformDataService.cs
@@ -79,7 +79,7 @@ public class TransformDataService
             participant = await transformString.TransformStringFields(participant);
 
             // Other transformation rules
-            participant = await TransformParticipantAsync(participant, requestBody.ExistingParticipant, ValidationHelper.CheckManualAddFileName(requestBody.FileName));
+            participant = await TransformParticipantAsync(participant, requestBody.ExistingParticipant, requestBody.ReasonForAdding);
 
             // Name prefix transformation
             if (participant.NamePrefix != null)
@@ -117,7 +117,7 @@ public class TransformDataService
     }
 
     public async Task<CohortDistributionParticipant> TransformParticipantAsync(CohortDistributionParticipant participant,
-                                                                            CohortDistribution databaseParticipant, bool isManualAdd = false)
+                                                                            CohortDistribution databaseParticipant, ReasonForAdding? reasonForAdding = null)
     {
         var excludedSMUList = await _dataLookup.GetCachedExcludedSMUValues();
 
@@ -127,7 +127,7 @@ public class TransformDataService
         var reSettings = new ReSettings
         {
             CustomActions = actions,
-            CustomTypes = [typeof(Actions), typeof(CohortDistributionParticipant), typeof(CohortDistribution)],
+            CustomTypes = [typeof(Actions), typeof(CohortDistributionParticipant), typeof(CohortDistribution), typeof(ReasonForAdding)],
             UseFastExpressionCompiler = false
         };
 
@@ -144,9 +144,14 @@ public class TransformDataService
 
         var resultList = await re.ExecuteAllRulesAsync("Common", ruleParameters);
 
-        if (isManualAdd)
+        if (reasonForAdding.HasValue && reasonForAdding != ReasonForAdding.DummyGpCodeRemoval)
         {
             resultList.AddRange(await re.ExecuteAllRulesAsync("ManualAdd", ruleParameters));
+        }
+        
+        if (reasonForAdding.HasValue && reasonForAdding == ReasonForAdding.DummyGpCodeRemoval)
+        {
+            resultList.AddRange(await re.ExecuteAllRulesAsync("DummyGpRemoval", ruleParameters));
         }
 
         await HandleExceptions(resultList, participant);

--- a/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/TransformDataService.cs
+++ b/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/TransformDataService.cs
@@ -148,7 +148,7 @@ public class TransformDataService
         {
             resultList.AddRange(await re.ExecuteAllRulesAsync("ManualAdd", ruleParameters));
         }
-        
+
         if (reasonForAdding.HasValue && reasonForAdding == ReasonForAdding.DummyGpCodeRemoval)
         {
             resultList.AddRange(await re.ExecuteAllRulesAsync("DummyGpRemoval", ruleParameters));

--- a/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/transformRules.json
+++ b/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/transformRules.json
@@ -796,5 +796,35 @@
         }
       }
     ]
+  },
+  {
+    "WorkflowName": "DummyGpRemoval",
+    "Rules": [
+        {
+        "RuleName": "71.DummyGpCodeRemoval",
+        "Expression": "new string[] { \"RDR\", \"RDI\", \"RPR\" }.Contains(participant.ReasonForRemoval)",
+        "Actions": {
+          "OnSuccess": {
+            "Name": "TransformAction",
+            "Context": {
+              "transformFields": [
+                {
+                  "field": "ReasonForRemoval",
+                  "value": "ORR",
+                  "isExpression": false
+                },
+                {
+                  "field": "ReasonForRemovalEffectiveFromDate",
+                  "value": "DateTime.UtcNow.Date.ToString(\"yyyyMMdd\")",
+                  "isExpression": true
+                }
+              ]
+            }
+          }
+        }
+      }
+
+    ]
   }
+
 ]

--- a/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/transformRules.json
+++ b/application/CohortManager/src/Functions/CohortDistributionServices/TransformDataService/transformRules.json
@@ -800,7 +800,7 @@
   {
     "WorkflowName": "DummyGpRemoval",
     "Rules": [
-        {
+      {
         "RuleName": "71.DummyGpCodeRemoval",
         "Expression": "new string[] { \"RDR\", \"RDI\", \"RPR\" }.Contains(participant.ReasonForRemoval)",
         "Actions": {
@@ -822,9 +822,40 @@
             }
           }
         }
+      },
+      {
+        "RuleName": "72.RemoveWelshGPCodeForDummyGpRemoval",
+        "LocalParams": [
+          {
+            "Name": "ValidPrimaryCareProvider",
+            "Expression": "string.IsNullOrEmpty(participant.PrimaryCareProvider) || dbLookup.CheckIfPrimaryCareProviderExists(participant.PrimaryCareProvider)"
+          },
+          {
+            "Name" : "WelshGPCode",
+            "Expression": "string.IsNullOrEmpty(participant.PrimaryCareProvider) ? false : participant.PrimaryCareProvider.StartsWith(\"W\")"
+          }
+        ],
+        "Expression": "!ValidPrimaryCareProvider && WelshGPCode",
+        "Actions": {
+          "OnSuccess": {
+            "Name": "TransformAction",
+            "Context": {
+              "transformFields": [
+                {
+                  "field": "ReasonForRemoval",
+                  "value": "ORR",
+                  "isExpression": false
+                },
+                {
+                  "field": "ReasonForRemovalEffectiveFromDate",
+                  "value": "DateTime.UtcNow.Date.ToString(\"yyyyMMdd\")",
+                  "isExpression": true
+                }
+              ]
+            }
+          }
+        }
       }
-
     ]
   }
-
 ]

--- a/application/CohortManager/src/Functions/ScreeningValidationService/LookupValidation/Breast_Screening_lookupRules.json
+++ b/application/CohortManager/src/Functions/ScreeningValidationService/LookupValidation/Breast_Screening_lookupRules.json
@@ -5,6 +5,10 @@
       {
         "Name": "ValidPrimaryCareProvider",
         "Expression": "string.IsNullOrEmpty(newParticipant.PrimaryCareProvider) || dbLookup.CheckIfPrimaryCareProviderExists(newParticipant.PrimaryCareProvider)"
+      },
+      {
+        "Name": "DummyGPCodeRemovalAdd",
+        "Expression": "(reasonForAdding == null ? false : reasonForAdding == ReasonForAdding.DummyGpCodeRemoval)"
       }
     ],
     "Rules": [
@@ -20,12 +24,24 @@
             "Expression": "dbLookup.CheckIfPrimaryCareProviderInExcludedSmuList(newParticipant.PrimaryCareProvider)"
           }
         ],
-        "Expression": "(WelshPostingCategory || ValidPrimaryCareProvider  || IsExcluded)",
+        "Expression": "(DummyGPCodeRemovalAdd || WelshPostingCategory || ValidPrimaryCareProvider  || IsExcluded)",
         "Actions": {
           "OnFailure": {
             "Name": "OutputExpression",
             "Context": {
               "Expression": "\"GP practice code does not exist\""
+            }
+          }
+        }
+      },
+      {
+        "RuleName": "70.DummyGpRemovalWithInvalidGP.BSS.NonFatal",
+        "Expression": "!DummyGPCodeRemovalAdd OR ValidPrimaryCareProvider OR (string.IsNullOrEmpty(newParticipant.PrimaryCareProvider) ? false : newParticipant.PrimaryCareProvider.StartsWith(\"W\"))",
+        "Actions":{
+          "OnFailure":{
+            "Name":"OutputExpression",
+            "Context":{
+              "Expression":"\"Reason for adding is Dummy GP code removal but primary care provider is not a valid GP code\""
             }
           }
         }

--- a/application/CohortManager/src/Functions/ScreeningValidationService/LookupValidation/LookupValidation.cs
+++ b/application/CohortManager/src/Functions/ScreeningValidationService/LookupValidation/LookupValidation.cs
@@ -69,7 +69,7 @@ public class LookupValidation
 
             var reSettings = new ReSettings
             {
-                CustomTypes = [typeof(Actions)],
+                CustomTypes = [typeof(Actions), typeof(ReasonForAdding)],
                 UseFastExpressionCompiler = false
             };
             var re = new RulesEngine.RulesEngine(rules, reSettings);
@@ -77,7 +77,8 @@ public class LookupValidation
             var ruleParameters = new[] {
                 new RuleParameter("existingParticipant", requestBody.ExistingParticipant),
                 new RuleParameter("newParticipant", newParticipant),
-                new RuleParameter("dbLookup", _dataLookup)
+                new RuleParameter("dbLookup", _dataLookup),
+                new RuleParameter("reasonForAdding", requestBody.ReasonForAdding)
             };
 
             var resultList = new List<RuleResultTree>();
@@ -92,12 +93,12 @@ public class LookupValidation
                 var ActionResults = await re.ExecuteAllRulesAsync(newParticipant.RecordType, ruleParameters);
                 resultList.AddRange(ActionResults);
             }
-            if (isManualAdd)
+            if (isManualAdd && requestBody.ReasonForAdding.HasValue && requestBody.ReasonForAdding != ReasonForAdding.DummyGpCodeRemoval)
             {
                 var ActionResults = await re.ExecuteAllRulesAsync("ManualAdd", ruleParameters);
                 resultList.AddRange(ActionResults);
             }
-
+            var res = requestBody.ReasonForAdding.HasValue && requestBody.ReasonForAdding == ReasonForAdding.DummyGpCodeRemoval;
             // Validation rules are logically reversed
             var validationErrors = resultList.Where(x => !x.IsSuccess).Select(x => new ValidationRuleResult(x));
 

--- a/application/CohortManager/src/Functions/ScreeningValidationService/LookupValidation/LookupValidation.cs
+++ b/application/CohortManager/src/Functions/ScreeningValidationService/LookupValidation/LookupValidation.cs
@@ -98,7 +98,6 @@ public class LookupValidation
                 var ActionResults = await re.ExecuteAllRulesAsync("ManualAdd", ruleParameters);
                 resultList.AddRange(ActionResults);
             }
-            var res = requestBody.ReasonForAdding.HasValue && requestBody.ReasonForAdding == ReasonForAdding.DummyGpCodeRemoval;
             // Validation rules are logically reversed
             var validationErrors = resultList.Where(x => !x.IsSuccess).Select(x => new ValidationRuleResult(x));
 

--- a/application/CohortManager/src/Functions/ScreeningValidationService/StaticValidation/Breast_Screening_staticRules.json
+++ b/application/CohortManager/src/Functions/ScreeningValidationService/StaticValidation/Breast_Screening_staticRules.json
@@ -91,7 +91,7 @@
           }
         }
       },
-            {
+      {
         "RuleName": "3.PrimaryCareProviderAndReasonForRemoval.NBO.NonFatal",
         "Expression": "manualAdd OR ((string.IsNullOrEmpty(participant.PrimaryCareProvider) AND !string.IsNullOrEmpty(participant.ReasonForRemoval)) OR (!string.IsNullOrEmpty(participant.PrimaryCareProvider) AND string.IsNullOrEmpty(participant.ReasonForRemoval)))",
         "Actions": {
@@ -180,7 +180,7 @@
     "Rules": [
       {
         "RuleName": "97.NoDummyGPorPCP.NBO.NonFatal",
-        "LocalParams" : [
+        "LocalParams": [
           {
             "Name": "ValidReasonForRemoval",
             "Expression": "participant.ReasonForRemoval == \"RDR\" || participant.ReasonForRemoval == \"RPR\" || participant.ReasonForRemoval == \"RDI\" "

--- a/application/CohortManager/src/Functions/ScreeningValidationService/StaticValidation/StaticValidation.cs
+++ b/application/CohortManager/src/Functions/ScreeningValidationService/StaticValidation/StaticValidation.cs
@@ -60,7 +60,7 @@ public class StaticValidation
 
             var reSettings = new ReSettings
             {
-                CustomTypes = [typeof(Regex), typeof(RegexOptions), typeof(ValidationHelper), typeof(Status), typeof(Actions)],
+                CustomTypes = [typeof(Regex), typeof(RegexOptions), typeof(ValidationHelper), typeof(Status), typeof(Actions), typeof(ReasonForAdding)],
                 UseFastExpressionCompiler = false
             };
 
@@ -69,7 +69,8 @@ public class StaticValidation
             var ruleParameters = new[] {
                 new RuleParameter("participant", participantCsvRecord.Participant),
                 new RuleParameter("reasonForRemovalLkp", _reasonForRemovalLookup),
-                new RuleParameter("manualAdd",isManualAdd)
+                new RuleParameter("manualAdd",isManualAdd),
+                new RuleParameter("reasonForAdding", participantCsvRecord.ReasonForAdding)
             };
 
             var resultList = new List<RuleResultTree>();
@@ -84,7 +85,7 @@ public class StaticValidation
                 }
             }
 
-            if (isManualAdd)
+            if (isManualAdd && participantCsvRecord.ReasonForAdding != ReasonForAdding.DummyGpCodeRemoval)
             {
                 var manualAddResults = await re.ExecuteAllRulesAsync("Manual_Add", ruleParameters);
                 resultList.AddRange(manualAddResults);

--- a/application/CohortManager/src/Functions/Shared/Common/LookupValidationRequestBody.cs
+++ b/application/CohortManager/src/Functions/Shared/Common/LookupValidationRequestBody.cs
@@ -8,6 +8,7 @@ public class LookupValidationRequestBody
     public Participant ExistingParticipant { get; set; }
     public Participant NewParticipant { get; set; }
     public string FileName { get; set; }
+    public ReasonForAdding? ReasonForAdding { get; set; } = null;
 
     public LookupValidationRequestBody() { }
 

--- a/application/CohortManager/src/Functions/Shared/Common/TransformDataRequestBody.cs
+++ b/application/CohortManager/src/Functions/Shared/Common/TransformDataRequestBody.cs
@@ -1,6 +1,7 @@
 namespace Common;
 
 using Model;
+using Model.Enums;
 
 public class TransformDataRequestBody
 {
@@ -8,4 +9,5 @@ public class TransformDataRequestBody
     public CohortDistribution ExistingParticipant { get; set; }
     public string? ServiceProvider { get; set; }
     public string? FileName {get;set;}
+    public ReasonForAdding? ReasonForAdding { get; set; } = null;
 }

--- a/application/CohortManager/src/Functions/Shared/Model/ParticipantCsvRecord.cs
+++ b/application/CohortManager/src/Functions/Shared/Model/ParticipantCsvRecord.cs
@@ -1,7 +1,10 @@
 namespace Model;
 
+using Model.Enums;
+
 public class ParticipantCsvRecord
 {
     public string FileName { get; set; }
     public Participant Participant { get; set; }
+    public ReasonForAdding? ReasonForAdding { get; set; } = null;
 }

--- a/tests/UnitTests/ScreeningValidationServiceTests/LookupValidation/LookupValidationTests.cs
+++ b/tests/UnitTests/ScreeningValidationServiceTests/LookupValidation/LookupValidationTests.cs
@@ -14,6 +14,7 @@ using Moq;
 using NHS.CohortManager.ScreeningValidationService;
 using Microsoft.Extensions.Logging.Abstractions;
 using NHS.CohortManager.Tests.TestUtils;
+using Model.Enums;
 
 [TestClass]
 public class LookupValidationTests
@@ -187,7 +188,7 @@ public class LookupValidationTests
         var response = await _sut.RunAsync(_request.Object);
 
         // Assert
-        Assert.AreEqual(response.StatusCode, HttpStatusCode.NoContent);
+        Assert.AreEqual(HttpStatusCode.NoContent, response.StatusCode);
     }
 
     [TestMethod]
@@ -482,6 +483,7 @@ public class LookupValidationTests
         _requestBody.NewParticipant.AddressLine1 = "123 Test Street";
         _requestBody.NewParticipant.Postcode = "TE57 1NG";
         _requestBody.ExistingParticipant = null;
+        _requestBody.ReasonForAdding = ReasonForAdding.VeryHighRisk;
 
         var json = JsonSerializer.Serialize(_requestBody);
         SetUpRequestBody(json);
@@ -495,6 +497,80 @@ public class LookupValidationTests
 
         // Assert
         StringAssert.Contains(body, "3601.ValidatePrimaryCareProvider.NBO.NonFatal");
+    }
+    [TestMethod]
+    public async Task Run_DummyGPCodeRemovalValidPCP_ReturnsNoContent()
+    {
+        // arrange
+
+        _requestBody.FileName = "CS0848402";
+        _requestBody.NewParticipant.RecordType = Actions.New;
+        _requestBody.NewParticipant.PrimaryCareProvider = "ZZZAGA";
+        _requestBody.NewParticipant.AddressLine1 = "123 Test Street";
+        _requestBody.NewParticipant.Postcode = "TE57 1NG";
+        _requestBody.ExistingParticipant.PrimaryCareProvider = "ZZZAGA";
+        _requestBody.ReasonForAdding = Model.Enums.ReasonForAdding.DummyGpCodeRemoval;
+
+        var json = JsonSerializer.Serialize(_requestBody);
+        SetUpRequestBody(json);
+
+        _lookupValidation.Setup(x => x.CheckIfPrimaryCareProviderExists("ZZZAGA")).Returns(true);
+
+        // act
+        var response = await _sut.RunAsync(_request.Object);
+
+        // assert
+        Assert.AreEqual(HttpStatusCode.NoContent, response.StatusCode);
+
+    }
+    [TestMethod]
+    public async Task Run_DummyGPCodeRemovalWelshGP_ReturnsNoContent()
+    {
+        // arrange
+
+        _requestBody.FileName = "CS0848402";
+        _requestBody.NewParticipant.RecordType = Actions.New;
+        _requestBody.NewParticipant.PrimaryCareProvider = "W02688";
+        _requestBody.NewParticipant.AddressLine1 = "123 Test Street";
+        _requestBody.NewParticipant.Postcode = "TE57 1NG";
+        _requestBody.ReasonForAdding = Model.Enums.ReasonForAdding.DummyGpCodeRemoval;
+
+        var json = JsonSerializer.Serialize(_requestBody);
+        SetUpRequestBody(json);
+
+        _lookupValidation.Setup(x => x.CheckIfPrimaryCareProviderExists("W02688")).Returns(false);
+
+        // act
+        var response = await _sut.RunAsync(_request.Object);
+
+        // assert
+        Assert.AreEqual(HttpStatusCode.NoContent, response.StatusCode);
+
+    }
+    [TestMethod]
+    public async Task Run_DummyGPCodeRemovalInvalidPCP_ReturnsValidationException()
+    {
+        // arrange
+
+        _requestBody.FileName = "CS0848402";
+        _requestBody.NewParticipant.RecordType = Actions.New;
+        _requestBody.NewParticipant.PrimaryCareProvider = "ZZZAGA";
+        _requestBody.NewParticipant.AddressLine1 = "123 Test Street";
+        _requestBody.NewParticipant.Postcode = "TE57 1NG";
+        _requestBody.ReasonForAdding = Model.Enums.ReasonForAdding.DummyGpCodeRemoval;
+
+        var json = JsonSerializer.Serialize(_requestBody);
+        SetUpRequestBody(json);
+
+        _lookupValidation.Setup(x => x.CheckIfPrimaryCareProviderExists("ZZZAGA")).Returns(false);
+
+        // act
+        var response = await _sut.RunAsync(_request.Object);
+        string body = await AssertionHelper.ReadResponseBodyAsync(response);
+
+        // assert
+        Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+        StringAssert.Contains(body, "70.DummyGpRemovalWithInvalidGP.BSS.NonFatal");
     }
 
     private void SetUpRequestBody(string json)

--- a/tests/UnitTests/TransformDataServiceTests/TransformDataServiceTests/TransformDataServiceTests.cs
+++ b/tests/UnitTests/TransformDataServiceTests/TransformDataServiceTests/TransformDataServiceTests.cs
@@ -66,6 +66,7 @@ public class TransformDataServiceTests
         _transformLookups.Setup(x => x.GetBsoCode(It.IsAny<string>())).Returns("ELD");
         _transformLookups.Setup(x => x.GetBsoCodeUsingPCP(It.IsAny<string>())).Returns("ELD");
         _transformLookups.Setup(x => x.ValidateLanguageCode(It.IsAny<string>())).Returns(true);
+        _transformLookups.Setup(x => x.CheckIfPrimaryCareProviderExists(It.IsAny<string>())).Returns(true);
 
         _transformReasonForRemoval = new TransformReasonForRemoval(_handleException.Object, _transformLookups.Object);
         _function = new TransformDataService(_createResponse.Object, _handleException.Object, _logger.Object, _transformReasonForRemoval, _transformLookups.Object, _reasonForRemovalLookup);
@@ -1123,6 +1124,56 @@ public class TransformDataServiceTests
         Assert.AreEqual(reasonForRemoval, actualResponse?.ReasonForRemoval);
         _handleException.Verify(i => i.CreateTransformExecutedExceptions(It.IsAny<CohortDistributionParticipant>(), "DummyGpCodeRemoval", 71, null), times: Times.Never);
 
+    }
+    [TestMethod]
+    public async Task Run_DummyGPCodeRemovalWithWelshGP_AddsReasonForRemovalOfORR()
+    {
+        // arrange
+        var primaryCareProvider = "W12345";
+
+        _requestBody.ReasonForAdding = ReasonForAdding.DummyGpCodeRemoval;
+        _requestBody.Participant.RecordType = Actions.New;
+        _requestBody.Participant.PrimaryCareProvider = primaryCareProvider;
+
+        var json = JsonSerializer.Serialize(_requestBody);
+        SetUpRequestBody(json);
+
+        _transformLookups.Setup(x => x.CheckIfPrimaryCareProviderExists(primaryCareProvider)).Returns(false);
+
+        // act
+        var result = await _function.RunAsync(_request.Object);
+
+        // assert
+        Assert.AreEqual(HttpStatusCode.OK, result.StatusCode);
+        string responseBody = await AssertionHelper.ReadResponseBodyAsync(result);
+        var actualResponse = JsonSerializer.Deserialize<CohortDistributionParticipant>(responseBody);
+        Assert.AreEqual("ORR", actualResponse?.ReasonForRemoval);
+         _handleException.Verify(i => i.CreateTransformExecutedExceptions(It.IsAny<CohortDistributionParticipant>(), "RemoveWelshGPCodeForDummyGpRemoval", 72, null), times: Times.Once);
+    }
+    [TestMethod]
+    public async Task Run_DummyGPCodeRemovalWithValidNonWelshGP_NoReasonForRemovalAdded()
+    {
+        // arrange
+        var primaryCareProvider = "G12345";
+
+        _requestBody.ReasonForAdding = ReasonForAdding.DummyGpCodeRemoval;
+        _requestBody.Participant.RecordType = Actions.New;
+        _requestBody.Participant.PrimaryCareProvider = primaryCareProvider;
+
+        var json = JsonSerializer.Serialize(_requestBody);
+        SetUpRequestBody(json);
+
+        _transformLookups.Setup(x => x.CheckIfPrimaryCareProviderExists(primaryCareProvider)).Returns(true);
+
+        // act
+        var result = await _function.RunAsync(_request.Object);
+
+        // assert
+        Assert.AreEqual(HttpStatusCode.OK, result.StatusCode);
+        string responseBody = await AssertionHelper.ReadResponseBodyAsync(result);
+        var actualResponse = JsonSerializer.Deserialize<CohortDistributionParticipant>(responseBody);
+        Assert.IsNull(actualResponse?.ReasonForRemoval);
+         _handleException.Verify(i => i.CreateTransformExecutedExceptions(It.IsAny<CohortDistributionParticipant>(), "RemoveWelshGPCodeForDummyGpRemoval", 72, null), times: Times.Never);
     }
 
     private void SetUpRequestBody(string json)

--- a/tests/UnitTests/TransformDataServiceTests/TransformDataServiceTests/TransformDataServiceTests.cs
+++ b/tests/UnitTests/TransformDataServiceTests/TransformDataServiceTests/TransformDataServiceTests.cs
@@ -996,7 +996,7 @@ public class TransformDataServiceTests
         _requestBody.Participant.PrimaryCareProvider = "ZZZXYZ";
         _requestBody.Participant.ReasonForRemoval = ReasonForRemoval;
         _requestBody.Participant.ReasonForRemovalEffectiveFromDate = DateTime.UtcNow.ToString();
-
+        _requestBody.ReasonForAdding = ReasonForAdding.VeryHighRisk;
         var json = JsonSerializer.Serialize(_requestBody);
         SetUpRequestBody(json);
 
@@ -1070,6 +1070,59 @@ public class TransformDataServiceTests
         // Assert
         Assert.AreEqual(HttpStatusCode.OK, result.StatusCode);
         _handleException.Verify(i => i.CreateTransformExecutedExceptions(It.IsAny<CohortDistributionParticipant>(), ruleName, ruleId, null), times: Times.Never);
+    }
+    [TestMethod]
+    [DataRow("RDR",DisplayName = "Reason for Removal is RDR")]
+    [DataRow("RDI",DisplayName = "Reason for Removal is RDI")]
+    [DataRow("RPR",DisplayName = "Reason for Removal is RPR")]
+    public async Task Run_DummyGPCodeRemovalWithRemovedFromGPCode_TransformsToORRandRaisesException(string reasonForRemoval)
+    {
+        // arrange
+        _requestBody.ReasonForAdding = ReasonForAdding.DummyGpCodeRemoval;
+        _requestBody.Participant.RecordType = Actions.New;
+        _requestBody.Participant.PrimaryCareProvider = null;
+        _requestBody.Participant.ReasonForRemoval = reasonForRemoval;
+
+        var json = JsonSerializer.Serialize(_requestBody);
+        SetUpRequestBody(json);
+
+        // act
+        var result = await _function.RunAsync(_request.Object);
+
+        // assert
+        Assert.AreEqual(HttpStatusCode.OK, result.StatusCode);
+        string responseBody = await AssertionHelper.ReadResponseBodyAsync(result);
+        var actualResponse = JsonSerializer.Deserialize<CohortDistributionParticipant>(responseBody);
+        Assert.AreEqual("ORR", actualResponse?.ReasonForRemoval);
+        _handleException.Verify(i => i.CreateTransformExecutedExceptions(It.IsAny<CohortDistributionParticipant>(), "DummyGpCodeRemoval", 71, null), times: Times.Once);
+
+    }
+    [TestMethod]
+    [DataRow("AFL",DisplayName = "Reason for Removal is RDR")]
+    [DataRow("",DisplayName = "Reason for Removal is empty")]
+    [DataRow(null,DisplayName = "Reason for Removal is null")]
+    [DataRow("LDN",DisplayName = "Reason for Removal is LDN")]
+    public async Task Run_DummyGPCodeRemovalWithOtherReasons_NoTransform(string reasonForRemoval)
+    {
+        // arrange
+        _requestBody.ReasonForAdding = ReasonForAdding.DummyGpCodeRemoval;
+        _requestBody.Participant.RecordType = Actions.New;
+        _requestBody.Participant.PrimaryCareProvider = null;
+        _requestBody.Participant.ReasonForRemoval = reasonForRemoval;
+
+        var json = JsonSerializer.Serialize(_requestBody);
+        SetUpRequestBody(json);
+
+        // act
+        var result = await _function.RunAsync(_request.Object);
+
+        // assert
+        Assert.AreEqual(HttpStatusCode.OK, result.StatusCode);
+        string responseBody = await AssertionHelper.ReadResponseBodyAsync(result);
+        var actualResponse = JsonSerializer.Deserialize<CohortDistributionParticipant>(responseBody);
+        Assert.AreEqual(reasonForRemoval, actualResponse?.ReasonForRemoval);
+        _handleException.Verify(i => i.CreateTransformExecutedExceptions(It.IsAny<CohortDistributionParticipant>(), "DummyGpCodeRemoval", 71, null), times: Times.Never);
+
     }
 
     private void SetUpRequestBody(string json)


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

- Extending data models sent to Validation Functions to include ReasonForAdding 
- Add CheckIfPrimaryCareProviderExists to TransfromDataLookupFacade - needed for rule 72
- Add 2 new Transfrom Rules to handle dummy GP code removal
- Prevent manual add rules from running on dummy GP code removal
- Add static Rule 70 - Prevents un recognised GPs from being adding in the absence of Current Posting
- Edit rule 45 to not run when Dummy GP Removal is the reason for adding

## Context

[DTOSS-12467](https://nhsd-jira.digital.nhs.uk/browse/DTOSS-12467)
[DTOSS-12468](https://nhsd-jira.digital.nhs.uk/browse/DTOSS-12468)

[Design Doc](https://nhsd-confluence.digital.nhs.uk/spaces/DTS/pages/1314218921/Dummy+GP+Code+Removal+Design)

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [x] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
