### PR TITLE
feat: DTOSS-12156 Ineffective session termination

### DIFF
--- a/application/CohortManager/src/Functions/ParticipantManagementServices/DeleteParticipant/DeleteParticipant.cs
+++ b/application/CohortManager/src/Functions/ParticipantManagementServices/DeleteParticipant/DeleteParticipant.cs
@@ -16,15 +16,18 @@ public class DeleteParticipant
     private readonly ILogger<DeleteParticipant> _logger;
     private readonly IExceptionHandler _exceptionHandler;
     private readonly IDataServiceClient<CohortDistribution> _cohortDistributionClient;
+    private readonly IDataServiceClient<ParticipantDemographic> _participantDemographic;
 
     public DeleteParticipant(ICreateResponse createResponse, ILogger<DeleteParticipant> logger,
                                 IDataServiceClient<CohortDistribution> cohortDistributionClient,
+                                IDataServiceClient<ParticipantDemographic> participantDemographic,
                                 IExceptionHandler exceptionHandler)
     {
         _createResponse = createResponse;
         _logger = logger;
         _exceptionHandler = exceptionHandler;
         _cohortDistributionClient = cohortDistributionClient;
+        _participantDemographic = participantDemographic;
     }
 
     /// <summary>
@@ -95,6 +98,7 @@ public class DeleteParticipant
             foreach (var participant in participantsToDelete)
             {
                 await _cohortDistributionClient.Delete(participant.CohortDistributionId.ToString());
+                await _participantDemographic.Delete(participant.ParticipantId.ToString());
             }
 
             _logger.LogInformation("Deleted participants");

--- a/application/CohortManager/src/Functions/ParticipantManagementServices/DeleteParticipant/DeleteParticipantConfig.cs
+++ b/application/CohortManager/src/Functions/ParticipantManagementServices/DeleteParticipant/DeleteParticipantConfig.cs
@@ -4,6 +4,9 @@ using System.ComponentModel.DataAnnotations;
 
 public class DeleteParticipantConfig
 {
+
+    [Required]
+    public required string ParticipantDemographicDataServiceUrl { get; set; }
     [Required]
     public required string CohortDistributionDataServiceUrl {get; set;}
 }

--- a/tests/UnitTests/ParticipantManagementServicesTests/DeleteParticipantTests/DeleteParticipantTests.cs
+++ b/tests/UnitTests/ParticipantManagementServicesTests/DeleteParticipantTests/DeleteParticipantTests.cs
@@ -27,6 +27,7 @@ public class DeleteParticipantTests
     private readonly DeleteParticipantRequestBody _requestBody;
     private readonly Mock<IExceptionHandler> _exceptionHandler = new();
     private Mock<IDataServiceClient<CohortDistribution>> _cohortDistributionClientMock = new();
+    private Mock<IDataServiceClient<ParticipantDemographic>> _mockParticipantDemographicClient = new();
 
     public DeleteParticipantTests()
     {
@@ -40,7 +41,7 @@ public class DeleteParticipantTests
 
         _request = _setupRequest.Setup(JsonSerializer.Serialize(_requestBody));
 
-        _sut = new DeleteParticipant(_createResponse.Object, _logger.Object, _cohortDistributionClientMock.Object,
+        _sut = new DeleteParticipant(_createResponse.Object, _logger.Object, _cohortDistributionClientMock.Object, _mockParticipantDemographicClient.Object,
                                             _exceptionHandler.Object);
 
         _createResponse.Setup(x => x.CreateHttpResponse(It.IsAny<HttpStatusCode>(), It.IsAny<HttpRequestData>(), It.IsAny<string>()))


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description
Implemented react-idle-timer to handle inactive user sessions.
<!-- Describe your changes in detail. -->

## Context
https://nhsd-jira.digital.nhs.uk/browse/DTOSS-12156

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [x] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
